### PR TITLE
add `ENABLED` and `\cdot` front-end

### DIFF
--- a/examples-draft/SimpleExampleWF.tla
+++ b/examples-draft/SimpleExampleWF.tla
@@ -1,0 +1,77 @@
+---------------------------- MODULE SimpleExampleWF ----------------------------
+(* An example that involves WF and induction over temporal properties. *)
+EXTENDS Integers, NaturalsInduction, TLAPS
+
+
+VARIABLE x
+
+
+Init == x = 0
+Next == x' = x + 1
+
+Spec == Init /\ [][Next]_x /\ WF_x(Next)
+
+
+THEOREM
+    \A n \in Nat:  Spec => <>(x = n)
+PROOF
+(* Type invariance. *)
+<1> DEFINE Inv == x \in Nat
+<1>1. Spec => []Inv
+    <2>1. Init => Inv
+        BY DEF Init, Inv
+    <2>2. Inv /\ [Next]_x => Inv'
+        BY DEF Inv, Next
+    <2> QED
+        BY <2>1, <2>2, PTL DEF Spec
+(* Temporal property over which induction is applied. *)
+<1> DEFINE P(m) == Spec => <>(x = m)
+<1> HIDE DEF P
+(* Induction over natural numbers. *)
+<1>2. \A n \in Nat:  P(n)
+    (* Base case for induction. *)
+    <2>1. P(0)
+        BY PTL DEF P, Spec, Init
+    (* Inductive case. *)
+    <2>2. \A n \in Nat:  P(n) => P(n + 1)
+        <3>1. SUFFICES
+                ASSUME NEW n \in Nat
+                PROVE (Spec /\ <>(x = n)) => <>(x = n + 1)
+            BY <3>1 DEF P
+        (* If x reaches n then it remains n or increases by 1. *)
+        <3>2. Spec => [] \/ ~ (x = n)
+                         \/ <> \/ [] (x = n)
+                               \/ (x = n + 1)
+            <4>1. ASSUME Inv /\ [Next]_x
+                  PROVE  \/ ~ (x = n)
+                         \/ (x = n)'
+                         \/ (x = n + 1)'
+                BY <4>1 DEF Inv, Next
+            <4> QED
+                BY <1>1, <4>1, PTL DEF Spec
+        (* Spec implies infinitely many Next steps that change x. *)
+        <3>3. Spec => []<><<Next>>_x
+            (* Replacing ENABLED by quantifiers. *)
+            <4>1. ASSUME Inv
+                  PROVE ENABLED <<Next>>_x
+                BY <4>1, ExpandENABLED DEF Next, Inv
+            (* Enabledness and fairness imply liveness. *)
+            <4>2. ASSUME []Inv
+                  PROVE WF_x(Next) => []<><<Next>>_x
+                BY <4>1, <4>2, PTL
+            <4> QED
+                BY <1>1, <4>1, <4>2 DEF Spec
+        (* Any <<Next>>_x step when x = n changes x so that ~(x = n)'. *)
+        <3>4. ASSUME Inv /\ (x = n) /\ <<Next>>_x
+              PROVE ~(x = n)'
+            BY <3>4 DEF Inv, Next
+        <3> QED
+            BY <1>1, <3>2, <3>3, <3>4, PTL
+    <2> QED
+        BY <2>1, <2>2, NatInduction
+(* Unhiding the definition of operator P. *)
+<1> QED
+    BY <1>2 DEF P
+
+
+================================================================================

--- a/library/TLAPS.tla
+++ b/library/TLAPS.tla
@@ -101,6 +101,7 @@ SpassT(X) == TRUE (*{ by (prover:"spass"; timeout:@) }*)
 (**************************************************************************)
 
 LS4 == TRUE (*{ by (prover: "ls4") }*)
+LS4T(X) == TRUE (*{ by (prover: "ls4"; timeout:@) }*)
 PTL == TRUE (*{ by (prover: "ls4") }*)
 
 (**************************************************************************)
@@ -314,6 +315,40 @@ AllIsaT(X) == TRUE (*{
     by (prover:"isabelle"; tactic:"auto, blast"; timeout:@)
   }*)
 
+
+(**************************************************************************)
+(* The pragma ExpandEnabled invokes expansion of the operator ENABLED.    *)
+(*                                                                        *)
+(* The pragma ExpandCdot invokes expansion of the operator \cdot.         *)
+(*                                                                        *)
+(* The pragma AutoUSE invokes automated expansion of definitions,         *)
+(* for both of ExpandEnabled and ExpandCdot, when each is present.        *)
+(*                                                                        *)
+(* The pragma Lambdify invokes expansion of the operators                 *)
+(* ENABLED and \cdot to an intermediate form with bound VARIABLES,        *)
+(* which is a form before introducing rigid quantifiers.                  *)
+(* The pragma Lambdify is sound for occurrences of ENABLED and \cdot      *)
+(* that are not nested.                                                   *)
+(**************************************************************************)
+ExpandENABLED == TRUE  (*{ by (prover:"expandenabled") }*)
+ExpandCdot == TRUE  (*{ by (prover:"expandcdot") }*)
+AutoUSE == TRUE  (*{ by (prover:"autouse") }*)
+Lambdify == TRUE  (*{ by (prover:"lambdify") }*)
+ENABLEDaxioms == TRUE  (*{ by (prover:"enabledaxioms") }*)
+LevelComparison == TRUE  (*{ by (prover:"levelcomparison") }*)
+
+(* The operators EnabledWrapper and CdotWrapper occur in an intermediate  *)
+(* representation within TLAPM.                                           *)
+EnabledWrapper(Op(_)) == FALSE
+CdotWrapper(Op(_)) == FALSE
+
+(***************************************************************************)
+(* The following may be used in a `BY ONLY ThmName` for unit testing the   *)
+(* triviality checks in TLAPM.                                             *)
+(***************************************************************************)
+Trivial == TRUE  (*{ by (prover:"trivial") }*)
+
+
 =============================================================================
 
 The material below is obsolete: the TLA proof rules below are superseded by
@@ -420,3 +455,4 @@ PROOF OMITTED
 (* propositional temporal logic.                                           *)
 (***************************************************************************)
 PropositionalTemporalLogic == TRUE
+=============================================================================

--- a/src/.depend
+++ b/src/.depend
@@ -1,507 +1,2083 @@
-revision.cmo: revision.mlt revision.cmi
-revision.cmx: revision.mlt revision.cmi
-sysconf.cmo: sysconf.mlt revision.cmi sysconf.cmi
-sysconf.cmx: sysconf.mlt revision.cmx sysconf.cmi
-util/ext.cmo: util/ext.mlt revision.cmi util/ext.cmi
-util/ext.cmx: util/ext.mlt revision.cmx util/ext.cmi
-system.cmo: system.mlt revision.cmi util/ext.cmi system.cmi
-system.cmx: system.mlt revision.cmx util/ext.cmx system.cmi
-builtin.cmo: builtin.mlt revision.cmi builtin.cmi
-builtin.cmx: builtin.mlt revision.cmx builtin.cmi
-config.cmo: config.mlt config.cmi
-config.cmx: config.mlt config.cmi
-method.cmo: method.mlt revision.cmi method.cmi
-method.cmx: method.mlt revision.cmx method.cmi
-version.cmo: version.mlt revision.cmi version.cmi
-version.cmx: version.mlt revision.cmx version.cmi
-loc.cmo: loc.mlt revision.cmi loc.cmi
-loc.cmx: loc.mlt revision.cmx loc.cmi
-toolbox_msg.cmo: toolbox_msg.mlt revision.cmi loc.cmi util/ext.cmi toolbox_msg.cmi
-toolbox_msg.cmx: toolbox_msg.mlt revision.cmx loc.cmx util/ext.cmx toolbox_msg.cmi
-params.cmo: params.mlt version.cmi sysconf.cmi revision.cmi method.cmi util/ext.cmi \
-    config.cmi params.cmi
-params.cmx: params.mlt version.cmx sysconf.cmx revision.cmx method.cmx util/ext.cmx \
-    config.cmx params.cmi
-pars/error.cmo: pars/error.mlt toolbox_msg.cmi revision.cmi params.cmi loc.cmi \
-    util/ext.cmi pars/error.cmi
-pars/error.cmx: pars/error.mlt toolbox_msg.cmx revision.cmx params.cmx loc.cmx \
-    util/ext.cmx pars/error.cmi
-pars/intf.cmo: pars/intf.mlt revision.cmi loc.cmi pars/intf.cmi
-pars/intf.cmx: pars/intf.mlt revision.cmx loc.cmx pars/intf.cmi
-pars/lazyList.cmo: pars/lazyList.mlt revision.cmi pars/lazyList.cmi
-pars/lazyList.cmx: pars/lazyList.mlt revision.cmx pars/lazyList.cmi
-pars/pco.cmo: pars/pco.mlt revision.cmi loc.cmi pars/lazyList.cmi pars/intf.cmi \
-    pars/error.cmi pars/pco.cmi
-pars/pco.cmx: pars/pco.mlt revision.cmx loc.cmx pars/lazyList.cmx pars/intf.cmx \
-    pars/error.cmx pars/pco.cmi
-pars.cmo: pars.mlt revision.cmi pars/pco.cmi pars/lazyList.cmi pars/intf.cmi \
-    pars/error.cmi pars.cmi
-pars.cmx: pars.mlt revision.cmx pars/pco.cmx pars/lazyList.cmx pars/intf.cmx \
-    pars/error.cmx pars.cmi
-util/property.cmo: util/property.mlt revision.cmi util/ext.cmi util/property.cmi
-util/property.cmx: util/property.mlt revision.cmx util/ext.cmx util/property.cmi
-util/util.cmo: util/util.mlt revision.cmi util/property.cmi params.cmi loc.cmi \
-    util/ext.cmi util/util.cmi
-util/util.cmx: util/util.mlt revision.cmx util/property.cmx params.cmx loc.cmx \
-    util/ext.cmx util/util.cmi
-ctx.cmo: ctx.mlt revision.cmi util/ext.cmi ctx.cmi
-ctx.cmx: ctx.mlt revision.cmx util/ext.cmx ctx.cmi
-errors.cmo: errors.mlt util/util.cmi toolbox_msg.cmi revision.cmi params.cmi loc.cmi \
+revision.cmo: revision.mlt \
+    revision.cmi
+revision.cmx: revision.mlt \
+    revision.cmi
+sysconf.cmo: sysconf.mlt \
+    revision.cmi \
+    sysconf.cmi
+sysconf.cmx: sysconf.mlt \
+    revision.cmx \
+    sysconf.cmi
+util/ext.cmo: util/ext.mlt \
+    revision.cmi \
+    util/ext.cmi
+util/ext.cmx: util/ext.mlt \
+    revision.cmx \
+    util/ext.cmi
+system.cmo: system.mlt \
+    revision.cmi \
+    util/ext.cmi \
+    system.cmi
+system.cmx: system.mlt \
+    revision.cmx \
+    util/ext.cmx \
+    system.cmi
+builtin.cmo: builtin.mlt \
+    revision.cmi \
+    builtin.cmi
+builtin.cmx: builtin.mlt \
+    revision.cmx \
+    builtin.cmi
+config.cmo: config.mlt \
+    config.cmi
+config.cmx: config.mlt \
+    config.cmi
+method.cmo: method.mlt \
+    revision.cmi \
+    method.cmi
+method.cmx: method.mlt \
+    revision.cmx \
+    method.cmi
+version.cmo: version.mlt \
+    revision.cmi \
+    version.cmi
+version.cmx: version.mlt \
+    revision.cmx \
+    version.cmi
+loc.cmo: loc.mlt \
+    revision.cmi \
+    loc.cmi
+loc.cmx: loc.mlt \
+    revision.cmx \
+    loc.cmi
+toolbox_msg.cmo: toolbox_msg.mlt \
+    revision.cmi \
+    loc.cmi \
+    util/ext.cmi \
+    toolbox_msg.cmi
+toolbox_msg.cmx: toolbox_msg.mlt \
+    revision.cmx \
+    loc.cmx \
+    util/ext.cmx \
+    toolbox_msg.cmi
+params.cmo: params.mlt \
+    version.cmi \
+    sysconf.cmi \
+    revision.cmi \
+    method.cmi \
+    util/ext.cmi \
+    config.cmi \
+    params.cmi
+params.cmx: params.mlt \
+    version.cmx \
+    sysconf.cmx \
+    revision.cmx \
+    method.cmx \
+    util/ext.cmx \
+    config.cmx \
+    params.cmi
+pars/error.cmo: pars/error.mlt \
+    toolbox_msg.cmi \
+    revision.cmi \
+    params.cmi \
+    loc.cmi \
+    util/ext.cmi \
+    pars/error.cmi
+pars/error.cmx: pars/error.mlt \
+    toolbox_msg.cmx \
+    revision.cmx \
+    params.cmx \
+    loc.cmx \
+    util/ext.cmx \
+    pars/error.cmi
+pars/intf.cmo: pars/intf.mlt \
+    revision.cmi \
+    loc.cmi \
+    pars/intf.cmi
+pars/intf.cmx: pars/intf.mlt \
+    revision.cmx \
+    loc.cmx \
+    pars/intf.cmi
+pars/lazyList.cmo: pars/lazyList.mlt \
+    revision.cmi \
+    pars/lazyList.cmi
+pars/lazyList.cmx: pars/lazyList.mlt \
+    revision.cmx \
+    pars/lazyList.cmi
+pars/pco.cmo: pars/pco.mlt \
+    revision.cmi \
+    loc.cmi \
+    pars/lazyList.cmi \
+    pars/intf.cmi \
+    pars/error.cmi \
+    pars/pco.cmi
+pars/pco.cmx: pars/pco.mlt \
+    revision.cmx \
+    loc.cmx \
+    pars/lazyList.cmx \
+    pars/intf.cmx \
+    pars/error.cmx \
+    pars/pco.cmi
+pars.cmo: pars.mlt \
+    revision.cmi \
+    pars/pco.cmi \
+    pars/lazyList.cmi \
+    pars/intf.cmi \
+    pars/error.cmi \
+    pars.cmi
+pars.cmx: pars.mlt \
+    revision.cmx \
+    pars/pco.cmx \
+    pars/lazyList.cmx \
+    pars/intf.cmx \
+    pars/error.cmx \
+    pars.cmi
+util/property.cmo: util/property.mlt \
+    revision.cmi \
+    util/ext.cmi \
+    util/property.cmi
+util/property.cmx: util/property.mlt \
+    revision.cmx \
+    util/ext.cmx \
+    util/property.cmi
+util/util.cmo: util/util.mlt \
+    revision.cmi \
+    util/property.cmi \
+    params.cmi \
+    loc.cmi \
+    util/ext.cmi \
+    util/util.cmi
+util/util.cmx: util/util.mlt \
+    revision.cmx \
+    util/property.cmx \
+    params.cmx \
+    loc.cmx \
+    util/ext.cmx \
+    util/util.cmi
+ctx.cmo: ctx.mlt \
+    revision.cmi \
+    util/ext.cmi \
+    ctx.cmi
+ctx.cmx: ctx.mlt \
+    revision.cmx \
+    util/ext.cmx \
+    ctx.cmi
+errors.cmo: errors.mlt \
+    util/util.cmi \
+    toolbox_msg.cmi \
+    revision.cmi \
+    params.cmi \
+    loc.cmi \
     errors.cmi
-errors.cmx: errors.mlt util/util.cmx toolbox_msg.cmx revision.cmx params.cmx loc.cmx \
+errors.cmx: errors.mlt \
+    util/util.cmx \
+    toolbox_msg.cmx \
+    revision.cmx \
+    params.cmx \
+    loc.cmx \
     errors.cmi
-optable.cmo: optable.mlt revision.cmi builtin.cmi optable.cmi
-optable.cmx: optable.mlt revision.cmx builtin.cmx optable.cmi
-util/fmtutil.cmo: util/fmtutil.mlt revision.cmi pars.cmi util/fmtutil.cmi
-util/fmtutil.cmx: util/fmtutil.mlt revision.cmx pars.cmx util/fmtutil.cmi
-isabelle_keywords.cmo: isabelle_keywords.mlt revision.cmi isabelle_keywords.cmi
-isabelle_keywords.cmx: isabelle_keywords.mlt revision.cmx isabelle_keywords.cmi
-tla_parser.cmo: tla_parser.mlt util/util.cmi revision.cmi util/property.cmi pars.cmi \
-    optable.cmi loc.cmi isabelle_keywords.cmi util/fmtutil.cmi util/ext.cmi \
+optable.cmo: optable.mlt \
+    revision.cmi \
+    builtin.cmi \
+    optable.cmi
+optable.cmx: optable.mlt \
+    revision.cmx \
+    builtin.cmx \
+    optable.cmi
+util/fmtutil.cmo: util/fmtutil.mlt \
+    revision.cmi \
+    pars.cmi \
+    util/fmtutil.cmi
+util/fmtutil.cmx: util/fmtutil.mlt \
+    revision.cmx \
+    pars.cmx \
+    util/fmtutil.cmi
+isabelle_keywords.cmo: isabelle_keywords.mlt \
+    revision.cmi \
+    isabelle_keywords.cmi
+isabelle_keywords.cmx: isabelle_keywords.mlt \
+    revision.cmx \
+    isabelle_keywords.cmi
+tla_parser.cmo: tla_parser.mlt \
+    util/util.cmi \
+    revision.cmi \
+    util/property.cmi \
+    pars.cmi \
+    optable.cmi \
+    loc.cmi \
+    isabelle_keywords.cmi \
+    util/fmtutil.cmi \
+    util/ext.cmi \
     tla_parser.cmi
-tla_parser.cmx: tla_parser.mlt util/util.cmx revision.cmx util/property.cmx pars.cmx \
-    optable.cmx loc.cmx isabelle_keywords.cmx util/fmtutil.cmx util/ext.cmx \
+tla_parser.cmx: tla_parser.mlt \
+    util/util.cmx \
+    revision.cmx \
+    util/property.cmx \
+    pars.cmx \
+    optable.cmx \
+    loc.cmx \
+    isabelle_keywords.cmx \
+    util/fmtutil.cmx \
+    util/ext.cmx \
     tla_parser.cmi
-util/deque.cmo: util/deque.mlt revision.cmi util/ext.cmi util/deque.cmi
-util/deque.cmx: util/deque.mlt revision.cmx util/ext.cmx util/deque.cmi
-alexer.cmo: alexer.mlt tla_parser.cmi pars.cmi loc.cmi pars/lazyList.cmi errors.cmi \
-    pars/error.cmi alexer.cmi
-alexer.cmx: alexer.mlt tla_parser.cmx pars.cmx loc.cmx pars/lazyList.cmx errors.cmx \
-    pars/error.cmx alexer.cmi
-expr/e_t.cmo: expr/e_t.mlt util/util.cmi revision.cmi util/property.cmi method.cmi \
-    util/deque.cmi builtin.cmi expr/e_t.cmi
-expr/e_t.cmx: expr/e_t.mlt util/util.cmx revision.cmx util/property.cmx method.cmx \
-    util/deque.cmx builtin.cmx expr/e_t.cmi
-expr/e_visit.cmo: expr/e_visit.mlt revision.cmi util/property.cmi util/ext.cmi expr/e_t.cmi \
-    util/deque.cmi expr/e_visit.cmi
-expr/e_visit.cmx: expr/e_visit.mlt revision.cmx util/property.cmx util/ext.cmx expr/e_t.cmx \
-    util/deque.cmx expr/e_visit.cmi
-expr/e_constness.cmo: expr/e_constness.mlt revision.cmi util/property.cmi util/ext.cmi \
-    errors.cmi expr/e_visit.cmi expr/e_t.cmi util/deque.cmi builtin.cmi \
+util/deque.cmo: util/deque.mlt \
+    revision.cmi \
+    util/ext.cmi \
+    util/deque.cmi
+util/deque.cmx: util/deque.mlt \
+    revision.cmx \
+    util/ext.cmx \
+    util/deque.cmi
+alexer.cmo: alexer.mlt \
+    tla_parser.cmi \
+    pars.cmi \
+    loc.cmi \
+    pars/lazyList.cmi \
+    errors.cmi \
+    pars/error.cmi \
+    alexer.cmi
+alexer.cmx: alexer.mlt \
+    tla_parser.cmx \
+    pars.cmx \
+    loc.cmx \
+    pars/lazyList.cmx \
+    errors.cmx \
+    pars/error.cmx \
+    alexer.cmi
+expr/e_t.cmo: expr/e_t.mlt \
+    util/util.cmi \
+    revision.cmi \
+    util/property.cmi \
+    method.cmi \
+    loc.cmi \
+    util/ext.cmi \
+    util/deque.cmi \
+    builtin.cmi \
+    expr/e_t.cmi
+expr/e_t.cmx: expr/e_t.mlt \
+    util/util.cmx \
+    revision.cmx \
+    util/property.cmx \
+    method.cmx \
+    loc.cmx \
+    util/ext.cmx \
+    util/deque.cmx \
+    builtin.cmx \
+    expr/e_t.cmi
+expr/e_visit.cmo: expr/e_visit.mlt \
+    revision.cmi \
+    util/property.cmi \
+    util/ext.cmi \
+    expr/e_t.cmi \
+    util/deque.cmi \
+    expr/e_visit.cmi
+expr/e_visit.cmx: expr/e_visit.mlt \
+    revision.cmx \
+    util/property.cmx \
+    util/ext.cmx \
+    expr/e_t.cmx \
+    util/deque.cmx \
+    expr/e_visit.cmi
+expr/e_fmt.cmo: expr/e_fmt.mlt \
+    util/util.cmi \
+    tla_parser.cmi \
+    revision.cmi \
+    util/property.cmi \
+    params.cmi \
+    optable.cmi \
+    method.cmi \
+    util/fmtutil.cmi \
+    util/ext.cmi \
+    errors.cmi \
+    expr/e_t.cmi \
+    util/deque.cmi \
+    ctx.cmi \
+    builtin.cmi \
+    expr/e_fmt.cmi
+expr/e_fmt.cmx: expr/e_fmt.mlt \
+    util/util.cmx \
+    tla_parser.cmx \
+    revision.cmx \
+    util/property.cmx \
+    params.cmx \
+    optable.cmx \
+    method.cmx \
+    util/fmtutil.cmx \
+    util/ext.cmx \
+    errors.cmx \
+    expr/e_t.cmx \
+    util/deque.cmx \
+    ctx.cmx \
+    builtin.cmx \
+    expr/e_fmt.cmi
+expr/e_levels.cmo: expr/e_levels.mlt \
+    util/util.cmi \
+    revision.cmi \
+    util/property.cmi \
+    util/ext.cmi \
+    expr/e_visit.cmi \
+    expr/e_t.cmi \
+    util/deque.cmi \
+    builtin.cmi \
+    expr/e_levels.cmi
+expr/e_levels.cmx: expr/e_levels.mlt \
+    util/util.cmx \
+    revision.cmx \
+    util/property.cmx \
+    util/ext.cmx \
+    expr/e_visit.cmx \
+    expr/e_t.cmx \
+    util/deque.cmx \
+    builtin.cmx \
+    expr/e_levels.cmi
+expr/e_constness.cmo: expr/e_constness.mlt \
+    util/util.cmi \
+    revision.cmi \
+    util/property.cmi \
+    util/ext.cmi \
+    errors.cmi \
+    expr/e_visit.cmi \
+    expr/e_t.cmi \
+    expr/e_fmt.cmi \
+    util/deque.cmi \
+    builtin.cmi \
     expr/e_constness.cmi
-expr/e_constness.cmx: expr/e_constness.mlt revision.cmx util/property.cmx util/ext.cmx \
-    errors.cmx expr/e_visit.cmx expr/e_t.cmx util/deque.cmx builtin.cmx \
+expr/e_constness.cmx: expr/e_constness.mlt \
+    util/util.cmx \
+    revision.cmx \
+    util/property.cmx \
+    util/ext.cmx \
+    errors.cmx \
+    expr/e_visit.cmx \
+    expr/e_t.cmx \
+    expr/e_fmt.cmx \
+    util/deque.cmx \
+    builtin.cmx \
     expr/e_constness.cmi
-expr/e_fmt.cmo: expr/e_fmt.mlt util/util.cmi tla_parser.cmi revision.cmi util/property.cmi \
-    params.cmi optable.cmi method.cmi util/fmtutil.cmi util/ext.cmi \
-    errors.cmi expr/e_t.cmi util/deque.cmi ctx.cmi builtin.cmi expr/e_fmt.cmi
-expr/e_fmt.cmx: expr/e_fmt.mlt util/util.cmx tla_parser.cmx revision.cmx util/property.cmx \
-    params.cmx optable.cmx method.cmx util/fmtutil.cmx util/ext.cmx \
-    errors.cmx expr/e_t.cmx util/deque.cmx ctx.cmx builtin.cmx expr/e_fmt.cmi
-expr/e_subst.cmo: expr/e_subst.mlt util/util.cmi revision.cmi util/property.cmi \
-    util/fmtutil.cmi util/ext.cmi expr/e_t.cmi expr/e_fmt.cmi util/deque.cmi \
-    ctx.cmi expr/e_subst.cmi
-expr/e_subst.cmx: expr/e_subst.mlt util/util.cmx revision.cmx util/property.cmx \
-    util/fmtutil.cmx util/ext.cmx expr/e_t.cmx expr/e_fmt.cmx util/deque.cmx \
-    ctx.cmx expr/e_subst.cmi
-expr/e_eq.cmo: expr/e_eq.mlt revision.cmi util/property.cmi expr/e_t.cmi util/deque.cmi \
+expr/e_substitutive.cmo: expr/e_substitutive.mlt \
+    util/property.cmi \
+    util/ext.cmi \
+    expr/e_visit.cmi \
+    expr/e_t.cmi \
+    expr/e_levels.cmi \
+    util/deque.cmi \
+    builtin.cmi \
+    expr/e_substitutive.cmi
+expr/e_substitutive.cmx: expr/e_substitutive.mlt \
+    util/property.cmx \
+    util/ext.cmx \
+    expr/e_visit.cmx \
+    expr/e_t.cmx \
+    expr/e_levels.cmx \
+    util/deque.cmx \
+    builtin.cmx \
+    expr/e_substitutive.cmi
+expr/e_subst.cmo: expr/e_subst.mlt \
+    util/util.cmi \
+    revision.cmi \
+    util/property.cmi \
+    util/fmtutil.cmi \
+    util/ext.cmi \
+    expr/e_t.cmi \
+    expr/e_fmt.cmi \
+    util/deque.cmi \
+    ctx.cmi \
+    expr/e_subst.cmi
+expr/e_subst.cmx: expr/e_subst.mlt \
+    util/util.cmx \
+    revision.cmx \
+    util/property.cmx \
+    util/fmtutil.cmx \
+    util/ext.cmx \
+    expr/e_t.cmx \
+    expr/e_fmt.cmx \
+    util/deque.cmx \
+    ctx.cmx \
+    expr/e_subst.cmi
+expr/e_eq.cmo: expr/e_eq.mlt \
+    revision.cmi \
+    util/property.cmi \
+    expr/e_t.cmi \
+    util/deque.cmi \
     expr/e_eq.cmi
-expr/e_eq.cmx: expr/e_eq.mlt revision.cmx util/property.cmx expr/e_t.cmx util/deque.cmx \
+expr/e_eq.cmx: expr/e_eq.mlt \
+    revision.cmx \
+    util/property.cmx \
+    expr/e_t.cmx \
+    util/deque.cmx \
     expr/e_eq.cmi
-expr/e_deref.cmo: expr/e_deref.mlt util/util.cmi revision.cmi util/property.cmi util/ext.cmi \
-    errors.cmi expr/e_visit.cmi expr/e_t.cmi expr/e_subst.cmi expr/e_fmt.cmi \
-    util/deque.cmi ctx.cmi expr/e_deref.cmi
-expr/e_deref.cmx: expr/e_deref.mlt util/util.cmx revision.cmx util/property.cmx util/ext.cmx \
-    errors.cmx expr/e_visit.cmx expr/e_t.cmx expr/e_subst.cmx expr/e_fmt.cmx \
-    util/deque.cmx ctx.cmx expr/e_deref.cmi
-expr/e_leibniz.cmo: expr/e_leibniz.mlt revision.cmi util/property.cmi util/ext.cmi errors.cmi \
-    expr/e_visit.cmi expr/e_t.cmi util/deque.cmi builtin.cmi \
+expr/e_deref.cmo: expr/e_deref.mlt \
+    util/util.cmi \
+    revision.cmi \
+    util/property.cmi \
+    util/ext.cmi \
+    errors.cmi \
+    expr/e_visit.cmi \
+    expr/e_t.cmi \
+    expr/e_subst.cmi \
+    expr/e_fmt.cmi \
+    util/deque.cmi \
+    ctx.cmi \
+    expr/e_deref.cmi
+expr/e_deref.cmx: expr/e_deref.mlt \
+    util/util.cmx \
+    revision.cmx \
+    util/property.cmx \
+    util/ext.cmx \
+    errors.cmx \
+    expr/e_visit.cmx \
+    expr/e_t.cmx \
+    expr/e_subst.cmx \
+    expr/e_fmt.cmx \
+    util/deque.cmx \
+    ctx.cmx \
+    expr/e_deref.cmi
+expr/e_leibniz.cmo: expr/e_leibniz.mlt \
+    revision.cmi \
+    util/property.cmi \
+    util/ext.cmi \
+    errors.cmi \
+    expr/e_visit.cmi \
+    expr/e_t.cmi \
+    util/deque.cmi \
+    builtin.cmi \
     expr/e_leibniz.cmi
-expr/e_leibniz.cmx: expr/e_leibniz.mlt revision.cmx util/property.cmx util/ext.cmx errors.cmx \
-    expr/e_visit.cmx expr/e_t.cmx util/deque.cmx builtin.cmx \
+expr/e_leibniz.cmx: expr/e_leibniz.mlt \
+    revision.cmx \
+    util/property.cmx \
+    util/ext.cmx \
+    errors.cmx \
+    expr/e_visit.cmx \
+    expr/e_t.cmx \
+    util/deque.cmx \
+    builtin.cmx \
     expr/e_leibniz.cmi
-expr/e_parser.cmo: expr/e_parser.mlt util/util.cmi tla_parser.cmi revision.cmi \
-    util/property.cmi optable.cmi loc.cmi util/ext.cmi errors.cmi \
-    expr/e_t.cmi util/deque.cmi builtin.cmi expr/e_parser.cmi
-expr/e_parser.cmx: expr/e_parser.mlt util/util.cmx tla_parser.cmx revision.cmx \
-    util/property.cmx optable.cmx loc.cmx util/ext.cmx errors.cmx \
-    expr/e_t.cmx util/deque.cmx builtin.cmx expr/e_parser.cmi
-expr/e_tla_norm.cmo: expr/e_tla_norm.mlt tla_parser.cmi revision.cmi util/property.cmi \
-    util/ext.cmi expr/e_visit.cmi expr/e_t.cmi util/deque.cmi builtin.cmi \
+expr/e_parser.cmo: expr/e_parser.mlt \
+    util/util.cmi \
+    tla_parser.cmi \
+    revision.cmi \
+    util/property.cmi \
+    optable.cmi \
+    loc.cmi \
+    util/ext.cmi \
+    errors.cmi \
+    expr/e_t.cmi \
+    util/deque.cmi \
+    builtin.cmi \
+    expr/e_parser.cmi
+expr/e_parser.cmx: expr/e_parser.mlt \
+    util/util.cmx \
+    tla_parser.cmx \
+    revision.cmx \
+    util/property.cmx \
+    optable.cmx \
+    loc.cmx \
+    util/ext.cmx \
+    errors.cmx \
+    expr/e_t.cmx \
+    util/deque.cmx \
+    builtin.cmx \
+    expr/e_parser.cmi
+expr/e_tla_norm.cmo: expr/e_tla_norm.mlt \
+    tla_parser.cmi \
+    revision.cmi \
+    util/property.cmi \
+    util/ext.cmi \
+    expr/e_visit.cmi \
+    expr/e_t.cmi \
+    util/deque.cmi \
+    builtin.cmi \
     expr/e_tla_norm.cmi
-expr/e_tla_norm.cmx: expr/e_tla_norm.mlt tla_parser.cmx revision.cmx util/property.cmx \
-    util/ext.cmx expr/e_visit.cmx expr/e_t.cmx util/deque.cmx builtin.cmx \
+expr/e_tla_norm.cmx: expr/e_tla_norm.mlt \
+    tla_parser.cmx \
+    revision.cmx \
+    util/property.cmx \
+    util/ext.cmx \
+    expr/e_visit.cmx \
+    expr/e_t.cmx \
+    util/deque.cmx \
+    builtin.cmx \
     expr/e_tla_norm.cmi
-expr/e_temporal_props.cmo: expr/e_temporal_props.mlt revision.cmi util/property.cmi util/ext.cmi \
-    expr/e_visit.cmi expr/e_tla_norm.cmi expr/e_t.cmi expr/e_constness.cmi \
-    util/deque.cmi builtin.cmi expr/e_temporal_props.cmi
-expr/e_temporal_props.cmx: expr/e_temporal_props.mlt revision.cmx util/property.cmx util/ext.cmx \
-    expr/e_visit.cmx expr/e_tla_norm.cmx expr/e_t.cmx expr/e_constness.cmx \
-    util/deque.cmx builtin.cmx expr/e_temporal_props.cmi
-expr/e_elab.cmo: expr/e_elab.mlt revision.cmi util/property.cmi errors.cmi expr/e_visit.cmi \
-    expr/e_t.cmi expr/e_subst.cmi expr/e_fmt.cmi expr/e_constness.cmi \
-    util/deque.cmi builtin.cmi expr/e_elab.cmi
-expr/e_elab.cmx: expr/e_elab.mlt revision.cmx util/property.cmx errors.cmx expr/e_visit.cmx \
-    expr/e_t.cmx expr/e_subst.cmx expr/e_fmt.cmx expr/e_constness.cmx \
-    util/deque.cmx builtin.cmx expr/e_elab.cmi
-expr/e_anon.cmo: expr/e_anon.mlt util/util.cmi revision.cmi util/property.cmi errors.cmi \
-    expr/e_visit.cmi expr/e_temporal_props.cmi expr/e_t.cmi expr/e_subst.cmi \
-    expr/e_eq.cmi expr/e_elab.cmi expr/e_deref.cmi util/deque.cmi builtin.cmi \
+expr/e_temporal_props.cmo: expr/e_temporal_props.mlt \
+    revision.cmi \
+    util/property.cmi \
+    util/ext.cmi \
+    expr/e_visit.cmi \
+    expr/e_tla_norm.cmi \
+    expr/e_t.cmi \
+    expr/e_constness.cmi \
+    util/deque.cmi \
+    builtin.cmi \
+    expr/e_temporal_props.cmi
+expr/e_temporal_props.cmx: expr/e_temporal_props.mlt \
+    revision.cmx \
+    util/property.cmx \
+    util/ext.cmx \
+    expr/e_visit.cmx \
+    expr/e_tla_norm.cmx \
+    expr/e_t.cmx \
+    expr/e_constness.cmx \
+    util/deque.cmx \
+    builtin.cmx \
+    expr/e_temporal_props.cmi
+expr/e_elab.cmo: expr/e_elab.mlt \
+    revision.cmi \
+    util/property.cmi \
+    errors.cmi \
+    expr/e_visit.cmi \
+    expr/e_t.cmi \
+    expr/e_subst.cmi \
+    expr/e_fmt.cmi \
+    expr/e_constness.cmi \
+    util/deque.cmi \
+    builtin.cmi \
+    expr/e_elab.cmi
+expr/e_elab.cmx: expr/e_elab.mlt \
+    revision.cmx \
+    util/property.cmx \
+    errors.cmx \
+    expr/e_visit.cmx \
+    expr/e_t.cmx \
+    expr/e_subst.cmx \
+    expr/e_fmt.cmx \
+    expr/e_constness.cmx \
+    util/deque.cmx \
+    builtin.cmx \
+    expr/e_elab.cmi
+expr/e_anon.cmo: expr/e_anon.mlt \
+    util/util.cmi \
+    revision.cmi \
+    util/property.cmi \
+    errors.cmi \
+    expr/e_visit.cmi \
+    expr/e_temporal_props.cmi \
+    expr/e_t.cmi \
+    expr/e_subst.cmi \
+    expr/e_eq.cmi \
+    expr/e_elab.cmi \
+    expr/e_deref.cmi \
+    util/deque.cmi \
+    builtin.cmi \
     expr/e_anon.cmi
-expr/e_anon.cmx: expr/e_anon.mlt util/util.cmx revision.cmx util/property.cmx errors.cmx \
-    expr/e_visit.cmx expr/e_temporal_props.cmx expr/e_t.cmx expr/e_subst.cmx \
-    expr/e_eq.cmx expr/e_elab.cmx expr/e_deref.cmx util/deque.cmx builtin.cmx \
+expr/e_anon.cmx: expr/e_anon.mlt \
+    util/util.cmx \
+    revision.cmx \
+    util/property.cmx \
+    errors.cmx \
+    expr/e_visit.cmx \
+    expr/e_temporal_props.cmx \
+    expr/e_t.cmx \
+    expr/e_subst.cmx \
+    expr/e_eq.cmx \
+    expr/e_elab.cmx \
+    expr/e_deref.cmx \
+    util/deque.cmx \
+    builtin.cmx \
     expr/e_anon.cmi
-expr.cmo: expr.mlt revision.cmi expr/e_visit.cmi expr/e_tla_norm.cmi \
-    expr/e_temporal_props.cmi expr/e_t.cmi expr/e_subst.cmi expr/e_parser.cmi \
-    expr/e_leibniz.cmi expr/e_fmt.cmi expr/e_eq.cmi expr/e_elab.cmi \
-    expr/e_deref.cmi expr/e_constness.cmi expr/e_anon.cmi expr.cmi
-expr.cmx: expr.mlt revision.cmx expr/e_visit.cmx expr/e_tla_norm.cmx \
-    expr/e_temporal_props.cmx expr/e_t.cmx expr/e_subst.cmx expr/e_parser.cmx \
-    expr/e_leibniz.cmx expr/e_fmt.cmx expr/e_eq.cmx expr/e_elab.cmx \
-    expr/e_deref.cmx expr/e_constness.cmx expr/e_anon.cmx expr.cmi
-method_prs.cmo: method_prs.mlt tla_parser.cmi revision.cmi method.cmi util/ext.cmi \
+expr/e_action.cmo: expr/e_action.mlt \
+    util/util.cmi \
+    revision.cmi \
+    util/property.cmi \
+    util/ext.cmi \
+    expr/e_visit.cmi \
+    expr/e_tla_norm.cmi \
+    expr/e_t.cmi \
+    expr/e_subst.cmi \
+    expr/e_levels.cmi \
+    expr/e_fmt.cmi \
+    expr/e_eq.cmi \
+    expr/e_anon.cmi \
+    util/deque.cmi \
+    builtin.cmi \
+    expr/e_action.cmi
+expr/e_action.cmx: expr/e_action.mlt \
+    util/util.cmx \
+    revision.cmx \
+    util/property.cmx \
+    util/ext.cmx \
+    expr/e_visit.cmx \
+    expr/e_tla_norm.cmx \
+    expr/e_t.cmx \
+    expr/e_subst.cmx \
+    expr/e_levels.cmx \
+    expr/e_fmt.cmx \
+    expr/e_eq.cmx \
+    expr/e_anon.cmx \
+    util/deque.cmx \
+    builtin.cmx \
+    expr/e_action.cmi
+expr/e_level_comparison.cmo: expr/e_level_comparison.mlt \
+    util/util.cmi \
+    revision.cmi \
+    util/property.cmi \
+    expr/e_visit.cmi \
+    expr/e_t.cmi \
+    expr/e_levels.cmi \
+    util/deque.cmi \
+    expr/e_level_comparison.cmi
+expr/e_level_comparison.cmx: expr/e_level_comparison.mlt \
+    util/util.cmx \
+    revision.cmx \
+    util/property.cmx \
+    expr/e_visit.cmx \
+    expr/e_t.cmx \
+    expr/e_levels.cmx \
+    util/deque.cmx \
+    expr/e_level_comparison.cmi
+expr.cmo: expr.mlt \
+    revision.cmi \
+    expr/e_visit.cmi \
+    expr/e_tla_norm.cmi \
+    expr/e_temporal_props.cmi \
+    expr/e_t.cmi \
+    expr/e_substitutive.cmi \
+    expr/e_subst.cmi \
+    expr/e_parser.cmi \
+    expr/e_levels.cmi \
+    expr/e_level_comparison.cmi \
+    expr/e_leibniz.cmi \
+    expr/e_fmt.cmi \
+    expr/e_eq.cmi \
+    expr/e_elab.cmi \
+    expr/e_deref.cmi \
+    expr/e_constness.cmi \
+    expr/e_anon.cmi \
+    expr/e_action.cmi \
+    expr.cmi
+expr.cmx: expr.mlt \
+    revision.cmx \
+    expr/e_visit.cmx \
+    expr/e_tla_norm.cmx \
+    expr/e_temporal_props.cmx \
+    expr/e_t.cmx \
+    expr/e_substitutive.cmx \
+    expr/e_subst.cmx \
+    expr/e_parser.cmx \
+    expr/e_levels.cmx \
+    expr/e_level_comparison.cmx \
+    expr/e_leibniz.cmx \
+    expr/e_fmt.cmx \
+    expr/e_eq.cmx \
+    expr/e_elab.cmx \
+    expr/e_deref.cmx \
+    expr/e_constness.cmx \
+    expr/e_anon.cmx \
+    expr/e_action.cmx \
+    expr.cmi
+method_prs.cmo: method_prs.mlt \
+    tla_parser.cmi \
+    revision.cmi \
+    method.cmi \
+    util/ext.cmi \
     method_prs.cmi
-method_prs.cmx: method_prs.mlt tla_parser.cmx revision.cmx method.cmx util/ext.cmx \
+method_prs.cmx: method_prs.mlt \
+    tla_parser.cmx \
+    revision.cmx \
+    method.cmx \
+    util/ext.cmx \
     method_prs.cmi
-proof/p_t.cmo: proof/p_t.mlt revision.cmi util/property.cmi method.cmi loc.cmi expr.cmi \
+proof/p_t.cmo: proof/p_t.mlt \
+    revision.cmi \
+    util/property.cmi \
+    method.cmi \
+    loc.cmi \
+    expr.cmi \
     proof/p_t.cmi
-proof/p_t.cmx: proof/p_t.mlt revision.cmx util/property.cmx method.cmx loc.cmx expr.cmx \
+proof/p_t.cmx: proof/p_t.mlt \
+    revision.cmx \
+    util/property.cmx \
+    method.cmx \
+    loc.cmx \
+    expr.cmx \
     proof/p_t.cmi
-proof/p_fmt.cmo: proof/p_fmt.mlt util/util.cmi revision.cmi util/property.cmi params.cmi \
-    proof/p_t.cmi method.cmi loc.cmi util/fmtutil.cmi util/ext.cmi expr.cmi \
-    util/deque.cmi ctx.cmi proof/p_fmt.cmi
-proof/p_fmt.cmx: proof/p_fmt.mlt util/util.cmx revision.cmx util/property.cmx params.cmx \
-    proof/p_t.cmx method.cmx loc.cmx util/fmtutil.cmx util/ext.cmx expr.cmx \
-    util/deque.cmx ctx.cmx proof/p_fmt.cmi
-proof/p_subst.cmo: proof/p_subst.mlt util/util.cmi revision.cmi util/property.cmi \
-    proof/p_t.cmi util/ext.cmi expr.cmi errors.cmi util/deque.cmi ctx.cmi \
+proof/p_fmt.cmo: proof/p_fmt.mlt \
+    util/util.cmi \
+    revision.cmi \
+    util/property.cmi \
+    params.cmi \
+    proof/p_t.cmi \
+    method.cmi \
+    loc.cmi \
+    util/fmtutil.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    util/deque.cmi \
+    ctx.cmi \
+    proof/p_fmt.cmi
+proof/p_fmt.cmx: proof/p_fmt.mlt \
+    util/util.cmx \
+    revision.cmx \
+    util/property.cmx \
+    params.cmx \
+    proof/p_t.cmx \
+    method.cmx \
+    loc.cmx \
+    util/fmtutil.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    util/deque.cmx \
+    ctx.cmx \
+    proof/p_fmt.cmi
+proof/p_subst.cmo: proof/p_subst.mlt \
+    util/util.cmi \
+    revision.cmi \
+    util/property.cmi \
+    proof/p_t.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    errors.cmi \
+    util/deque.cmi \
+    ctx.cmi \
     proof/p_subst.cmi
-proof/p_subst.cmx: proof/p_subst.mlt util/util.cmx revision.cmx util/property.cmx \
-    proof/p_t.cmx util/ext.cmx expr.cmx errors.cmx util/deque.cmx ctx.cmx \
+proof/p_subst.cmx: proof/p_subst.mlt \
+    util/util.cmx \
+    revision.cmx \
+    util/property.cmx \
+    proof/p_t.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    errors.cmx \
+    util/deque.cmx \
+    ctx.cmx \
     proof/p_subst.cmi
-proof/p_visit.cmo: proof/p_visit.mlt revision.cmi util/property.cmi proof/p_t.cmi \
-    util/ext.cmi expr.cmi errors.cmi util/deque.cmi proof/p_visit.cmi
-proof/p_visit.cmx: proof/p_visit.mlt revision.cmx util/property.cmx proof/p_t.cmx \
-    util/ext.cmx expr.cmx errors.cmx util/deque.cmx proof/p_visit.cmi
-proof/p_gen.cmo: proof/p_gen.mlt util/util.cmi revision.cmi util/property.cmi params.cmi \
-    proof/p_visit.cmi proof/p_t.cmi loc.cmi util/ext.cmi expr.cmi errors.cmi \
-    util/deque.cmi ctx.cmi builtin.cmi proof/p_gen.cmi
-proof/p_gen.cmx: proof/p_gen.mlt util/util.cmx revision.cmx util/property.cmx params.cmx \
-    proof/p_visit.cmx proof/p_t.cmx loc.cmx util/ext.cmx expr.cmx errors.cmx \
-    util/deque.cmx ctx.cmx builtin.cmx proof/p_gen.cmi
-proof/p_simplify.cmo: proof/p_simplify.mlt util/util.cmi revision.cmi util/property.cmi \
-    proof/p_t.cmi proof/p_gen.cmi proof/p_fmt.cmi util/ext.cmi expr.cmi \
-    errors.cmi util/deque.cmi ctx.cmi builtin.cmi proof/p_simplify.cmi
-proof/p_simplify.cmx: proof/p_simplify.mlt util/util.cmx revision.cmx util/property.cmx \
-    proof/p_t.cmx proof/p_gen.cmx proof/p_fmt.cmx util/ext.cmx expr.cmx \
-    errors.cmx util/deque.cmx ctx.cmx builtin.cmx proof/p_simplify.cmi
-proof/p_anon.cmo: proof/p_anon.mlt revision.cmi util/property.cmi proof/p_visit.cmi \
-    proof/p_t.cmi util/ext.cmi expr.cmi util/deque.cmi builtin.cmi \
+proof/p_visit.cmo: proof/p_visit.mlt \
+    revision.cmi \
+    util/property.cmi \
+    proof/p_t.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    errors.cmi \
+    util/deque.cmi \
+    proof/p_visit.cmi
+proof/p_visit.cmx: proof/p_visit.mlt \
+    revision.cmx \
+    util/property.cmx \
+    proof/p_t.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    errors.cmx \
+    util/deque.cmx \
+    proof/p_visit.cmi
+proof/p_gen.cmo: proof/p_gen.mlt \
+    util/util.cmi \
+    revision.cmi \
+    util/property.cmi \
+    params.cmi \
+    proof/p_visit.cmi \
+    proof/p_t.cmi \
+    loc.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    errors.cmi \
+    util/deque.cmi \
+    ctx.cmi \
+    builtin.cmi \
+    proof/p_gen.cmi
+proof/p_gen.cmx: proof/p_gen.mlt \
+    util/util.cmx \
+    revision.cmx \
+    util/property.cmx \
+    params.cmx \
+    proof/p_visit.cmx \
+    proof/p_t.cmx \
+    loc.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    errors.cmx \
+    util/deque.cmx \
+    ctx.cmx \
+    builtin.cmx \
+    proof/p_gen.cmi
+proof/p_simplify.cmo: proof/p_simplify.mlt \
+    util/util.cmi \
+    revision.cmi \
+    util/property.cmi \
+    proof/p_t.cmi \
+    proof/p_gen.cmi \
+    proof/p_fmt.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    errors.cmi \
+    util/deque.cmi \
+    ctx.cmi \
+    builtin.cmi \
+    proof/p_simplify.cmi
+proof/p_simplify.cmx: proof/p_simplify.mlt \
+    util/util.cmx \
+    revision.cmx \
+    util/property.cmx \
+    proof/p_t.cmx \
+    proof/p_gen.cmx \
+    proof/p_fmt.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    errors.cmx \
+    util/deque.cmx \
+    ctx.cmx \
+    builtin.cmx \
+    proof/p_simplify.cmi
+proof/p_anon.cmo: proof/p_anon.mlt \
+    revision.cmi \
+    util/property.cmi \
+    proof/p_visit.cmi \
+    proof/p_t.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    util/deque.cmi \
+    builtin.cmi \
     proof/p_anon.cmi
-proof/p_anon.cmx: proof/p_anon.mlt revision.cmx util/property.cmx proof/p_visit.cmx \
-    proof/p_t.cmx util/ext.cmx expr.cmx util/deque.cmx builtin.cmx \
+proof/p_anon.cmx: proof/p_anon.mlt \
+    revision.cmx \
+    util/property.cmx \
+    proof/p_visit.cmx \
+    proof/p_t.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    util/deque.cmx \
+    builtin.cmx \
     proof/p_anon.cmi
-proof/p_parser.cmo: proof/p_parser.mlt util/util.cmi tla_parser.cmi revision.cmi \
-    util/property.cmi proof/p_t.cmi method_prs.cmi method.cmi loc.cmi \
-    util/ext.cmi expr.cmi errors.cmi util/deque.cmi proof/p_parser.cmi
-proof/p_parser.cmx: proof/p_parser.mlt util/util.cmx tla_parser.cmx revision.cmx \
-    util/property.cmx proof/p_t.cmx method_prs.cmx method.cmx loc.cmx \
-    util/ext.cmx expr.cmx errors.cmx util/deque.cmx proof/p_parser.cmi
-proof.cmo: proof.mlt revision.cmi proof/p_visit.cmi proof/p_t.cmi proof/p_subst.cmi \
-    proof/p_simplify.cmi proof/p_parser.cmi proof/p_gen.cmi proof/p_fmt.cmi \
-    proof/p_anon.cmi proof.cmi
-proof.cmx: proof.mlt revision.cmx proof/p_visit.cmx proof/p_t.cmx proof/p_subst.cmx \
-    proof/p_simplify.cmx proof/p_parser.cmx proof/p_gen.cmx proof/p_fmt.cmx \
-    proof/p_anon.cmx proof.cmi
-smt/smtcommons.cmo: smt/smtcommons.mlt util/util.cmi tla_parser.cmi revision.cmi \
-    util/property.cmi params.cmi util/fmtutil.cmi util/ext.cmi expr.cmi \
-    util/deque.cmi ctx.cmi builtin.cmi smt/smtcommons.cmi
-smt/smtcommons.cmx: smt/smtcommons.mlt util/util.cmx tla_parser.cmx revision.cmx \
-    util/property.cmx params.cmx util/fmtutil.cmx util/ext.cmx expr.cmx \
-    util/deque.cmx ctx.cmx builtin.cmx smt/smtcommons.cmi
-typesystem/typ_t.cmo: typesystem/typ_t.mlt tla_parser.cmi smt/smtcommons.cmi revision.cmi \
-    util/property.cmi util/fmtutil.cmi util/ext.cmi expr.cmi util/deque.cmi \
-    builtin.cmi typesystem/typ_t.cmi
-typesystem/typ_t.cmx: typesystem/typ_t.mlt tla_parser.cmx smt/smtcommons.cmx revision.cmx \
-    util/property.cmx util/fmtutil.cmx util/ext.cmx expr.cmx util/deque.cmx \
-    builtin.cmx typesystem/typ_t.cmi
-typesystem/typ_e.cmo: typesystem/typ_e.mlt util/util.cmi typesystem/typ_t.cmi tla_parser.cmi \
-    smt/smtcommons.cmi revision.cmi util/property.cmi params.cmi optable.cmi \
-    method.cmi util/fmtutil.cmi util/ext.cmi expr.cmi errors.cmi \
-    util/deque.cmi ctx.cmi builtin.cmi typesystem/typ_e.cmi
-typesystem/typ_e.cmx: typesystem/typ_e.mlt util/util.cmx typesystem/typ_t.cmx tla_parser.cmx \
-    smt/smtcommons.cmx revision.cmx util/property.cmx params.cmx optable.cmx \
-    method.cmx util/fmtutil.cmx util/ext.cmx expr.cmx errors.cmx \
-    util/deque.cmx ctx.cmx builtin.cmx typesystem/typ_e.cmi
-typesystem/typ_c.cmo: typesystem/typ_c.mlt util/util.cmi typesystem/typ_t.cmi \
-    typesystem/typ_e.cmi smt/smtcommons.cmi revision.cmi util/property.cmi \
-    util/fmtutil.cmi util/ext.cmi expr.cmi ctx.cmi builtin.cmi \
+proof/p_parser.cmo: proof/p_parser.mlt \
+    util/util.cmi \
+    tla_parser.cmi \
+    revision.cmi \
+    util/property.cmi \
+    proof/p_t.cmi \
+    method_prs.cmi \
+    method.cmi \
+    loc.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    errors.cmi \
+    util/deque.cmi \
+    proof/p_parser.cmi
+proof/p_parser.cmx: proof/p_parser.mlt \
+    util/util.cmx \
+    tla_parser.cmx \
+    revision.cmx \
+    util/property.cmx \
+    proof/p_t.cmx \
+    method_prs.cmx \
+    method.cmx \
+    loc.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    errors.cmx \
+    util/deque.cmx \
+    proof/p_parser.cmi
+proof.cmo: proof.mlt \
+    revision.cmi \
+    proof/p_visit.cmi \
+    proof/p_t.cmi \
+    proof/p_subst.cmi \
+    proof/p_simplify.cmi \
+    proof/p_parser.cmi \
+    proof/p_gen.cmi \
+    proof/p_fmt.cmi \
+    proof/p_anon.cmi \
+    proof.cmi
+proof.cmx: proof.mlt \
+    revision.cmx \
+    proof/p_visit.cmx \
+    proof/p_t.cmx \
+    proof/p_subst.cmx \
+    proof/p_simplify.cmx \
+    proof/p_parser.cmx \
+    proof/p_gen.cmx \
+    proof/p_fmt.cmx \
+    proof/p_anon.cmx \
+    proof.cmi
+smt/smtcommons.cmo: smt/smtcommons.mlt \
+    util/util.cmi \
+    tla_parser.cmi \
+    revision.cmi \
+    util/property.cmi \
+    params.cmi \
+    util/fmtutil.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    util/deque.cmi \
+    ctx.cmi \
+    builtin.cmi \
+    smt/smtcommons.cmi
+smt/smtcommons.cmx: smt/smtcommons.mlt \
+    util/util.cmx \
+    tla_parser.cmx \
+    revision.cmx \
+    util/property.cmx \
+    params.cmx \
+    util/fmtutil.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    util/deque.cmx \
+    ctx.cmx \
+    builtin.cmx \
+    smt/smtcommons.cmi
+typesystem/typ_t.cmo: typesystem/typ_t.mlt \
+    tla_parser.cmi \
+    smt/smtcommons.cmi \
+    revision.cmi \
+    util/property.cmi \
+    util/fmtutil.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    util/deque.cmi \
+    builtin.cmi \
+    typesystem/typ_t.cmi
+typesystem/typ_t.cmx: typesystem/typ_t.mlt \
+    tla_parser.cmx \
+    smt/smtcommons.cmx \
+    revision.cmx \
+    util/property.cmx \
+    util/fmtutil.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    util/deque.cmx \
+    builtin.cmx \
+    typesystem/typ_t.cmi
+typesystem/typ_e.cmo: typesystem/typ_e.mlt \
+    util/util.cmi \
+    typesystem/typ_t.cmi \
+    tla_parser.cmi \
+    smt/smtcommons.cmi \
+    revision.cmi \
+    util/property.cmi \
+    params.cmi \
+    optable.cmi \
+    method.cmi \
+    util/fmtutil.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    errors.cmi \
+    util/deque.cmi \
+    ctx.cmi \
+    builtin.cmi \
+    typesystem/typ_e.cmi
+typesystem/typ_e.cmx: typesystem/typ_e.mlt \
+    util/util.cmx \
+    typesystem/typ_t.cmx \
+    tla_parser.cmx \
+    smt/smtcommons.cmx \
+    revision.cmx \
+    util/property.cmx \
+    params.cmx \
+    optable.cmx \
+    method.cmx \
+    util/fmtutil.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    errors.cmx \
+    util/deque.cmx \
+    ctx.cmx \
+    builtin.cmx \
+    typesystem/typ_e.cmi
+typesystem/typ_c.cmo: typesystem/typ_c.mlt \
+    util/util.cmi \
+    typesystem/typ_t.cmi \
+    typesystem/typ_e.cmi \
+    smt/smtcommons.cmi \
+    revision.cmi \
+    util/property.cmi \
+    util/fmtutil.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    ctx.cmi \
+    builtin.cmi \
     typesystem/typ_c.cmi
-typesystem/typ_c.cmx: typesystem/typ_c.mlt util/util.cmx typesystem/typ_t.cmx \
-    typesystem/typ_e.cmx smt/smtcommons.cmx revision.cmx util/property.cmx \
-    util/fmtutil.cmx util/ext.cmx expr.cmx ctx.cmx builtin.cmx \
+typesystem/typ_c.cmx: typesystem/typ_c.mlt \
+    util/util.cmx \
+    typesystem/typ_t.cmx \
+    typesystem/typ_e.cmx \
+    smt/smtcommons.cmx \
+    revision.cmx \
+    util/property.cmx \
+    util/fmtutil.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    ctx.cmx \
+    builtin.cmx \
     typesystem/typ_c.cmi
-typesystem/typ_cg1.cmo: typesystem/typ_cg1.mlt util/util.cmi typesystem/typ_t.cmi \
-    typesystem/typ_e.cmi typesystem/typ_c.cmi tla_parser.cmi \
-    smt/smtcommons.cmi revision.cmi util/property.cmi util/fmtutil.cmi \
-    util/ext.cmi expr.cmi errors.cmi util/deque.cmi ctx.cmi builtin.cmi \
+typesystem/typ_cg1.cmo: typesystem/typ_cg1.mlt \
+    util/util.cmi \
+    typesystem/typ_t.cmi \
+    typesystem/typ_e.cmi \
+    typesystem/typ_c.cmi \
+    tla_parser.cmi \
+    smt/smtcommons.cmi \
+    revision.cmi \
+    util/property.cmi \
+    util/fmtutil.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    errors.cmi \
+    util/deque.cmi \
+    ctx.cmi \
+    builtin.cmi \
     typesystem/typ_cg1.cmi
-typesystem/typ_cg1.cmx: typesystem/typ_cg1.mlt util/util.cmx typesystem/typ_t.cmx \
-    typesystem/typ_e.cmx typesystem/typ_c.cmx tla_parser.cmx \
-    smt/smtcommons.cmx revision.cmx util/property.cmx util/fmtutil.cmx \
-    util/ext.cmx expr.cmx errors.cmx util/deque.cmx ctx.cmx builtin.cmx \
+typesystem/typ_cg1.cmx: typesystem/typ_cg1.mlt \
+    util/util.cmx \
+    typesystem/typ_t.cmx \
+    typesystem/typ_e.cmx \
+    typesystem/typ_c.cmx \
+    tla_parser.cmx \
+    smt/smtcommons.cmx \
+    revision.cmx \
+    util/property.cmx \
+    util/fmtutil.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    errors.cmx \
+    util/deque.cmx \
+    ctx.cmx \
+    builtin.cmx \
     typesystem/typ_cg1.cmi
-typesystem/typ_cg2.cmo: typesystem/typ_cg2.mlt util/util.cmi typesystem/typ_t.cmi \
-    typesystem/typ_e.cmi typesystem/typ_c.cmi tla_parser.cmi \
-    smt/smtcommons.cmi revision.cmi util/property.cmi util/fmtutil.cmi \
-    util/ext.cmi expr.cmi errors.cmi util/deque.cmi ctx.cmi builtin.cmi \
+typesystem/typ_cg2.cmo: typesystem/typ_cg2.mlt \
+    util/util.cmi \
+    typesystem/typ_t.cmi \
+    typesystem/typ_e.cmi \
+    typesystem/typ_c.cmi \
+    tla_parser.cmi \
+    smt/smtcommons.cmi \
+    revision.cmi \
+    util/property.cmi \
+    util/fmtutil.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    errors.cmi \
+    util/deque.cmi \
+    ctx.cmi \
+    builtin.cmi \
     typesystem/typ_cg2.cmi
-typesystem/typ_cg2.cmx: typesystem/typ_cg2.mlt util/util.cmx typesystem/typ_t.cmx \
-    typesystem/typ_e.cmx typesystem/typ_c.cmx tla_parser.cmx \
-    smt/smtcommons.cmx revision.cmx util/property.cmx util/fmtutil.cmx \
-    util/ext.cmx expr.cmx errors.cmx util/deque.cmx ctx.cmx builtin.cmx \
+typesystem/typ_cg2.cmx: typesystem/typ_cg2.mlt \
+    util/util.cmx \
+    typesystem/typ_t.cmx \
+    typesystem/typ_e.cmx \
+    typesystem/typ_c.cmx \
+    tla_parser.cmx \
+    smt/smtcommons.cmx \
+    revision.cmx \
+    util/property.cmx \
+    util/fmtutil.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    errors.cmx \
+    util/deque.cmx \
+    ctx.cmx \
+    builtin.cmx \
     typesystem/typ_cg2.cmi
-typesystem/typ_impgraph.cmo: typesystem/typ_impgraph.mlt util/util.cmi typesystem/typ_t.cmi \
-    typesystem/typ_e.cmi typesystem/typ_c.cmi smt/smtcommons.cmi revision.cmi \
-    util/property.cmi util/ext.cmi expr.cmi builtin.cmi \
+typesystem/typ_impgraph.cmo: typesystem/typ_impgraph.mlt \
+    util/util.cmi \
+    typesystem/typ_t.cmi \
+    typesystem/typ_e.cmi \
+    typesystem/typ_c.cmi \
+    smt/smtcommons.cmi \
+    revision.cmi \
+    util/property.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    builtin.cmi \
     typesystem/typ_impgraph.cmi
-typesystem/typ_impgraph.cmx: typesystem/typ_impgraph.mlt util/util.cmx typesystem/typ_t.cmx \
-    typesystem/typ_e.cmx typesystem/typ_c.cmx smt/smtcommons.cmx revision.cmx \
-    util/property.cmx util/ext.cmx expr.cmx builtin.cmx \
+typesystem/typ_impgraph.cmx: typesystem/typ_impgraph.mlt \
+    util/util.cmx \
+    typesystem/typ_t.cmx \
+    typesystem/typ_e.cmx \
+    typesystem/typ_c.cmx \
+    smt/smtcommons.cmx \
+    revision.cmx \
+    util/property.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    builtin.cmx \
     typesystem/typ_impgraph.cmi
-typesystem/typ_system.cmo: typesystem/typ_system.mlt util/util.cmi typesystem/typ_t.cmi \
-    typesystem/typ_impgraph.cmi typesystem/typ_e.cmi typesystem/typ_cg2.cmi \
-    typesystem/typ_cg1.cmi typesystem/typ_c.cmi tla_parser.cmi \
-    smt/smtcommons.cmi revision.cmi util/property.cmi util/fmtutil.cmi \
-    util/ext.cmi expr.cmi ctx.cmi builtin.cmi typesystem/typ_system.cmi
-typesystem/typ_system.cmx: typesystem/typ_system.mlt util/util.cmx typesystem/typ_t.cmx \
-    typesystem/typ_impgraph.cmx typesystem/typ_e.cmx typesystem/typ_cg2.cmx \
-    typesystem/typ_cg1.cmx typesystem/typ_c.cmx tla_parser.cmx \
-    smt/smtcommons.cmx revision.cmx util/property.cmx util/fmtutil.cmx \
-    util/ext.cmx expr.cmx ctx.cmx builtin.cmx typesystem/typ_system.cmi
-smt/fmt.cmo: smt/fmt.mlt util/util.cmi typesystem/typ_t.cmi smt/smtcommons.cmi \
-    revision.cmi util/property.cmi util/ext.cmi expr.cmi errors.cmi \
-    builtin.cmi smt/fmt.cmi
-smt/fmt.cmx: smt/fmt.mlt util/util.cmx typesystem/typ_t.cmx smt/smtcommons.cmx \
-    revision.cmx util/property.cmx util/ext.cmx expr.cmx errors.cmx \
-    builtin.cmx smt/fmt.cmi
-smt/boolify.cmo: smt/boolify.mlt smt/smtcommons.cmi revision.cmi util/property.cmi \
-    util/ext.cmi expr.cmi builtin.cmi smt/boolify.cmi
-smt/boolify.cmx: smt/boolify.mlt smt/smtcommons.cmx revision.cmx util/property.cmx \
-    util/ext.cmx expr.cmx builtin.cmx smt/boolify.cmi
-smt/rewrite_trivial.cmo: smt/rewrite_trivial.mlt typesystem/typ_t.cmi smt/smtcommons.cmi \
-    util/property.cmi util/ext.cmi expr.cmi builtin.cmi \
+typesystem/typ_system.cmo: typesystem/typ_system.mlt \
+    util/util.cmi \
+    typesystem/typ_t.cmi \
+    typesystem/typ_impgraph.cmi \
+    typesystem/typ_e.cmi \
+    typesystem/typ_cg2.cmi \
+    typesystem/typ_cg1.cmi \
+    typesystem/typ_c.cmi \
+    tla_parser.cmi \
+    smt/smtcommons.cmi \
+    revision.cmi \
+    util/property.cmi \
+    util/fmtutil.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    ctx.cmi \
+    builtin.cmi \
+    typesystem/typ_system.cmi
+typesystem/typ_system.cmx: typesystem/typ_system.mlt \
+    util/util.cmx \
+    typesystem/typ_t.cmx \
+    typesystem/typ_impgraph.cmx \
+    typesystem/typ_e.cmx \
+    typesystem/typ_cg2.cmx \
+    typesystem/typ_cg1.cmx \
+    typesystem/typ_c.cmx \
+    tla_parser.cmx \
+    smt/smtcommons.cmx \
+    revision.cmx \
+    util/property.cmx \
+    util/fmtutil.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    ctx.cmx \
+    builtin.cmx \
+    typesystem/typ_system.cmi
+smt/fmt.cmo: smt/fmt.mlt \
+    util/util.cmi \
+    typesystem/typ_t.cmi \
+    smt/smtcommons.cmi \
+    revision.cmi \
+    util/property.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    errors.cmi \
+    builtin.cmi \
+    smt/fmt.cmi
+smt/fmt.cmx: smt/fmt.mlt \
+    util/util.cmx \
+    typesystem/typ_t.cmx \
+    smt/smtcommons.cmx \
+    revision.cmx \
+    util/property.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    errors.cmx \
+    builtin.cmx \
+    smt/fmt.cmi
+smt/boolify.cmo: smt/boolify.mlt \
+    smt/smtcommons.cmi \
+    revision.cmi \
+    util/property.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    builtin.cmi \
+    smt/boolify.cmi
+smt/boolify.cmx: smt/boolify.mlt \
+    smt/smtcommons.cmx \
+    revision.cmx \
+    util/property.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    builtin.cmx \
+    smt/boolify.cmi
+smt/rewrite_trivial.cmo: smt/rewrite_trivial.mlt \
+    typesystem/typ_t.cmi \
+    smt/smtcommons.cmi \
+    util/property.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    builtin.cmi \
     smt/rewrite_trivial.cmi
-smt/rewrite_trivial.cmx: smt/rewrite_trivial.mlt typesystem/typ_t.cmx smt/smtcommons.cmx \
-    util/property.cmx util/ext.cmx expr.cmx builtin.cmx \
+smt/rewrite_trivial.cmx: smt/rewrite_trivial.mlt \
+    typesystem/typ_t.cmx \
+    smt/smtcommons.cmx \
+    util/property.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    builtin.cmx \
     smt/rewrite_trivial.cmi
-smt/rewrite_arith.cmo: smt/rewrite_arith.mlt typesystem/typ_t.cmi smt/smtcommons.cmi \
-    util/property.cmi util/ext.cmi expr.cmi builtin.cmi smt/rewrite_arith.cmi
-smt/rewrite_arith.cmx: smt/rewrite_arith.mlt typesystem/typ_t.cmx smt/smtcommons.cmx \
-    util/property.cmx util/ext.cmx expr.cmx builtin.cmx smt/rewrite_arith.cmi
-smt/rewrite.cmo: smt/rewrite.mlt typesystem/typ_t.cmi tla_parser.cmi smt/smtcommons.cmi \
-    smt/rewrite_trivial.cmi smt/rewrite_arith.cmi revision.cmi \
-    util/property.cmi util/fmtutil.cmi util/ext.cmi expr.cmi util/deque.cmi \
-    builtin.cmi smt/rewrite.cmi
-smt/rewrite.cmx: smt/rewrite.mlt typesystem/typ_t.cmx tla_parser.cmx smt/smtcommons.cmx \
-    smt/rewrite_trivial.cmx smt/rewrite_arith.cmx revision.cmx \
-    util/property.cmx util/fmtutil.cmx util/ext.cmx expr.cmx util/deque.cmx \
-    builtin.cmx smt/rewrite.cmi
-smt/ectx.cmo: smt/ectx.mlt typesystem/typ_t.cmi tla_parser.cmi smt/smtcommons.cmi \
-    revision.cmi util/property.cmi util/ext.cmi expr.cmi errors.cmi \
-    util/deque.cmi ctx.cmi smt/axioms.cmi smt/ectx.cmi
-smt/ectx.cmx: smt/ectx.mlt typesystem/typ_t.cmx tla_parser.cmx smt/smtcommons.cmx \
-    revision.cmx util/property.cmx util/ext.cmx expr.cmx errors.cmx \
-    util/deque.cmx ctx.cmx smt/axioms.cmx smt/ectx.cmi
-smt/preprocess.cmo: smt/preprocess.mlt typesystem/typ_t.cmi typesystem/typ_e.cmi \
-    tla_parser.cmi smt/smtcommons.cmi revision.cmi util/property.cmi \
-    util/fmtutil.cmi util/ext.cmi expr.cmi errors.cmi smt/ectx.cmi \
-    util/deque.cmi ctx.cmi builtin.cmi smt/preprocess.cmi
-smt/preprocess.cmx: smt/preprocess.mlt typesystem/typ_t.cmx typesystem/typ_e.cmx \
-    tla_parser.cmx smt/smtcommons.cmx revision.cmx util/property.cmx \
-    util/fmtutil.cmx util/ext.cmx expr.cmx errors.cmx smt/ectx.cmx \
-    util/deque.cmx ctx.cmx builtin.cmx smt/preprocess.cmi
-smt/axioms.cmo: smt/axioms.mlt typesystem/typ_t.cmi tla_parser.cmi smt/smtcommons.cmi \
-    revision.cmi util/property.cmi proof.cmi util/fmtutil.cmi util/ext.cmi \
-    expr.cmi util/deque.cmi builtin.cmi smt/axioms.cmi
-smt/axioms.cmx: smt/axioms.mlt typesystem/typ_t.cmx tla_parser.cmx smt/smtcommons.cmx \
-    revision.cmx util/property.cmx proof.cmx util/fmtutil.cmx util/ext.cmx \
-    expr.cmx util/deque.cmx builtin.cmx smt/axioms.cmi
-util/timing.cmo: util/timing.mlt revision.cmi util/timing.cmi
-util/timing.cmx: util/timing.mlt revision.cmx util/timing.cmi
-module/m_t.cmo: module/m_t.mlt util/util.cmi revision.cmi util/property.cmi proof.cmi \
-    loc.cmi util/ext.cmi expr.cmi errors.cmi util/deque.cmi module/m_t.cmi
-module/m_t.cmx: module/m_t.mlt util/util.cmx revision.cmx util/property.cmx proof.cmx \
-    loc.cmx util/ext.cmx expr.cmx errors.cmx util/deque.cmx module/m_t.cmi
-module/m_fmt.cmo: module/m_fmt.mlt util/util.cmi revision.cmi util/property.cmi proof.cmi \
-    params.cmi module/m_t.cmi loc.cmi util/fmtutil.cmi util/ext.cmi expr.cmi \
-    util/deque.cmi ctx.cmi module/m_fmt.cmi
-module/m_fmt.cmx: module/m_fmt.mlt util/util.cmx revision.cmx util/property.cmx proof.cmx \
-    params.cmx module/m_t.cmx loc.cmx util/fmtutil.cmx util/ext.cmx expr.cmx \
-    util/deque.cmx ctx.cmx module/m_fmt.cmi
-module/m_globalness.cmo: module/m_globalness.mlt util/property.cmi proof.cmi module/m_t.cmi \
-    util/deque.cmi module/m_globalness.cmi
-module/m_globalness.cmx: module/m_globalness.mlt util/property.cmx proof.cmx module/m_t.cmx \
-    util/deque.cmx module/m_globalness.cmi
-module/m_gen.cmo: module/m_gen.mlt util/util.cmi revision.cmi util/property.cmi proof.cmi \
-    params.cmi module/m_t.cmi loc.cmi util/ext.cmi expr.cmi errors.cmi \
-    util/deque.cmi module/m_gen.cmi
-module/m_gen.cmx: module/m_gen.mlt util/util.cmx revision.cmx util/property.cmx proof.cmx \
-    params.cmx module/m_t.cmx loc.cmx util/ext.cmx expr.cmx errors.cmx \
-    util/deque.cmx module/m_gen.cmi
-module/m_elab.cmo: module/m_elab.mlt util/util.cmi revision.cmi util/property.cmi proof.cmi \
-    module/m_t.cmi module/m_gen.cmi module/m_fmt.cmi util/ext.cmi expr.cmi \
-    errors.cmi util/deque.cmi ctx.cmi module/m_elab.cmi
-module/m_elab.cmx: module/m_elab.mlt util/util.cmx revision.cmx util/property.cmx proof.cmx \
-    module/m_t.cmx module/m_gen.cmx module/m_fmt.cmx util/ext.cmx expr.cmx \
-    errors.cmx util/deque.cmx ctx.cmx module/m_elab.cmi
-module/m_standard.cmo: module/m_standard.mlt util/util.cmi revision.cmi util/property.cmi \
-    module/m_t.cmi module/m_elab.cmi loc.cmi util/ext.cmi expr.cmi \
-    util/deque.cmi builtin.cmi module/m_standard.cmi
-module/m_standard.cmx: module/m_standard.mlt util/util.cmx revision.cmx util/property.cmx \
-    module/m_t.cmx module/m_elab.cmx loc.cmx util/ext.cmx expr.cmx \
-    util/deque.cmx builtin.cmx module/m_standard.cmi
-module/m_flatten.cmo: module/m_flatten.mlt util/util.cmi revision.cmi util/property.cmi \
-    proof.cmi module/m_t.cmi util/ext.cmi expr.cmi util/deque.cmi \
-    module/m_flatten.cmi
-module/m_flatten.cmx: module/m_flatten.mlt util/util.cmx revision.cmx util/property.cmx \
-    proof.cmx module/m_t.cmx util/ext.cmx expr.cmx util/deque.cmx \
-    module/m_flatten.cmi
-module/m_dep.cmo: module/m_dep.mlt util/util.cmi revision.cmi util/property.cmi proof.cmi \
-    module/m_t.cmi module/m_flatten.cmi util/ext.cmi expr.cmi util/deque.cmi \
-    module/m_dep.cmi
-module/m_dep.cmx: module/m_dep.mlt util/util.cmx revision.cmx util/property.cmx proof.cmx \
-    module/m_t.cmx module/m_flatten.cmx util/ext.cmx expr.cmx util/deque.cmx \
-    module/m_dep.cmi
-module/m_parser.cmo: module/m_parser.mlt tla_parser.cmi revision.cmi util/property.cmi \
-    proof.cmi method_prs.cmi module/m_t.cmi util/ext.cmi expr.cmi \
-    util/deque.cmi module/m_parser.cmi
-module/m_parser.cmx: module/m_parser.mlt tla_parser.cmx revision.cmx util/property.cmx \
-    proof.cmx method_prs.cmx module/m_t.cmx util/ext.cmx expr.cmx \
-    util/deque.cmx module/m_parser.cmi
-module/m_save.cmo: module/m_save.mlt util/util.cmi tla_parser.cmi util/timing.cmi \
-    revision.cmi util/property.cmi params.cmi module/m_t.cmi \
-    module/m_standard.cmi module/m_parser.cmi module/m_dep.cmi loc.cmi \
-    errors.cmi util/deque.cmi alexer.cmi module/m_save.cmi
-module/m_save.cmx: module/m_save.mlt util/util.cmx tla_parser.cmx util/timing.cmx \
-    revision.cmx util/property.cmx params.cmx module/m_t.cmx \
-    module/m_standard.cmx module/m_parser.cmx module/m_dep.cmx loc.cmx \
-    errors.cmx util/deque.cmx alexer.cmx module/m_save.cmi
-module.cmo: module.mlt revision.cmi module/m_t.cmi module/m_standard.cmi \
-    module/m_save.cmi module/m_parser.cmi module/m_globalness.cmi \
-    module/m_gen.cmi module/m_fmt.cmi module/m_flatten.cmi module/m_elab.cmi \
-    module/m_dep.cmi module.cmi
-module.cmx: module.mlt revision.cmx module/m_t.cmx module/m_standard.cmx \
-    module/m_save.cmx module/m_parser.cmx module/m_globalness.cmx \
-    module/m_gen.cmx module/m_fmt.cmx module/m_flatten.cmx module/m_elab.cmx \
-    module/m_dep.cmx module.cmi
-frontend/symbol_commute.cmo: frontend/symbol_commute.mlt util/util.cmi tla_parser.cmi revision.cmi \
-    util/property.cmi proof.cmi util/ext.cmi expr.cmi util/deque.cmi ctx.cmi \
+smt/rewrite_arith.cmo: smt/rewrite_arith.mlt \
+    typesystem/typ_t.cmi \
+    smt/smtcommons.cmi \
+    util/property.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    builtin.cmi \
+    smt/rewrite_arith.cmi
+smt/rewrite_arith.cmx: smt/rewrite_arith.mlt \
+    typesystem/typ_t.cmx \
+    smt/smtcommons.cmx \
+    util/property.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    builtin.cmx \
+    smt/rewrite_arith.cmi
+smt/rewrite.cmo: smt/rewrite.mlt \
+    typesystem/typ_t.cmi \
+    tla_parser.cmi \
+    smt/smtcommons.cmi \
+    smt/rewrite_trivial.cmi \
+    smt/rewrite_arith.cmi \
+    revision.cmi \
+    util/property.cmi \
+    util/fmtutil.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    util/deque.cmi \
+    builtin.cmi \
+    smt/rewrite.cmi
+smt/rewrite.cmx: smt/rewrite.mlt \
+    typesystem/typ_t.cmx \
+    tla_parser.cmx \
+    smt/smtcommons.cmx \
+    smt/rewrite_trivial.cmx \
+    smt/rewrite_arith.cmx \
+    revision.cmx \
+    util/property.cmx \
+    util/fmtutil.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    util/deque.cmx \
+    builtin.cmx \
+    smt/rewrite.cmi
+smt/ectx.cmo: smt/ectx.mlt \
+    typesystem/typ_t.cmi \
+    tla_parser.cmi \
+    smt/smtcommons.cmi \
+    revision.cmi \
+    util/property.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    errors.cmi \
+    util/deque.cmi \
+    ctx.cmi \
+    smt/axioms.cmi \
+    smt/ectx.cmi
+smt/ectx.cmx: smt/ectx.mlt \
+    typesystem/typ_t.cmx \
+    tla_parser.cmx \
+    smt/smtcommons.cmx \
+    revision.cmx \
+    util/property.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    errors.cmx \
+    util/deque.cmx \
+    ctx.cmx \
+    smt/axioms.cmx \
+    smt/ectx.cmi
+smt/preprocess.cmo: smt/preprocess.mlt \
+    typesystem/typ_t.cmi \
+    typesystem/typ_e.cmi \
+    tla_parser.cmi \
+    smt/smtcommons.cmi \
+    revision.cmi \
+    util/property.cmi \
+    util/fmtutil.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    errors.cmi \
+    smt/ectx.cmi \
+    util/deque.cmi \
+    ctx.cmi \
+    builtin.cmi \
+    smt/preprocess.cmi
+smt/preprocess.cmx: smt/preprocess.mlt \
+    typesystem/typ_t.cmx \
+    typesystem/typ_e.cmx \
+    tla_parser.cmx \
+    smt/smtcommons.cmx \
+    revision.cmx \
+    util/property.cmx \
+    util/fmtutil.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    errors.cmx \
+    smt/ectx.cmx \
+    util/deque.cmx \
+    ctx.cmx \
+    builtin.cmx \
+    smt/preprocess.cmi
+smt/axioms.cmo: smt/axioms.mlt \
+    typesystem/typ_t.cmi \
+    tla_parser.cmi \
+    smt/smtcommons.cmi \
+    revision.cmi \
+    util/property.cmi \
+    proof.cmi \
+    util/fmtutil.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    util/deque.cmi \
+    builtin.cmi \
+    smt/axioms.cmi
+smt/axioms.cmx: smt/axioms.mlt \
+    typesystem/typ_t.cmx \
+    tla_parser.cmx \
+    smt/smtcommons.cmx \
+    revision.cmx \
+    util/property.cmx \
+    proof.cmx \
+    util/fmtutil.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    util/deque.cmx \
+    builtin.cmx \
+    smt/axioms.cmi
+util/timing.cmo: util/timing.mlt \
+    revision.cmi \
+    util/timing.cmi
+util/timing.cmx: util/timing.mlt \
+    revision.cmx \
+    util/timing.cmi
+frontend/symbol_commute.cmo: frontend/symbol_commute.mlt \
+    util/util.cmi \
+    tla_parser.cmi \
+    revision.cmi \
+    util/property.cmi \
+    proof.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    util/deque.cmi \
+    ctx.cmi \
     frontend/symbol_commute.cmi
-frontend/symbol_commute.cmx: frontend/symbol_commute.mlt util/util.cmx tla_parser.cmx revision.cmx \
-    util/property.cmx proof.cmx util/ext.cmx expr.cmx util/deque.cmx ctx.cmx \
+frontend/symbol_commute.cmx: frontend/symbol_commute.mlt \
+    util/util.cmx \
+    tla_parser.cmx \
+    revision.cmx \
+    util/property.cmx \
+    proof.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    util/deque.cmx \
+    ctx.cmx \
     frontend/symbol_commute.cmi
-frontend/coalesce.cmo: frontend/coalesce.mlt tla_parser.cmi revision.cmi util/property.cmi \
-    util/ext.cmi expr.cmi util/deque.cmi ctx.cmi builtin.cmi \
+frontend/coalesce.cmo: frontend/coalesce.mlt \
+    tla_parser.cmi \
+    revision.cmi \
+    util/property.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    util/deque.cmi \
+    ctx.cmi \
+    builtin.cmi \
     frontend/coalesce.cmi
-frontend/coalesce.cmx: frontend/coalesce.mlt tla_parser.cmx revision.cmx util/property.cmx \
-    util/ext.cmx expr.cmx util/deque.cmx ctx.cmx builtin.cmx \
+frontend/coalesce.cmx: frontend/coalesce.mlt \
+    tla_parser.cmx \
+    revision.cmx \
+    util/property.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    util/deque.cmx \
+    ctx.cmx \
+    builtin.cmx \
     frontend/coalesce.cmi
-frontend/action.cmo: frontend/action.mlt util/util.cmi tla_parser.cmi \
-    frontend/symbol_commute.cmi revision.cmi util/property.cmi proof.cmi \
-    util/ext.cmi expr.cmi util/deque.cmi ctx.cmi frontend/coalesce.cmi \
-    builtin.cmi frontend/action.cmi
-frontend/action.cmx: frontend/action.mlt util/util.cmx tla_parser.cmx \
-    frontend/symbol_commute.cmx revision.cmx util/property.cmx proof.cmx \
-    util/ext.cmx expr.cmx util/deque.cmx ctx.cmx frontend/coalesce.cmx \
-    builtin.cmx frontend/action.cmi
-frontend/pltl.cmo: frontend/pltl.mlt tla_parser.cmi revision.cmi util/property.cmi proof.cmi \
-    util/ext.cmi expr.cmi util/deque.cmi frontend/coalesce.cmi builtin.cmi \
+frontend/action.cmo: frontend/action.mlt \
+    util/util.cmi \
+    tla_parser.cmi \
+    frontend/symbol_commute.cmi \
+    revision.cmi \
+    util/property.cmi \
+    proof.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    util/deque.cmi \
+    ctx.cmi \
+    frontend/coalesce.cmi \
+    builtin.cmi \
+    frontend/action.cmi
+frontend/action.cmx: frontend/action.mlt \
+    util/util.cmx \
+    tla_parser.cmx \
+    frontend/symbol_commute.cmx \
+    revision.cmx \
+    util/property.cmx \
+    proof.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    util/deque.cmx \
+    ctx.cmx \
+    frontend/coalesce.cmx \
+    builtin.cmx \
+    frontend/action.cmi
+frontend/pltl.cmo: frontend/pltl.mlt \
+    tla_parser.cmi \
+    revision.cmi \
+    util/property.cmi \
+    proof.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    util/deque.cmi \
+    frontend/coalesce.cmi \
+    builtin.cmi \
     frontend/pltl.cmi
-frontend/pltl.cmx: frontend/pltl.mlt tla_parser.cmx revision.cmx util/property.cmx proof.cmx \
-    util/ext.cmx expr.cmx util/deque.cmx frontend/coalesce.cmx builtin.cmx \
+frontend/pltl.cmx: frontend/pltl.mlt \
+    tla_parser.cmx \
+    revision.cmx \
+    util/property.cmx \
+    proof.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    util/deque.cmx \
+    frontend/coalesce.cmx \
+    builtin.cmx \
     frontend/pltl.cmi
-backend/toolbox.cmo: backend/toolbox.mlt util/util.cmi backend/types.cmi toolbox_msg.cmi \
-    system.cmi revision.cmi util/property.cmi proof.cmi params.cmi method.cmi \
-    util/ext.cmi expr.cmi util/deque.cmi ctx.cmi backend/toolbox.cmi
-backend/toolbox.cmx: backend/toolbox.mlt util/util.cmx backend/types.cmx toolbox_msg.cmx \
-    system.cmx revision.cmx util/property.cmx proof.cmx params.cmx method.cmx \
-    util/ext.cmx expr.cmx util/deque.cmx ctx.cmx backend/toolbox.cmi
-backend/schedule.cmo: backend/schedule.mlt backend/toolbox.cmi system.cmi revision.cmi \
-    params.cmi backend/schedule.cmi
-backend/schedule.cmx: backend/schedule.mlt backend/toolbox.cmx system.cmx revision.cmx \
-    params.cmx backend/schedule.cmi
-backend/types.cmo: backend/types.mlt revision.cmi proof.cmi method.cmi backend/types.cmi
-backend/types.cmx: backend/types.mlt revision.cmx proof.cmx method.cmx backend/types.cmi
-backend/isabelle.cmo: backend/isabelle.mlt util/util.cmi tla_parser.cmi system.cmi revision.cmi \
-    util/property.cmi proof.cmi params.cmi util/fmtutil.cmi util/ext.cmi \
-    expr.cmi errors.cmi util/deque.cmi ctx.cmi builtin.cmi \
+backend/toolbox.cmo: backend/toolbox.mlt \
+    util/util.cmi \
+    backend/types.cmi \
+    toolbox_msg.cmi \
+    system.cmi \
+    revision.cmi \
+    util/property.cmi \
+    proof.cmi \
+    params.cmi \
+    method.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    util/deque.cmi \
+    ctx.cmi \
+    backend/toolbox.cmi
+backend/toolbox.cmx: backend/toolbox.mlt \
+    util/util.cmx \
+    backend/types.cmx \
+    toolbox_msg.cmx \
+    system.cmx \
+    revision.cmx \
+    util/property.cmx \
+    proof.cmx \
+    params.cmx \
+    method.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    util/deque.cmx \
+    ctx.cmx \
+    backend/toolbox.cmi
+backend/schedule.cmo: backend/schedule.mlt \
+    backend/toolbox.cmi \
+    system.cmi \
+    revision.cmi \
+    params.cmi \
+    backend/schedule.cmi
+backend/schedule.cmx: backend/schedule.mlt \
+    backend/toolbox.cmx \
+    system.cmx \
+    revision.cmx \
+    params.cmx \
+    backend/schedule.cmi
+backend/types.cmo: backend/types.mlt \
+    revision.cmi \
+    proof.cmi \
+    method.cmi \
+    backend/types.cmi
+backend/types.cmx: backend/types.mlt \
+    revision.cmx \
+    proof.cmx \
+    method.cmx \
+    backend/types.cmi
+backend/isabelle.cmo: backend/isabelle.mlt \
+    util/util.cmi \
+    tla_parser.cmi \
+    system.cmi \
+    revision.cmi \
+    util/property.cmi \
+    proof.cmi \
+    params.cmi \
+    util/fmtutil.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    errors.cmi \
+    util/deque.cmi \
+    ctx.cmi \
+    builtin.cmi \
     backend/isabelle.cmi
-backend/isabelle.cmx: backend/isabelle.mlt util/util.cmx tla_parser.cmx system.cmx revision.cmx \
-    util/property.cmx proof.cmx params.cmx util/fmtutil.cmx util/ext.cmx \
-    expr.cmx errors.cmx util/deque.cmx ctx.cmx builtin.cmx \
+backend/isabelle.cmx: backend/isabelle.mlt \
+    util/util.cmx \
+    tla_parser.cmx \
+    system.cmx \
+    revision.cmx \
+    util/property.cmx \
+    proof.cmx \
+    params.cmx \
+    util/fmtutil.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    errors.cmx \
+    util/deque.cmx \
+    ctx.cmx \
+    builtin.cmx \
     backend/isabelle.cmi
-backend/zenon.cmo: backend/zenon.mlt util/util.cmi tla_parser.cmi revision.cmi \
-    util/property.cmi proof.cmi backend/isabelle.cmi util/fmtutil.cmi \
-    util/ext.cmi expr.cmi errors.cmi util/deque.cmi builtin.cmi \
+backend/zenon.cmo: backend/zenon.mlt \
+    util/util.cmi \
+    tla_parser.cmi \
+    revision.cmi \
+    util/property.cmi \
+    proof.cmi \
+    backend/isabelle.cmi \
+    util/fmtutil.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    errors.cmi \
+    util/deque.cmi \
+    builtin.cmi \
     backend/zenon.cmi
-backend/zenon.cmx: backend/zenon.mlt util/util.cmx tla_parser.cmx revision.cmx \
-    util/property.cmx proof.cmx backend/isabelle.cmx util/fmtutil.cmx \
-    util/ext.cmx expr.cmx errors.cmx util/deque.cmx builtin.cmx \
+backend/zenon.cmx: backend/zenon.mlt \
+    util/util.cmx \
+    tla_parser.cmx \
+    revision.cmx \
+    util/property.cmx \
+    proof.cmx \
+    backend/isabelle.cmx \
+    util/fmtutil.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    errors.cmx \
+    util/deque.cmx \
+    builtin.cmx \
     backend/zenon.cmi
-backend/ls4.cmo: backend/ls4.mlt tla_parser.cmi revision.cmi util/property.cmi proof.cmi \
-    util/fmtutil.cmi util/ext.cmi expr.cmi errors.cmi util/deque.cmi ctx.cmi \
-    builtin.cmi backend/ls4.cmi
-backend/ls4.cmx: backend/ls4.mlt tla_parser.cmx revision.cmx util/property.cmx proof.cmx \
-    util/fmtutil.cmx util/ext.cmx expr.cmx errors.cmx util/deque.cmx ctx.cmx \
-    builtin.cmx backend/ls4.cmi
-backend/fingerprints.cmo: backend/fingerprints.mlt revision.cmi util/property.cmi proof.cmi \
-    util/ext.cmi expr.cmi errors.cmi util/deque.cmi builtin.cmi \
+backend/ls4.cmo: backend/ls4.mlt \
+    tla_parser.cmi \
+    revision.cmi \
+    util/property.cmi \
+    proof.cmi \
+    util/fmtutil.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    errors.cmi \
+    util/deque.cmi \
+    ctx.cmi \
+    frontend/coalesce.cmi \
+    builtin.cmi \
+    backend/ls4.cmi
+backend/ls4.cmx: backend/ls4.mlt \
+    tla_parser.cmx \
+    revision.cmx \
+    util/property.cmx \
+    proof.cmx \
+    util/fmtutil.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    errors.cmx \
+    util/deque.cmx \
+    ctx.cmx \
+    frontend/coalesce.cmx \
+    builtin.cmx \
+    backend/ls4.cmi
+backend/fingerprints.cmo: backend/fingerprints.mlt \
+    revision.cmi \
+    util/property.cmi \
+    proof.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    errors.cmi \
+    util/deque.cmi \
+    builtin.cmi \
     backend/fingerprints.cmi
-backend/fingerprints.cmx: backend/fingerprints.mlt revision.cmx util/property.cmx proof.cmx \
-    util/ext.cmx expr.cmx errors.cmx util/deque.cmx builtin.cmx \
+backend/fingerprints.cmx: backend/fingerprints.mlt \
+    revision.cmx \
+    util/property.cmx \
+    proof.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    errors.cmx \
+    util/deque.cmx \
+    builtin.cmx \
     backend/fingerprints.cmi
-backend/fpfile.cmo: backend/fpfile.mlt util/util.cmi backend/types.cmi revision.cmi params.cmi \
-    method.cmi util/ext.cmi errors.cmi backend/fpfile.cmi
-backend/fpfile.cmx: backend/fpfile.mlt util/util.cmx backend/types.cmx revision.cmx params.cmx \
-    method.cmx util/ext.cmx errors.cmx backend/fpfile.cmi
-backend/smt.cmo: backend/smt.mlt util/util.cmi typesystem/typ_t.cmi \
-    typesystem/typ_system.cmi typesystem/typ_e.cmi tla_parser.cmi \
-    smt/smtcommons.cmi smt/rewrite.cmi revision.cmi util/property.cmi \
-    proof.cmi smt/preprocess.cmi params.cmi util/fmtutil.cmi smt/fmt.cmi \
-    util/ext.cmi expr.cmi errors.cmi smt/ectx.cmi util/deque.cmi ctx.cmi \
-    builtin.cmi smt/boolify.cmi smt/axioms.cmi backend/smt.cmi
-backend/smt.cmx: backend/smt.mlt util/util.cmx typesystem/typ_t.cmx \
-    typesystem/typ_system.cmx typesystem/typ_e.cmx tla_parser.cmx \
-    smt/smtcommons.cmx smt/rewrite.cmx revision.cmx util/property.cmx \
-    proof.cmx smt/preprocess.cmx params.cmx util/fmtutil.cmx smt/fmt.cmx \
-    util/ext.cmx expr.cmx errors.cmx smt/ectx.cmx util/deque.cmx ctx.cmx \
-    builtin.cmx smt/boolify.cmx smt/axioms.cmx backend/smt.cmi
-backend/prep.cmo: backend/prep.mlt backend/zenon.cmi util/util.cmi backend/types.cmi \
-    backend/toolbox.cmi backend/smt.cmi backend/schedule.cmi revision.cmi \
-    util/property.cmi proof.cmi frontend/pltl.cmi params.cmi method.cmi \
-    backend/ls4.cmi loc.cmi backend/isabelle.cmi backend/fpfile.cmi \
-    backend/fingerprints.cmi util/ext.cmi expr.cmi errors.cmi util/deque.cmi \
-    ctx.cmi builtin.cmi frontend/action.cmi backend/prep.cmi
-backend/prep.cmx: backend/prep.mlt backend/zenon.cmx util/util.cmx backend/types.cmx \
-    backend/toolbox.cmx backend/smt.cmx backend/schedule.cmx revision.cmx \
-    util/property.cmx proof.cmx frontend/pltl.cmx params.cmx method.cmx \
-    backend/ls4.cmx loc.cmx backend/isabelle.cmx backend/fpfile.cmx \
-    backend/fingerprints.cmx util/ext.cmx expr.cmx errors.cmx util/deque.cmx \
-    ctx.cmx builtin.cmx frontend/action.cmx backend/prep.cmi
-backend.cmo: backend.mlt backend/zenon.cmi backend/types.cmi backend/toolbox.cmi \
-    revision.cmi backend/prep.cmi backend/fpfile.cmi backend/fingerprints.cmi \
+backend/fpfile.cmo: backend/fpfile.mlt \
+    util/util.cmi \
+    backend/types.cmi \
+    revision.cmi \
+    params.cmi \
+    method.cmi \
+    util/ext.cmi \
+    errors.cmi \
+    backend/fpfile.cmi
+backend/fpfile.cmx: backend/fpfile.mlt \
+    util/util.cmx \
+    backend/types.cmx \
+    revision.cmx \
+    params.cmx \
+    method.cmx \
+    util/ext.cmx \
+    errors.cmx \
+    backend/fpfile.cmi
+backend/smt.cmo: backend/smt.mlt \
+    util/util.cmi \
+    typesystem/typ_t.cmi \
+    typesystem/typ_system.cmi \
+    typesystem/typ_e.cmi \
+    tla_parser.cmi \
+    smt/smtcommons.cmi \
+    smt/rewrite.cmi \
+    revision.cmi \
+    util/property.cmi \
+    proof.cmi \
+    smt/preprocess.cmi \
+    params.cmi \
+    util/fmtutil.cmi \
+    smt/fmt.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    errors.cmi \
+    smt/ectx.cmi \
+    util/deque.cmi \
+    ctx.cmi \
+    builtin.cmi \
+    smt/boolify.cmi \
+    smt/axioms.cmi \
+    backend/smt.cmi
+backend/smt.cmx: backend/smt.mlt \
+    util/util.cmx \
+    typesystem/typ_t.cmx \
+    typesystem/typ_system.cmx \
+    typesystem/typ_e.cmx \
+    tla_parser.cmx \
+    smt/smtcommons.cmx \
+    smt/rewrite.cmx \
+    revision.cmx \
+    util/property.cmx \
+    proof.cmx \
+    smt/preprocess.cmx \
+    params.cmx \
+    util/fmtutil.cmx \
+    smt/fmt.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    errors.cmx \
+    smt/ectx.cmx \
+    util/deque.cmx \
+    ctx.cmx \
+    builtin.cmx \
+    smt/boolify.cmx \
+    smt/axioms.cmx \
+    backend/smt.cmi
+backend/prep.cmo: backend/prep.mlt \
+    backend/zenon.cmi \
+    util/util.cmi \
+    backend/types.cmi \
+    backend/toolbox.cmi \
+    backend/smt.cmi \
+    backend/schedule.cmi \
+    revision.cmi \
+    util/property.cmi \
+    proof.cmi \
+    frontend/pltl.cmi \
+    params.cmi \
+    method.cmi \
+    backend/ls4.cmi \
+    loc.cmi \
+    backend/isabelle.cmi \
+    backend/fpfile.cmi \
+    backend/fingerprints.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    errors.cmi \
+    util/deque.cmi \
+    ctx.cmi \
+    builtin.cmi \
+    frontend/action.cmi \
+    backend/prep.cmi
+backend/prep.cmx: backend/prep.mlt \
+    backend/zenon.cmx \
+    util/util.cmx \
+    backend/types.cmx \
+    backend/toolbox.cmx \
+    backend/smt.cmx \
+    backend/schedule.cmx \
+    revision.cmx \
+    util/property.cmx \
+    proof.cmx \
+    frontend/pltl.cmx \
+    params.cmx \
+    method.cmx \
+    backend/ls4.cmx \
+    loc.cmx \
+    backend/isabelle.cmx \
+    backend/fpfile.cmx \
+    backend/fingerprints.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    errors.cmx \
+    util/deque.cmx \
+    ctx.cmx \
+    builtin.cmx \
+    frontend/action.cmx \
+    backend/prep.cmi
+backend.cmo: backend.mlt \
+    backend/zenon.cmi \
+    backend/types.cmi \
+    backend/toolbox.cmi \
+    revision.cmi \
+    backend/prep.cmi \
+    backend/fpfile.cmi \
+    backend/fingerprints.cmi \
     backend.cmi
-backend.cmx: backend.mlt backend/zenon.cmx backend/types.cmx backend/toolbox.cmx \
-    revision.cmx backend/prep.cmx backend/fpfile.cmx backend/fingerprints.cmx \
+backend.cmx: backend.mlt \
+    backend/zenon.cmx \
+    backend/types.cmx \
+    backend/toolbox.cmx \
+    revision.cmx \
+    backend/prep.cmx \
+    backend/fpfile.cmx \
+    backend/fingerprints.cmx \
     backend.cmi
-tlapm_args.cmo: tlapm_args.mlt version.cmi revision.cmi params.cmi method.cmi util/ext.cmi \
-    backend.cmi tlapm_args.cmi
-tlapm_args.cmx: tlapm_args.mlt version.cmx revision.cmx params.cmx method.cmx util/ext.cmx \
-    backend.cmx tlapm_args.cmi
-tlapm.cmo: tlapm.mlt util/util.cmi backend/types.cmi backend/toolbox.cmi \
-    tlapm_args.cmi tla_parser.cmi util/timing.cmi backend/schedule.cmi \
-    revision.cmi util/property.cmi proof.cmi backend/prep.cmi params.cmi \
-    module.cmi method.cmi loc.cmi backend/isabelle.cmi backend/fpfile.cmi \
-    util/ext.cmi expr.cmi errors.cmi util/deque.cmi ctx.cmi config.cmi \
-    backend.cmi tlapm.cmi
-tlapm.cmx: tlapm.mlt util/util.cmx backend/types.cmx backend/toolbox.cmx \
-    tlapm_args.cmx tla_parser.cmx util/timing.cmx backend/schedule.cmx \
-    revision.cmx util/property.cmx proof.cmx backend/prep.cmx params.cmx \
-    module.cmx method.cmx loc.cmx backend/isabelle.cmx backend/fpfile.cmx \
-    util/ext.cmx expr.cmx errors.cmx util/deque.cmx ctx.cmx config.cmx \
-    backend.cmx tlapm.cmi
+module/m_t.cmo: module/m_t.mlt \
+    util/util.cmi \
+    revision.cmi \
+    util/property.cmi \
+    proof.cmi \
+    loc.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    errors.cmi \
+    util/deque.cmi \
+    module/m_t.cmi
+module/m_t.cmx: module/m_t.mlt \
+    util/util.cmx \
+    revision.cmx \
+    util/property.cmx \
+    proof.cmx \
+    loc.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    errors.cmx \
+    util/deque.cmx \
+    module/m_t.cmi
+module/m_visit.cmo: module/m_visit.mlt \
+    util/property.cmi \
+    module/m_t.cmi \
+    expr.cmi \
+    util/deque.cmi \
+    module/m_visit.cmi
+module/m_visit.cmx: module/m_visit.mlt \
+    util/property.cmx \
+    module/m_t.cmx \
+    expr.cmx \
+    util/deque.cmx \
+    module/m_visit.cmi
+module/m_subst.cmo: module/m_subst.mlt \
+    util/property.cmi \
+    proof.cmi \
+    module/m_t.cmi \
+    expr.cmi \
+    util/deque.cmi \
+    module/m_subst.cmi
+module/m_subst.cmx: module/m_subst.mlt \
+    util/property.cmx \
+    proof.cmx \
+    module/m_t.cmx \
+    expr.cmx \
+    util/deque.cmx \
+    module/m_subst.cmi
+module/m_fmt.cmo: module/m_fmt.mlt \
+    util/util.cmi \
+    revision.cmi \
+    util/property.cmi \
+    proof.cmi \
+    params.cmi \
+    module/m_t.cmi \
+    loc.cmi \
+    util/fmtutil.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    util/deque.cmi \
+    ctx.cmi \
+    module/m_fmt.cmi
+module/m_fmt.cmx: module/m_fmt.mlt \
+    util/util.cmx \
+    revision.cmx \
+    util/property.cmx \
+    proof.cmx \
+    params.cmx \
+    module/m_t.cmx \
+    loc.cmx \
+    util/fmtutil.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    util/deque.cmx \
+    ctx.cmx \
+    module/m_fmt.cmi
+module/m_globalness.cmo: module/m_globalness.mlt \
+    util/property.cmi \
+    proof.cmi \
+    module/m_t.cmi \
+    util/deque.cmi \
+    module/m_globalness.cmi
+module/m_globalness.cmx: module/m_globalness.mlt \
+    util/property.cmx \
+    proof.cmx \
+    module/m_t.cmx \
+    util/deque.cmx \
+    module/m_globalness.cmi
+module/m_gen.cmo: module/m_gen.mlt \
+    util/util.cmi \
+    revision.cmi \
+    util/property.cmi \
+    proof.cmi \
+    params.cmi \
+    module/m_t.cmi \
+    loc.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    errors.cmi \
+    util/deque.cmi \
+    module/m_gen.cmi
+module/m_gen.cmx: module/m_gen.mlt \
+    util/util.cmx \
+    revision.cmx \
+    util/property.cmx \
+    proof.cmx \
+    params.cmx \
+    module/m_t.cmx \
+    loc.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    errors.cmx \
+    util/deque.cmx \
+    module/m_gen.cmi
+module/m_elab.cmo: module/m_elab.mlt \
+    util/util.cmi \
+    tla_parser.cmi \
+    revision.cmi \
+    util/property.cmi \
+    proof.cmi \
+    params.cmi \
+    module/m_visit.cmi \
+    module/m_t.cmi \
+    module/m_subst.cmi \
+    module/m_gen.cmi \
+    module/m_fmt.cmi \
+    util/fmtutil.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    errors.cmi \
+    expr/e_t.cmi \
+    util/deque.cmi \
+    ctx.cmi \
+    builtin.cmi \
+    backend.cmi \
+    module/m_elab.cmi
+module/m_elab.cmx: module/m_elab.mlt \
+    util/util.cmx \
+    tla_parser.cmx \
+    revision.cmx \
+    util/property.cmx \
+    proof.cmx \
+    params.cmx \
+    module/m_visit.cmx \
+    module/m_t.cmx \
+    module/m_subst.cmx \
+    module/m_gen.cmx \
+    module/m_fmt.cmx \
+    util/fmtutil.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    errors.cmx \
+    expr/e_t.cmx \
+    util/deque.cmx \
+    ctx.cmx \
+    builtin.cmx \
+    backend.cmx \
+    module/m_elab.cmi
+module/m_standard.cmo: module/m_standard.mlt \
+    util/util.cmi \
+    revision.cmi \
+    util/property.cmi \
+    module/m_t.cmi \
+    module/m_elab.cmi \
+    loc.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    util/deque.cmi \
+    builtin.cmi \
+    module/m_standard.cmi
+module/m_standard.cmx: module/m_standard.mlt \
+    util/util.cmx \
+    revision.cmx \
+    util/property.cmx \
+    module/m_t.cmx \
+    module/m_elab.cmx \
+    loc.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    util/deque.cmx \
+    builtin.cmx \
+    module/m_standard.cmi
+module/m_flatten.cmo: module/m_flatten.mlt \
+    util/util.cmi \
+    revision.cmi \
+    util/property.cmi \
+    proof.cmi \
+    module/m_t.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    util/deque.cmi \
+    module/m_flatten.cmi
+module/m_flatten.cmx: module/m_flatten.mlt \
+    util/util.cmx \
+    revision.cmx \
+    util/property.cmx \
+    proof.cmx \
+    module/m_t.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    util/deque.cmx \
+    module/m_flatten.cmi
+module/m_dep.cmo: module/m_dep.mlt \
+    util/util.cmi \
+    revision.cmi \
+    util/property.cmi \
+    proof.cmi \
+    module/m_t.cmi \
+    module/m_flatten.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    util/deque.cmi \
+    module/m_dep.cmi
+module/m_dep.cmx: module/m_dep.mlt \
+    util/util.cmx \
+    revision.cmx \
+    util/property.cmx \
+    proof.cmx \
+    module/m_t.cmx \
+    module/m_flatten.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    util/deque.cmx \
+    module/m_dep.cmi
+module/m_parser.cmo: module/m_parser.mlt \
+    tla_parser.cmi \
+    revision.cmi \
+    util/property.cmi \
+    proof.cmi \
+    method_prs.cmi \
+    module/m_t.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    util/deque.cmi \
+    module/m_parser.cmi
+module/m_parser.cmx: module/m_parser.mlt \
+    tla_parser.cmx \
+    revision.cmx \
+    util/property.cmx \
+    proof.cmx \
+    method_prs.cmx \
+    module/m_t.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    util/deque.cmx \
+    module/m_parser.cmi
+module/m_save.cmo: module/m_save.mlt \
+    util/util.cmi \
+    tla_parser.cmi \
+    util/timing.cmi \
+    revision.cmi \
+    util/property.cmi \
+    params.cmi \
+    module/m_t.cmi \
+    module/m_standard.cmi \
+    module/m_parser.cmi \
+    module/m_dep.cmi \
+    loc.cmi \
+    errors.cmi \
+    util/deque.cmi \
+    alexer.cmi \
+    module/m_save.cmi
+module/m_save.cmx: module/m_save.mlt \
+    util/util.cmx \
+    tla_parser.cmx \
+    util/timing.cmx \
+    revision.cmx \
+    util/property.cmx \
+    params.cmx \
+    module/m_t.cmx \
+    module/m_standard.cmx \
+    module/m_parser.cmx \
+    module/m_dep.cmx \
+    loc.cmx \
+    errors.cmx \
+    util/deque.cmx \
+    alexer.cmx \
+    module/m_save.cmi
+module.cmo: module.mlt \
+    revision.cmi \
+    module/m_visit.cmi \
+    module/m_t.cmi \
+    module/m_subst.cmi \
+    module/m_standard.cmi \
+    module/m_save.cmi \
+    module/m_parser.cmi \
+    module/m_globalness.cmi \
+    module/m_gen.cmi \
+    module/m_fmt.cmi \
+    module/m_flatten.cmi \
+    module/m_elab.cmi \
+    module/m_dep.cmi \
+    module.cmi
+module.cmx: module.mlt \
+    revision.cmx \
+    module/m_visit.cmx \
+    module/m_t.cmx \
+    module/m_subst.cmx \
+    module/m_standard.cmx \
+    module/m_save.cmx \
+    module/m_parser.cmx \
+    module/m_globalness.cmx \
+    module/m_gen.cmx \
+    module/m_fmt.cmx \
+    module/m_flatten.cmx \
+    module/m_elab.cmx \
+    module/m_dep.cmx \
+    module.cmi
+tlapm_args.cmo: tlapm_args.mlt \
+    version.cmi \
+    revision.cmi \
+    params.cmi \
+    method.cmi \
+    util/ext.cmi \
+    backend.cmi \
+    tlapm_args.cmi
+tlapm_args.cmx: tlapm_args.mlt \
+    version.cmx \
+    revision.cmx \
+    params.cmx \
+    method.cmx \
+    util/ext.cmx \
+    backend.cmx \
+    tlapm_args.cmi
+tlapm.cmo: tlapm.mlt \
+    util/util.cmi \
+    backend/types.cmi \
+    backend/toolbox.cmi \
+    tlapm_args.cmi \
+    tla_parser.cmi \
+    util/timing.cmi \
+    backend/schedule.cmi \
+    revision.cmi \
+    util/property.cmi \
+    proof.cmi \
+    backend/prep.cmi \
+    params.cmi \
+    module.cmi \
+    method.cmi \
+    loc.cmi \
+    backend/isabelle.cmi \
+    backend/fpfile.cmi \
+    util/ext.cmi \
+    expr.cmi \
+    errors.cmi \
+    util/deque.cmi \
+    ctx.cmi \
+    config.cmi \
+    backend.cmi \
+    tlapm.cmi
+tlapm.cmx: tlapm.mlt \
+    util/util.cmx \
+    backend/types.cmx \
+    backend/toolbox.cmx \
+    tlapm_args.cmx \
+    tla_parser.cmx \
+    util/timing.cmx \
+    backend/schedule.cmx \
+    revision.cmx \
+    util/property.cmx \
+    proof.cmx \
+    backend/prep.cmx \
+    params.cmx \
+    module.cmx \
+    method.cmx \
+    loc.cmx \
+    backend/isabelle.cmx \
+    backend/fpfile.cmx \
+    util/ext.cmx \
+    expr.cmx \
+    errors.cmx \
+    util/deque.cmx \
+    ctx.cmx \
+    config.cmx \
+    backend.cmx \
+    tlapm.cmi
 revision.cmi :
 sysconf.cmi :
 util/ext.cmi :
@@ -511,102 +2087,315 @@ config.cmi :
 method.cmi :
 version.cmi :
 loc.cmi :
-toolbox_msg.cmi : loc.cmi
-params.cmi : method.cmi
-pars/error.cmi : loc.cmi
-pars/intf.cmi : loc.cmi
+toolbox_msg.cmi : \
+    loc.cmi
+params.cmi : \
+    method.cmi
+pars/error.cmi : \
+    loc.cmi
+pars/intf.cmi : \
+    loc.cmi
 pars/lazyList.cmi :
-pars/pco.cmi : loc.cmi pars/lazyList.cmi pars/intf.cmi
-pars.cmi : loc.cmi
+pars/pco.cmi : \
+    loc.cmi \
+    pars/lazyList.cmi \
+    pars/intf.cmi
+pars.cmi : \
+    loc.cmi
 util/property.cmi :
-util/util.cmi : util/property.cmi loc.cmi
+util/util.cmi : \
+    util/property.cmi \
+    loc.cmi
 ctx.cmi :
-errors.cmi : util/property.cmi
-optable.cmi : builtin.cmi
-util/fmtutil.cmi : pars.cmi
+errors.cmi : \
+    util/property.cmi
+optable.cmi : \
+    builtin.cmi
+util/fmtutil.cmi : \
+    pars.cmi
 isabelle_keywords.cmi :
-tla_parser.cmi : util/property.cmi pars.cmi loc.cmi util/fmtutil.cmi
+tla_parser.cmi : \
+    util/property.cmi \
+    pars.cmi \
+    loc.cmi \
+    util/fmtutil.cmi
 util/deque.cmi :
-alexer.cmi : tla_parser.cmi pars.cmi loc.cmi pars/lazyList.cmi
-expr/e_t.cmi : util/util.cmi util/property.cmi method.cmi util/deque.cmi \
+alexer.cmi : \
+    tla_parser.cmi \
+    pars.cmi \
+    loc.cmi \
+    pars/lazyList.cmi
+expr/e_t.cmi : \
+    util/util.cmi \
+    util/property.cmi \
+    method.cmi \
+    util/deque.cmi \
     builtin.cmi
-expr/e_visit.cmi : util/util.cmi expr/e_t.cmi util/deque.cmi
-expr/e_constness.cmi : util/property.cmi expr/e_visit.cmi expr/e_t.cmi \
+expr/e_visit.cmi : \
+    util/util.cmi \
+    expr/e_t.cmi \
     util/deque.cmi
-expr/e_fmt.cmi : util/util.cmi tla_parser.cmi expr/e_t.cmi util/deque.cmi \
+expr/e_fmt.cmi : \
+    util/util.cmi \
+    tla_parser.cmi \
+    expr/e_t.cmi \
+    util/deque.cmi \
     ctx.cmi
-expr/e_subst.cmi : util/property.cmi expr/e_t.cmi expr/e_fmt.cmi \
+expr/e_levels.cmi : \
+    util/property.cmi \
+    expr/e_visit.cmi \
+    expr/e_t.cmi
+expr/e_constness.cmi : \
+    util/property.cmi \
+    expr/e_visit.cmi \
+    expr/e_t.cmi
+expr/e_substitutive.cmi : \
+    util/property.cmi \
+    expr/e_t.cmi
+expr/e_subst.cmi : \
+    util/property.cmi \
+    expr/e_t.cmi \
+    expr/e_fmt.cmi \
     util/deque.cmi
-expr/e_eq.cmi : expr/e_t.cmi
-expr/e_deref.cmi : expr/e_t.cmi util/deque.cmi
-expr/e_leibniz.cmi : util/property.cmi expr/e_visit.cmi expr/e_t.cmi \
+expr/e_eq.cmi : \
+    expr/e_t.cmi
+expr/e_deref.cmi : \
+    expr/e_t.cmi \
     util/deque.cmi
-expr/e_parser.cmi : util/util.cmi tla_parser.cmi expr/e_t.cmi
-expr/e_tla_norm.cmi : expr/e_visit.cmi expr/e_t.cmi
-expr/e_temporal_props.cmi : expr/e_t.cmi util/deque.cmi
-expr/e_elab.cmi : expr/e_visit.cmi expr/e_t.cmi util/deque.cmi
-expr/e_anon.cmi : expr/e_visit.cmi expr/e_t.cmi
-expr.cmi : util/util.cmi tla_parser.cmi util/property.cmi method.cmi \
-    util/deque.cmi ctx.cmi builtin.cmi
-method_prs.cmi : tla_parser.cmi method.cmi
-proof/p_t.cmi : util/property.cmi method.cmi loc.cmi expr.cmi
-proof/p_fmt.cmi : proof/p_t.cmi expr.cmi util/deque.cmi ctx.cmi
-proof/p_subst.cmi : proof/p_t.cmi expr.cmi
-proof/p_visit.cmi : proof/p_t.cmi expr.cmi util/deque.cmi
-proof/p_gen.cmi : util/property.cmi proof/p_t.cmi loc.cmi expr.cmi \
+expr/e_leibniz.cmi : \
+    util/property.cmi \
+    expr/e_visit.cmi \
+    expr/e_t.cmi \
     util/deque.cmi
-proof/p_simplify.cmi : util/property.cmi proof/p_t.cmi expr.cmi \
+expr/e_parser.cmi : \
+    util/util.cmi \
+    tla_parser.cmi \
+    expr/e_t.cmi
+expr/e_tla_norm.cmi : \
+    expr/e_visit.cmi \
+    expr/e_t.cmi
+expr/e_temporal_props.cmi : \
+    expr/e_t.cmi \
     util/deque.cmi
-proof/p_anon.cmi : proof/p_visit.cmi
-proof/p_parser.cmi : tla_parser.cmi proof/p_t.cmi
-proof.cmi : tla_parser.cmi util/property.cmi method.cmi loc.cmi expr.cmi \
-    util/deque.cmi ctx.cmi
-smt/smtcommons.cmi : util/util.cmi util/property.cmi expr.cmi util/deque.cmi
-typesystem/typ_t.cmi : util/property.cmi expr.cmi util/deque.cmi
-typesystem/typ_e.cmi : typesystem/typ_t.cmi expr.cmi util/deque.cmi
-typesystem/typ_c.cmi : typesystem/typ_t.cmi typesystem/typ_e.cmi expr.cmi \
+expr/e_elab.cmi : \
+    expr/e_visit.cmi \
+    expr/e_t.cmi \
+    util/deque.cmi
+expr/e_anon.cmi : \
+    expr/e_visit.cmi \
+    expr/e_t.cmi
+expr/e_action.cmi : \
+    expr/e_t.cmi
+expr/e_level_comparison.cmi : \
+    util/util.cmi \
+    util/property.cmi \
+    expr/e_t.cmi
+expr.cmi : \
+    util/util.cmi \
+    tla_parser.cmi \
+    util/property.cmi \
+    method.cmi \
+    util/deque.cmi \
+    ctx.cmi \
     builtin.cmi
-typesystem/typ_cg1.cmi : typesystem/typ_e.cmi typesystem/typ_c.cmi expr.cmi
-typesystem/typ_cg2.cmi : typesystem/typ_e.cmi typesystem/typ_c.cmi expr.cmi
-typesystem/typ_impgraph.cmi : typesystem/typ_t.cmi typesystem/typ_e.cmi \
-    expr.cmi builtin.cmi
-typesystem/typ_system.cmi : typesystem/typ_t.cmi typesystem/typ_e.cmi \
-    typesystem/typ_c.cmi expr.cmi
-smt/fmt.cmi : expr.cmi util/deque.cmi
-smt/boolify.cmi : expr.cmi
-smt/rewrite_trivial.cmi : expr.cmi
-smt/rewrite_arith.cmi : expr.cmi
-smt/rewrite.cmi : expr.cmi
-smt/ectx.cmi : expr.cmi util/deque.cmi ctx.cmi smt/axioms.cmi
-smt/preprocess.cmi : expr.cmi
-smt/axioms.cmi : expr.cmi builtin.cmi
+method_prs.cmi : \
+    tla_parser.cmi \
+    method.cmi
+proof/p_t.cmi : \
+    util/property.cmi \
+    method.cmi \
+    loc.cmi \
+    expr.cmi
+proof/p_fmt.cmi : \
+    proof/p_t.cmi \
+    expr.cmi \
+    util/deque.cmi \
+    ctx.cmi
+proof/p_subst.cmi : \
+    proof/p_t.cmi \
+    expr.cmi
+proof/p_visit.cmi : \
+    proof/p_t.cmi \
+    expr.cmi \
+    util/deque.cmi
+proof/p_gen.cmi : \
+    util/property.cmi \
+    proof/p_t.cmi \
+    loc.cmi \
+    expr.cmi \
+    util/deque.cmi
+proof/p_simplify.cmi : \
+    util/property.cmi \
+    proof/p_t.cmi \
+    expr.cmi \
+    util/deque.cmi
+proof/p_anon.cmi : \
+    proof/p_visit.cmi
+proof/p_parser.cmi : \
+    tla_parser.cmi \
+    proof/p_t.cmi
+proof.cmi : \
+    tla_parser.cmi \
+    util/property.cmi \
+    method.cmi \
+    loc.cmi \
+    expr.cmi \
+    util/deque.cmi \
+    ctx.cmi
+smt/smtcommons.cmi : \
+    util/util.cmi \
+    util/property.cmi \
+    expr.cmi \
+    util/deque.cmi
+typesystem/typ_t.cmi : \
+    util/property.cmi \
+    expr.cmi \
+    util/deque.cmi
+typesystem/typ_e.cmi : \
+    typesystem/typ_t.cmi \
+    expr.cmi \
+    util/deque.cmi
+typesystem/typ_c.cmi : \
+    typesystem/typ_t.cmi \
+    typesystem/typ_e.cmi \
+    expr.cmi \
+    builtin.cmi
+typesystem/typ_cg1.cmi : \
+    typesystem/typ_e.cmi \
+    typesystem/typ_c.cmi \
+    expr.cmi
+typesystem/typ_cg2.cmi : \
+    typesystem/typ_e.cmi \
+    typesystem/typ_c.cmi \
+    expr.cmi
+typesystem/typ_impgraph.cmi : \
+    typesystem/typ_t.cmi \
+    typesystem/typ_e.cmi \
+    expr.cmi \
+    builtin.cmi
+typesystem/typ_system.cmi : \
+    typesystem/typ_t.cmi \
+    typesystem/typ_e.cmi \
+    typesystem/typ_c.cmi \
+    expr.cmi
+smt/fmt.cmi : \
+    expr.cmi \
+    util/deque.cmi
+smt/boolify.cmi : \
+    expr.cmi
+smt/rewrite_trivial.cmi : \
+    expr.cmi
+smt/rewrite_arith.cmi : \
+    expr.cmi
+smt/rewrite.cmi : \
+    expr.cmi
+smt/ectx.cmi : \
+    expr.cmi \
+    util/deque.cmi \
+    ctx.cmi \
+    smt/axioms.cmi
+smt/preprocess.cmi : \
+    expr.cmi
+smt/axioms.cmi : \
+    expr.cmi \
+    builtin.cmi
 util/timing.cmi :
-module/m_t.cmi : util/util.cmi util/property.cmi proof.cmi loc.cmi expr.cmi
-module/m_fmt.cmi : module/m_t.cmi expr.cmi ctx.cmi
-module/m_globalness.cmi : util/property.cmi module/m_t.cmi
-module/m_gen.cmi : proof.cmi module/m_t.cmi expr.cmi util/deque.cmi
-module/m_elab.cmi : proof.cmi module/m_t.cmi expr.cmi util/deque.cmi
-module/m_standard.cmi : module/m_t.cmi
-module/m_flatten.cmi : util/util.cmi util/property.cmi module/m_t.cmi
-module/m_dep.cmi : util/util.cmi util/property.cmi module/m_t.cmi
-module/m_parser.cmi : tla_parser.cmi module/m_t.cmi
-module/m_save.cmi : util/util.cmi util/timing.cmi module/m_t.cmi
-module.cmi : util/util.cmi tla_parser.cmi util/timing.cmi util/property.cmi \
-    proof.cmi loc.cmi expr.cmi util/deque.cmi ctx.cmi
-frontend/symbol_commute.cmi : expr.cmi
-frontend/coalesce.cmi : expr.cmi util/deque.cmi
-frontend/action.cmi : proof.cmi
-frontend/pltl.cmi : proof.cmi
-backend/toolbox.cmi : backend/types.cmi proof.cmi
+frontend/symbol_commute.cmi : \
+    expr.cmi
+frontend/coalesce.cmi : \
+    expr.cmi
+frontend/action.cmi : \
+    proof.cmi
+frontend/pltl.cmi : \
+    proof.cmi
+backend/toolbox.cmi : \
+    backend/types.cmi \
+    proof.cmi
 backend/schedule.cmi :
-backend/types.cmi : proof.cmi method.cmi
-backend/isabelle.cmi : util/util.cmi proof.cmi expr.cmi ctx.cmi
-backend/zenon.cmi : proof.cmi
-backend/ls4.cmi : proof.cmi
-backend/fingerprints.cmi : proof.cmi
-backend/fpfile.cmi : backend/types.cmi method.cmi
-backend/smt.cmi : proof.cmi
-backend/prep.cmi : backend/types.cmi backend/schedule.cmi proof.cmi expr.cmi
-backend.cmi : proof.cmi method.cmi
+backend/types.cmi : \
+    proof.cmi \
+    method.cmi
+backend/isabelle.cmi : \
+    util/util.cmi \
+    proof.cmi \
+    expr.cmi \
+    ctx.cmi
+backend/zenon.cmi : \
+    proof.cmi
+backend/ls4.cmi : \
+    proof.cmi
+backend/fingerprints.cmi : \
+    proof.cmi
+backend/fpfile.cmi : \
+    backend/types.cmi \
+    method.cmi
+backend/smt.cmi : \
+    proof.cmi
+backend/prep.cmi : \
+    backend/types.cmi \
+    backend/schedule.cmi \
+    proof.cmi \
+    expr.cmi
+backend.cmi : \
+    proof.cmi \
+    method.cmi
+module/m_t.cmi : \
+    util/util.cmi \
+    util/property.cmi \
+    proof.cmi \
+    loc.cmi \
+    expr.cmi
+module/m_visit.cmi : \
+    util/util.cmi \
+    proof.cmi \
+    module/m_t.cmi \
+    expr.cmi
+module/m_subst.cmi : \
+    module/m_t.cmi \
+    expr.cmi
+module/m_fmt.cmi : \
+    module/m_t.cmi \
+    expr.cmi \
+    ctx.cmi
+module/m_globalness.cmi : \
+    util/property.cmi \
+    module/m_t.cmi
+module/m_gen.cmi : \
+    proof.cmi \
+    module/m_t.cmi \
+    expr.cmi \
+    util/deque.cmi
+module/m_elab.cmi : \
+    module/m_t.cmi \
+    expr.cmi \
+    util/deque.cmi
+module/m_standard.cmi : \
+    module/m_t.cmi
+module/m_flatten.cmi : \
+    util/util.cmi \
+    util/property.cmi \
+    module/m_t.cmi
+module/m_dep.cmi : \
+    util/util.cmi \
+    util/property.cmi \
+    module/m_t.cmi
+module/m_parser.cmi : \
+    tla_parser.cmi \
+    module/m_t.cmi
+module/m_save.cmi : \
+    util/util.cmi \
+    util/timing.cmi \
+    module/m_t.cmi
+module.cmi : \
+    util/util.cmi \
+    tla_parser.cmi \
+    util/timing.cmi \
+    util/property.cmi \
+    proof.cmi \
+    module/m_t.cmi \
+    loc.cmi \
+    expr.cmi \
+    util/deque.cmi \
+    ctx.cmi
 tlapm_args.cmi :
 tlapm.cmi :

--- a/src/Makefile
+++ b/src/Makefile
@@ -22,7 +22,8 @@ BACKEND_PACK = \
   backend/smt backend/prep
 
 MODULE_PACK = \
-  module/m_t module/m_fmt module/m_globalness module/m_gen module/m_elab \
+  module/m_t module/m_visit module/m_subst \
+  module/m_fmt module/m_globalness module/m_gen module/m_elab \
   module/m_standard \
   module/m_flatten module/m_dep module/m_parser module/m_save
 
@@ -34,9 +35,11 @@ PARS_PACK = \
   pars/error pars/intf pars/lazyList pars/pco
 
 EXPR_PACK = \
-  expr/e_t expr/e_visit expr/e_constness expr/e_fmt expr/e_subst expr/e_eq expr/e_deref \
+  expr/e_t expr/e_visit expr/e_fmt expr/e_levels expr/e_constness \
+  expr/e_substitutive expr/e_subst expr/e_eq expr/e_deref \
   expr/e_leibniz expr/e_parser expr/e_tla_norm expr/e_temporal_props \
-  expr/e_elab expr/e_anon
+  expr/e_elab expr/e_anon \
+  expr/e_action expr/e_level_comparison
 
 TYPESYSTEM_DIR = \
   typesystem/typ_t typesystem/typ_e typesystem/typ_c \
@@ -52,9 +55,11 @@ MODULES = revision sysconf \
   params ${PARS_PACK} pars util/property \
   util/util ctx errors optable util/fmtutil \
   isabelle_keywords tla_parser util/deque alexer ${EXPR_PACK} expr \
-  method_prs ${PROOF_PACK} proof ${SMT_DIR} util/timing \
-	${MODULE_PACK} module ${FRONTEND_PACK} \
+  method_prs \
+  ${PROOF_PACK} proof ${SMT_DIR} util/timing \
+	${FRONTEND_PACK} \
   backend/toolbox backend/schedule ${BACKEND_PACK} backend \
+  ${MODULE_PACK} module \
   tlapm_args tlapm
 
 INC0 = -I ../backend -I ../frontend -I ../expr -I ../module -I ../proof \

--- a/src/backend/fingerprints.ml
+++ b/src/backend/fingerprints.ml
@@ -488,8 +488,7 @@ and fp_sequent stack buf sq =
              spin stack cx;
              ignore (Stack.pop stack)
           | Defn ({core = Instance _}, _, Visible, _) -> assert false
-          | Fact (e, visibility, tm) ->
-              assert (visibility = Visible);  (* see pattern case above *)
+          | Fact (e, Visible, tm) ->
                Stack.push stack (Identhyp ("HYP", "None"), ref false);
               spin stack cx;
               ignore (Stack.pop stack);

--- a/src/backend/fingerprints.ml
+++ b/src/backend/fingerprints.ml
@@ -417,7 +417,19 @@ and fp_sequent stack buf sq =
         bprintf buf "$Goal(%a)" (fp_expr counthyp countvar stack) sq.active
     | Some (h, cx) ->
          match h.core with
-          | Fresh (hint, _, _, Unbounded)
+          | Fresh (hint, _, kind, Unbounded)
+          ->
+              let kind_str = match kind with
+                | Constant -> "CONSTANT"
+                | State -> "STATE"
+                | Action -> "ACTION"
+                | Temporal -> "TEMPORAL"
+                | Unknown -> "Unknown" in
+              Stack.push stack (Identhyp (kind_str, hint.core), ref false);
+              spin stack cx;
+              let (v, r) = Stack.pop stack in
+              if !r then
+                bprintf buf "%s" (kind_str ^ hint.core)
           | Fresh (hint, _, _, Bounded (_, Hidden))
           | Defn ({core = Recursive (hint, _)}, _, _, _)
           ->  Stack.push stack (Identhyp ("CON", hint.core), ref false);
@@ -441,6 +453,13 @@ and fp_sequent stack buf sq =
              ignore (Stack.pop stack)
           | Defn ({core = Instance _}, _, Hidden, _) -> assert false
           | Fact (_, Hidden, _) ->
+              (* These are pragmas mentioned in the `BY` and made hidden
+              by the function `Backend.Prep.find_meth`. The function
+              `Backend.Prep.find_meth` has been changed to keep these facts
+              visible, so that proofs with identical assertions and different
+              `BY` statements would correspond to different fingerprints.
+              *)
+              (* Util.printf ~prefix:"[DEBUG]: " "Hidden `Fact`"; *)
               Stack.push stack (No(*Identvar "HIDDENFACT"*), ref false);
               spin stack cx ;
               ignore (Stack.pop stack)
@@ -469,10 +488,22 @@ and fp_sequent stack buf sq =
              spin stack cx;
              ignore (Stack.pop stack)
           | Defn ({core = Instance _}, _, Visible, _) -> assert false
-          | Fact (e, _, tm) ->
+          | Fact (e, visibility, tm) ->
+              assert (visibility = Visible);  (* see pattern case above *)
                Stack.push stack (Identhyp ("HYP", "None"), ref false);
               spin stack cx;
               ignore (Stack.pop stack);
+              (*
+              Util.printf ~prefix:"[DEBUG]: " "Visible `Fact` ";
+              let msg = "expr:\n" in
+              let pr_obl fmt = ignore (
+                  let print = Expr.Fmt.pp_print_expr in
+                  let cx = (Deque.empty, Ctx.dot) in
+                  let fmt = Format.std_formatter in
+                  print cx fmt e)
+              in Util.printf ~at:e ~prefix:"[DEBUG]: "
+                "%s@\n  @[<b0>%t@]@." msg pr_obl;
+              *)
               bprintf buf "$Fact(%a,%s)" (fp_expr counthyp countvar stack) e
                       (time_to_string tm);
   in

--- a/src/backend/fingerprints.ml
+++ b/src/backend/fingerprints.ml
@@ -453,7 +453,7 @@ and fp_sequent stack buf sq =
              ignore (Stack.pop stack)
           | Defn ({core = Instance _}, _, Hidden, _) -> assert false
           | Fact (_, Hidden, _) ->
-              (* These are pragmas mentioned in the `BY` and made hidden
+              (* These include pragmas mentioned in the `BY` and made hidden
               by the function `Backend.Prep.find_meth`. The function
               `Backend.Prep.find_meth` has been changed to keep these facts
               visible, so that proofs with identical assertions and different

--- a/src/backend/fpfile.ml
+++ b/src/backend/fpfile.ml
@@ -1016,7 +1016,7 @@ module V11 = struct
 
   (* File format:
      - magic number as a marshalled integer = 20101013
-     - Fpver10 of tbl
+     - Fpver11 of tbl
      - any number of (Digest.t, sti list) pairs
   *)
 
@@ -1117,11 +1117,125 @@ module V12 = struct
 
   (* File format:
      - magic number as a marshalled integer = 20101013
-     - Fpver10 of tbl
+     - Fpver12 of tbl
      - any number of (Digest.t, sti list) pairs
   *)
 
   let version = 12;;
+
+end;;
+
+module V13 = struct
+
+  (* introduced on 2019- in revision *)
+  (* Adds the cases "ExpandENABLED", "ExpandCdot", "AutoUSE", "Lambdify",
+     "ENABLEDaxioms", "LevelComparison"
+     to type meth.
+   *)
+
+  type floatomega = F of float | Omega;;
+
+  type meth =
+  | Isabelle of isabelle
+  | Zenon of zenon
+  | Smt
+  | SmtT of floatomega
+  | Yices
+  | YicesT of floatomega
+  | Z3
+  | Z3T of floatomega
+  | Cooper
+  | Sorry
+  | Fail
+  | Cvc3T of floatomega
+  | Smt2lib of floatomega
+  | Smt2z3 of floatomega
+  | Smt3 of floatomega
+  | Z33 of floatomega
+  | Cvc33 of floatomega
+  | Yices3 of floatomega
+  | Verit of floatomega
+  | Spass of floatomega
+  | Tptp of floatomega
+  | LS4 of floatomega
+  | ExpandENABLED
+  | AutoUSE  (* as needed for expanding `ENABLED` and `\cdot` *)
+  | ExpandCdot
+  | Lambdify
+  | ENABLEDaxioms
+  | LevelComparison
+  | Trivial
+
+  and zenon = {
+    zenon_timeout : float;
+    zenon_fallback : meth;
+  }
+
+  and isabelle = {
+    isabelle_timeout : floatomega;
+    isabelle_tactic : string;
+  }
+  ;;
+
+  type reason =
+  | False
+  | Timeout
+  | Cantwork of string
+  ;;
+
+  type status_type_aux =
+  | RSucc
+  | RFail of reason option
+  | RInt
+  ;;
+
+  type status_type =
+  | Triv
+  | NTriv of status_type_aux * meth
+  ;;
+
+  type date = int * int * int * int * int * int;;
+  (* year, month-1, day, hour, minute, second *)
+
+  type sti = status_type * date * string * string * string;;
+             (* status, date, pm version, zenon version, isabelle version *)
+
+  type str = {
+    tres : sti option;
+    zres : sti option;
+    ires : sti option;
+    smtres : sti option;
+    cooperres : sti option;
+    yres : sti option;
+    z3res : sti option;
+    cvc3res : sti option;
+    smt2libres : sti option;
+    smt2z3res : sti option;
+    smt3res : sti option;
+    z33res : sti option;
+    cvc33res : sti option;
+    yices3res : sti option;
+    veritres : sti option;
+    spassres : sti option;
+    tptpres : sti option;
+    ls4res : sti option;
+    expandenabledres : sti option;
+    expandcdotres : sti option;
+    lambdifyres: sti option;
+    enabledaxiomsres: sti option;
+    levelcomparisonres: sti option;
+  };;
+
+  type tbl = (string, str) Hashtbl.t;;
+  (* The key is the MD5 converted to hex. *)
+
+  (* File format:
+     - magic number as a marshalled integer = 20101013
+     - Fpver13 of tbl
+     - any number of (Digest.t, sti list) pairs
+  *)
+
+  let version = 13;;
 
 end;;
 
@@ -1138,6 +1252,7 @@ type fp =
   | FP10 of V10.tbl
   | FP11 of V11.tbl
   | FP12 of V12.tbl
+  | FP13 of V13.tbl
   | FPunknown of unit
 ;;
 
@@ -1152,15 +1267,15 @@ type fp =
 let myrevision = "$Rev$";;
 
 open Printf;;
-open V12;;
+open V13;;
 
-let fptbl = ref (Hashtbl.create 500 : V12.tbl);;
+let fptbl = ref (Hashtbl.create 500 : V13.tbl);;
 
 let magic_number = 20101013;;
 
 let write_fp_table oc =
   output_value oc magic_number;
-  output_value oc (FP12 !fptbl);
+  output_value oc (FP13 !fptbl);
 ;;
 
 let get_date month_offset =
@@ -1200,7 +1315,7 @@ let fp_init fp_file sources =
 module T = Types;;
 module M = Method;;
 
-(* Vx means the latest version, currently V12 *)
+(* Vx means the latest version, currently V13 *)
 
 let rec st6_to_Vx st =
   match st with
@@ -1241,17 +1356,24 @@ and meth_to_Vx m =
   | M.Spass tmo -> Spass (floatomega_to_Vx tmo)
   | M.Tptp tmo -> Tptp (floatomega_to_Vx tmo)
   | M.LS4 tmo -> LS4 (floatomega_to_Vx tmo)
+  | M.ExpandENABLED -> ExpandENABLED
+  | M.AutoUSE -> AutoUSE
+  | M.ExpandCdot -> ExpandCdot
+  | M.Lambdify -> Lambdify
+  | M.ENABLEDaxioms -> ENABLEDaxioms
+  | M.LevelComparison -> LevelComparison
+  | M.Trivial -> Trivial
 
 and floatomega_to_Vx f = F f;;
 
 let fp_to_Vx fp = fp;;
-(* V12 fingerprints are hex-encoded digests, as are external fingerprints.
+(* V13 fingerprints are hex-encoded digests, as are external fingerprints.
    Future versions will use raw digests, hence the need for this translation
    function.
 *)
 
 let date_to_Vx d = d;;
-(* V12 dates use month-1, as do external dates.  Future versions will use
+(* V13 dates use month-1, as do external dates.  Future versions will use
    month, hence the need for this translation function. *)
 
 type prover =
@@ -1274,6 +1396,13 @@ type prover =
   | Pspass
   | Ptptp
   | Pls4
+  | Pexpandenabled
+  | Pautouse
+  | Pexpandcdot
+  | Plambdify
+  | Penabledaxioms
+  | Plevelcomparison
+  | Ptrivial
 ;;
 
 let prover_of_method m =
@@ -1297,6 +1426,13 @@ let prover_of_method m =
   | Spass _ -> Pspass
   | Tptp _ -> Ptptp
   | LS4 _ -> Pls4
+  | ExpandENABLED -> Pexpandenabled
+  | ExpandCdot -> Pexpandcdot
+  | AutoUSE -> Pautouse
+  | Lambdify -> Plambdify
+  | ENABLEDaxioms -> Penabledaxioms
+  | LevelComparison -> Plevelcomparison
+  | Trivial -> Ptrivial
 ;;
 
 let normalize m =
@@ -1419,6 +1555,11 @@ let empty = {
   spassres = None;
   tptpres = None;
   ls4res = None;
+  expandenabledres = None;
+  expandcdotres = None;
+  lambdifyres = None;
+  enabledaxiomsres = None;
+  levelcomparisonres = None;
 };;
 
 let add_to_record r st =
@@ -1442,6 +1583,11 @@ let add_to_record r st =
   | NTriv (_, Spass _) -> {r with spassres = Some st}
   | NTriv (_, Tptp _) -> {r with tptpres = Some st}
   | NTriv (_, LS4 _) -> {r with ls4res = Some st}
+  | NTriv (_, ExpandENABLED) -> {r with expandenabledres = Some st}
+  | NTriv (_, ExpandCdot) -> {r with expandcdotres = Some st}
+  | NTriv (_, Lambdify) -> {r with lambdifyres = Some st}
+  | NTriv (_, ENABLEDaxioms) -> {r with enabledaxiomsres = Some st}
+  | NTriv (_, LevelComparison) -> {r with levelcomparisonres = Some st}
   | _ -> r
 ;;
 
@@ -1454,12 +1600,24 @@ let add_to_table fp l1 =
   Hashtbl.replace !fptbl fp (list_to_record l)
 ;;
 
-let fp_writes oc fp results =
-  let fp = fp_to_Vx fp in
+let fp_writes
+        (oc: out_channel)
+        (fp: string)
+        (results: Types.status_type6 list):
+            unit =
+  let fp: string = fp_to_Vx fp in
   let date = get_date (-1) in
   let zv = Params.get_zenon_verfp () in
   let iv = Params.get_isabelle_version () in
-  let f r = (st6_to_Vx r, date_to_Vx date, Params.rawversion (), zv, iv) in
+  let f (result: Types.status_type6) =
+      (
+          st6_to_Vx result,  (* : status_type6 *)
+          date_to_Vx date,  (* = date *)
+          Params.rawversion (),  (* : string = `tlapm` version *)
+          zv,  (* : string = `zenon` version *)
+          iv  (* : string = `isabelle` version *)
+      )
+    in
   let l = List.map f results in
   (* FIXME Triv results should not be sent back to server.ml, instead
      of propagating them all the way and then eliminating them here. *)
@@ -2054,7 +2212,94 @@ let add_v11r fp str =
   add_v11l (tr_fp fp) (str_to_list str)
 ;;
 
-let add_v12l fp stl = add_to_table fp stl;;
+let add_v12l fp stil =
+  let tr_fp x = x in
+  let tr_floatomega x =
+    match x with
+    | V12.F f -> F f
+    | V12.Omega -> F infinity
+  in
+  let rec tr_method m =
+    match m with
+    | V12.Isabelle {V12.isabelle_timeout = tmo; V12.isabelle_tactic = tac} ->
+      Isabelle {isabelle_timeout = tr_floatomega tmo; isabelle_tactic = tac}
+    | V12.Zenon {V12.zenon_timeout = t; V12.zenon_fallback = mm} ->
+      Zenon {zenon_timeout = t; zenon_fallback = tr_method mm}
+    | V12.Smt -> SmtT (F infinity)
+    | V12.SmtT tmo -> SmtT (tr_floatomega tmo)
+    | V12.Yices -> YicesT (F infinity)
+    | V12.YicesT tmo -> YicesT (tr_floatomega tmo)
+    | V12.Z3 -> Z3T (F infinity)
+    | V12.Z3T tmo -> Z3T (tr_floatomega tmo)
+    | V12.Cooper -> Cooper
+    | V12.Sorry -> Sorry
+    | V12.Fail -> Fail
+    | V12.Cvc3T tmo -> Cvc3T (tr_floatomega tmo)
+    | V12.Smt2lib tmo -> Smt2lib (tr_floatomega tmo)
+    | V12.Smt2z3 tmo -> Smt2z3 (tr_floatomega tmo)
+    | V12.Smt3 tmo -> Smt2z3 (tr_floatomega tmo)
+    | V12.Z33 tmo -> Z33 (tr_floatomega tmo)
+    | V12.Cvc33 tmo -> Cvc33 (tr_floatomega tmo)
+    | V12.Yices3 tmo -> Yices3 (tr_floatomega tmo)
+    | V12.Verit tmo -> Verit (tr_floatomega tmo)
+    | V12.Spass tmo -> Spass (tr_floatomega tmo)
+    | V12.Tptp tmo -> Tptp (tr_floatomega tmo)
+    | V12.LS4 tmo -> LS4 (tr_floatomega tmo)
+  in
+  let tr_reason_option x =
+    match x with
+    | None -> None
+    | Some V12.False -> Some False
+    | Some V12.Timeout -> Some Timeout
+    | Some (V12.Cantwork s) -> Some (Cantwork s)
+  in
+  let tr_st st =
+    match st with
+    | V12.Triv -> Triv
+    | V12.NTriv (V12.RSucc, m) -> NTriv (RSucc, tr_method m)
+    | V12.NTriv (V12.RFail r, m) ->
+      NTriv (RFail (tr_reason_option r), tr_method m)
+    | V12.NTriv (V12.RInt, m) -> NTriv (RInt, tr_method m)
+  in
+  let tr_sti (st, dt, pmv, zv, iv) =
+    try [(tr_st st, dt, pmv, zv, iv)]
+    with Failure _ -> []
+  in
+  add_to_table (tr_fp fp) (List.flatten (List.map tr_sti stil))
+;;
+
+let add_v12r fp str =
+  let tr_fp x = x in
+  let option_to_list x =
+    match x with
+    | None -> []
+    | Some x -> [x]
+  in
+  let str_to_list r =
+    List.flatten [
+      option_to_list r.V12.tres;
+      option_to_list r.V12.zres;
+      option_to_list r.V12.ires;
+      option_to_list r.V12.smtres;
+      option_to_list r.V12.cooperres;
+      option_to_list r.V12.yres;
+      option_to_list r.V12.z3res;
+      option_to_list r.V12.cvc3res;
+      option_to_list r.V12.smt2libres;
+      option_to_list r.V12.smt2z3res;
+      option_to_list r.V12.smt3res;
+      option_to_list r.V12.z33res;
+      option_to_list r.V12.cvc33res;
+      option_to_list r.V12.yices3res;
+      option_to_list r.V12.veritres;
+      option_to_list r.V12.spassres;
+      option_to_list r.V12.tptpres;
+    ]
+  in
+  add_v12l (tr_fp fp) (str_to_list str)
+;;
+
+let add_v13l fp stl = add_to_table fp stl;;
 
 let iter_tbl vnum f fps =
   Errors.err "Translating fingerprints from version %d to version %d"
@@ -2084,7 +2329,8 @@ let translate v ic =
   | FP9 fps -> iter_tbl 9 add_v9r fps; iter_file add_v9l ic;
   | FP10 fps -> iter_tbl 10 add_v10r fps; iter_file add_v10l ic;
   | FP11 fps -> iter_tbl 11 add_v11r fps; iter_file add_v11l ic;
-  | FP12 fps -> fptbl := fps; iter_file add_v12l ic;
+  | FP12 fps -> iter_tbl 12 add_v12r fps; iter_file add_v12l ic;
+  | FP13 fps -> fptbl := fps; iter_file add_v13l ic;
   | _ -> assert false
 ;;
 
@@ -3132,6 +3378,177 @@ let print_fp_line_12l fp stil =
   List.iter print_sti_12 stil;
 ;;
 
+let print_sti_13 (st, d, pv, zv, iv) =
+    let print_floatomega x =
+        match x with
+        | V13.F f -> printf "%g" f;
+        | V13.Omega -> printf "infinity";
+    in
+    let rec print_meth m =
+        match m with
+        | V13.Isabelle {
+                V13.isabelle_timeout = tmo;
+                V13.isabelle_tactic = s} ->
+            printf "Isabelle {timeout = ";
+            print_floatomega tmo;
+            printf "; tactic = %S}" s;
+        | V13.Zenon {
+                V13.zenon_timeout = t;
+                V13.zenon_fallback = m2} ->
+            printf "Zenon {timeout = %g; fallback = " t;
+            print_meth m2;
+            printf "}";
+        | V13.Smt -> printf "Smt";
+        | V13.SmtT tmo ->
+            printf "SmtT (";
+            print_floatomega tmo;
+            printf ")";
+        | V13.Yices -> printf "Yices";
+        | V13.YicesT tmo ->
+            printf "YicesT (";
+            print_floatomega tmo;
+            printf ")";
+        | V13.Z3 -> printf "Z3";
+        | V13.Z3T tmo ->
+            printf "Z3T";
+            print_floatomega tmo;
+            printf ")";
+        | V13.Cooper -> printf "Cooper";
+        | V13.Sorry -> printf "Sorry";
+        | V13.Fail -> printf "Fail";
+        | V13.Cvc3T tmo ->
+            printf "Cvc3T (";
+            print_floatomega tmo;
+            printf ")";
+        | V13.Smt2lib tmo ->
+            printf "Smt2lib (";
+            print_floatomega tmo;
+            printf ")";
+        | V13.Smt2z3 tmo ->
+            printf "Smt2z3 (";
+            print_floatomega tmo;
+            printf ")";
+        | V13.Smt3 tmo ->
+            printf "Smt3 (";
+            print_floatomega tmo;
+            printf ")";
+        | V13.Z33 tmo ->
+            printf "Z33 (";
+            print_floatomega tmo;
+            printf ")";
+        | V13.Cvc33 tmo ->
+            printf "Cvc33 (";
+            print_floatomega tmo;
+            printf ")";
+        | V13.Yices3 tmo ->
+            printf "Yices3 (";
+            print_floatomega tmo;
+            printf ")";
+        | V13.Verit tmo ->
+            printf "Verit (";
+            print_floatomega tmo;
+            printf ")";
+        | V13.Spass tmo ->
+            printf "Spass (";
+            print_floatomega tmo;
+            printf ")";
+        | V13.Tptp tmo ->
+            printf "Tptp (";
+            print_floatomega tmo;
+            printf ")";
+        | V13.LS4 tmo ->
+            printf "LS4 (";
+            print_floatomega tmo;
+            printf ")";
+        | V13.ExpandENABLED ->
+            printf "ExpandENABLED";
+        | V13.ExpandCdot ->
+            printf "ExpandCdot";
+        | V13.AutoUSE ->
+            printf "Auto-expand definitions";
+        | V13.Lambdify ->
+            printf "Lambdify definitions";
+        | V13.ENABLEDaxioms ->
+            printf "ENABLED axioms";
+        | V13.LevelComparison ->
+            printf "Level Comparison";
+        | V13.Trivial ->
+            printf "Trivial backend";
+    in
+    let print_reason r =
+        match r with
+        | None -> printf "No reason";
+        | Some V13.False -> printf "False";
+        | Some V13.Timeout -> printf "Timeout";
+        | Some V13.Cantwork s -> printf "Cantwork (%S)" s;
+    in
+    let print_stat s =
+        match s with
+        | V13.Triv -> printf "Trivial";
+        | V13.NTriv (V13.RSucc, m) ->
+            printf "RSucc (";
+            print_meth m;
+            printf ")";
+        | V13.NTriv (V13.RFail r, m) ->
+            printf "Fail (";
+            print_reason r;
+            printf ", ";
+            print_meth m;
+            printf ")";
+        | V13.NTriv (V13.RInt, m) ->
+            printf "RInt (";
+            print_meth m;
+            printf ")";
+    in
+    let print_date (y, m, d, hr, mn, sc) =
+        printf "%04d-%02d-%02dT%02d:%02d:%02d" y (m+1) d hr mn sc
+    in
+    printf "    status = "; print_stat st; printf "\n";
+    printf "    date = "; print_date d; printf "\n";
+    printf "    tlapm version = %S\n" pv;
+    printf "    zenon version = %S\n" zv;
+    printf "    isabelle version = %S\n" iv;
+;;
+
+let print_fp_line_13r fp str =
+  let print_sti_opt lbl o =
+    match o with
+    | None -> ()
+    | Some sti ->
+      printf "    %s:\n" lbl;
+      print_sti_13 sti;
+  in
+  printf "  %s :\n" fp;
+  print_sti_opt "Trivial" str.V13.tres;
+  print_sti_opt "Zenon" str.V13.zres;
+  print_sti_opt "Isabelle" str.V13.ires;
+  print_sti_opt "SMT" str.V13.smtres;
+  print_sti_opt "Cooper" str.V13.cooperres;
+  print_sti_opt "Yices" str.V13.yres;
+  print_sti_opt "Z3" str.V13.z3res;
+  print_sti_opt "CVC3" str.V13.cvc3res;
+  print_sti_opt "Smt2lib" str.V13.smt2libres;
+  print_sti_opt "Smt2z3" str.V13.smt2z3res;
+  print_sti_opt "Smt3" str.V13.smt3res;
+  print_sti_opt "Z33" str.V13.z33res;
+  print_sti_opt "Cvc33" str.V13.cvc33res;
+  print_sti_opt "Yices3" str.V13.yices3res;
+  print_sti_opt "Verit" str.V13.veritres;
+  print_sti_opt "Spass" str.V13.spassres;
+  print_sti_opt "Tptp" str.V13.tptpres;
+  print_sti_opt "LS4" str.V13.ls4res;
+  print_sti_opt "ExpandENABLED" str.V13.expandenabledres;
+  print_sti_opt "ExpandCdot" str.V13.expandcdotres;
+  print_sti_opt "Lambdify" str.V13.lambdifyres;
+  print_sti_opt "ENABLED axioms" str.V13.enabledaxiomsres;
+  print_sti_opt "LevelComparison" str.V13.levelcomparisonres;
+;;
+
+let print_fp_line_13l fp stil =
+  printf "  %s :\n" fp;
+  List.iter print_sti_13 stil;
+;;
+
 let iter_file f ic =
   try while true do
     let (fp, stil) = Marshal.from_channel ic in
@@ -3220,6 +3637,12 @@ let print file =
        Hashtbl.iter print_fp_line_12r tbl;
        printf "=========== Incremental lines\n";
        iter_file print_fp_line_12l ic;
+    | FP13 tbl ->
+       printf "Fingerprints version = 13\n";
+       printf "=========== Hashtable\n";
+       Hashtbl.iter print_fp_line_13r tbl;
+       printf "=========== Incremental lines\n";
+       iter_file print_fp_line_13l ic;
     | _ -> assert false
     end;
     stop ();
@@ -3294,6 +3717,13 @@ and vx_to_meth m =
   | Spass tmo -> Some (M.Spass (vx_to_floatomega tmo))
   | Tptp tmo -> Some (M.Tptp (vx_to_floatomega tmo))
   | LS4 tmo -> Some (M.LS4 (vx_to_floatomega tmo))
+  | ExpandENABLED -> Some M.ExpandENABLED
+  | ExpandCdot -> Some M.ExpandCdot
+  | AutoUSE -> Some M.AutoUSE
+  | Lambdify -> Some M.Lambdify
+  | ENABLEDaxioms -> Some M.ENABLEDaxioms
+  | LevelComparison -> Some M.LevelComparison
+  | Trivial -> Some M.Trivial
 
 and vx_to_floatomega f =
   match f with

--- a/src/backend/fpfile.ml
+++ b/src/backend/fpfile.ml
@@ -2221,9 +2221,9 @@ let add_v12l fp stil =
   in
   let rec tr_method m =
     match m with
-    | V12.Isabelle {V12.isabelle_timeout = tmo; V12.isabelle_tactic = tac} ->
+    | V12.(Isabelle {isabelle_timeout = tmo; isabelle_tactic = tac}) ->
       Isabelle {isabelle_timeout = tr_floatomega tmo; isabelle_tactic = tac}
-    | V12.Zenon {V12.zenon_timeout = t; V12.zenon_fallback = mm} ->
+    | V12.(Zenon {zenon_timeout = t; zenon_fallback = mm}) ->
       Zenon {zenon_timeout = t; zenon_fallback = tr_method mm}
     | V12.Smt -> SmtT (F infinity)
     | V12.SmtT tmo -> SmtT (tr_floatomega tmo)

--- a/src/backend/isabelle.ml
+++ b/src/backend/isabelle.ml
@@ -171,8 +171,8 @@ let rec pp_apply sd cx ff op args = match op.core with
         | B.Int, [] -> atomic "Int"
         | B.Real, [] -> atomic (cook "Real")
         | B.Plus, [e ; f] -> nonfix "arith_add" [e ; f]
-        | B.Minus, [e ; f] -> nonfix "arith_add"
-            [e ; Apply (Internal B.Uminus @@ f, [f]) @@ f]
+        | B.Minus, [e ; f] ->
+            nonfix "arith_add" [e ; Apply (Internal B.Uminus @@ f, [f]) @@ f]
         | B.Uminus, [e] -> nonfix "minus" [e]
         | B.Times, [e ; f] -> nonfix "mult" [e ; f]
         | B.Ratio, [e ; f] -> nonfix (cook "/") [e ; f]

--- a/src/backend/isabelle.ml
+++ b/src/backend/isabelle.ml
@@ -67,6 +67,8 @@ let print_shape ff shp =
 ;;
 
 exception Unsupported of string;;
+let failwith_unsupp op = failwith ("Unsupported operator `" ^ op ^ "`.\n")
+
 
 let rec pp_apply sd cx ff op args = match op.core with
   | Ix n ->
@@ -102,6 +104,7 @@ let rec pp_apply sd cx ff op args = match op.core with
           (pp_print_delimited (pp_print_expr sd cx)) args
       in
       match b, args with
+        (* Logic operators *)
         | B.TRUE, [] -> atomic "TRUE"
         | B.FALSE, [] -> atomic "FALSE"
         | B.Implies, [e ; f] -> binary "\\<Rightarrow>" e f
@@ -111,18 +114,21 @@ let rec pp_apply sd cx ff op args = match op.core with
         | B.Neg, [e] -> unary "~" e
         | B.Eq, [e ; f] -> binary "=" e f
         | B.Neq, [e ; f] -> binary "\\<noteq>" e f
-
+        (* Function operators *)
+        | B.DOMAIN, [e] -> unary "DOMAIN" e
+        (* Set operators *)
         | B.STRING, [] -> atomic "STRING"
         | B.BOOLEAN, [] -> atomic "BOOLEAN"
+        (* Set theory operators *)
         | B.SUBSET, [e] -> unary "SUBSET" e
         | B.UNION, [e] -> unary "UNION" e
-        | B.DOMAIN, [e] -> unary "DOMAIN" e
         | B.Subseteq, [e ; f] -> binary "\\<subseteq>" e f
         | B.Mem, [e ; f] -> binary "\\<in>" e f
         | B.Notmem, [e ; f] -> binary "\\<notin>" e f
         | B.Setminus, [e ; f] -> binary "\\\\" e f
         | B.Cap, [e ; f] -> binary "\\<inter>" e f
         | B.Cup, [e ; f] -> binary "\\<union>" e f
+        (* Modal operators *)
         | (B.Prime | B.StrongPrime), [e] -> assert false
          (* prime handling was moved from the backends and TLAPM to action frontends *)
          (*  begin match e.core  with
@@ -133,8 +139,13 @@ let rec pp_apply sd cx ff op args = match op.core with
                 else atomic (crypthash cx e)
              | _ ->  atomic (crypthash cx e)
            end *)
-        | B.Leadsto, [e; f] -> raise (Unsupported "Leadsto")
-        | B.ENABLED, _ -> raise (Unsupported "ENABLED")
+        | B.Leadsto, [e; f] ->
+            failwith_unsupp "Leadsto"
+            (* raise (Unsupported "Leadsto") *)
+        | B.ENABLED, [e] ->
+            failwith_unsupp "ENABLED"
+            (* raise (Unsupported "ENABLED") *)
+            (* unary (cook "ENABLED") e *)
         | B.UNCHANGED, [e] -> assert false
             (* UNCHANGED is now handled by the action front-end *)
             (* pp_print_expr sd cx ff
@@ -142,16 +153,26 @@ let rec pp_apply sd cx ff op args = match op.core with
                       [ Apply (Internal B.StrongPrime @@ e, [e]) @@ e ; e ]) @@
                       e) *)
         | B.Cdot, [e ; f] ->
-            binary (cook "\\cdot") e f
+            failwith_unsupp "\\cdot"
+            (* TODO: failwith, raise Unsupported, or cook ? *)
+            (* raise (Unsupported "\\cdot" *)
+            (* binary (cook "\\cdot") e f *)
         | B.Actplus, [e ; f] ->
-            binary (cook "-+->") e f
-        | B.Box _, [e] -> raise (Unsupported "Box")
-        | B.Diamond, [e] -> raise (Unsupported "Diamond")
+            failwith_unsupp "-+->"
+            (* binary (cook "-+->") e f *)
+        | B.Box _, [e] ->
+            failwith_unsupp "[]"
+            (* raise (Unsupported "Box") *)
+        | B.Diamond, [e] ->
+            failwith_unsupp "<>"
+            (* raise (Unsupported "Diamond") *)
+        (* Arithmetic operators *)
         | B.Nat, [] -> atomic "Nat"
         | B.Int, [] -> atomic "Int"
         | B.Real, [] -> atomic (cook "Real")
         | B.Plus, [e ; f] -> nonfix "arith_add" [e ; f]
-        | B.Minus, [e ; f] -> nonfix "arith_add" [e ; Apply (Internal B.Uminus @@ f, [f]) @@ f]
+        | B.Minus, [e ; f] -> nonfix "arith_add"
+            [e ; Apply (Internal B.Uminus @@ f, [f]) @@ f]
         | B.Uminus, [e] -> nonfix "minus" [e]
         | B.Times, [e ; f] -> nonfix "mult" [e ; f]
         | B.Ratio, [e ; f] -> nonfix (cook "/") [e ; f]
@@ -164,7 +185,7 @@ let rec pp_apply sd cx ff op args = match op.core with
         | B.Gteq, [e ; f] -> nonfix "geq" [e ; f]
         | B.Gt, [e ; f] -> nonfix "greater" [e ; f]
         | B.Range, [e ; f] -> nonfix (cook "..") [e ; f]
-
+        (* Sequence operators *)
         | B.Seq, [e] -> nonfix "Seq" [e]
         | B.Len, [e] -> nonfix "Len" [e]
         | B.BSeq, [e] -> nonfix "BSeq" [e]
@@ -174,7 +195,7 @@ let rec pp_apply sd cx ff op args = match op.core with
         | B.Tail, [e] -> nonfix "Tail" [e]
         | B.SubSeq, [e ; m ; n] -> nonfix "SubSeq" [e ; m ; n]
         | B.SelectSeq, [e ; f] -> nonfix "SelectSeq" [e ; f]
-
+        (* TLC operators *)
         | B.OneArg, [e ; f] -> binary ":>" e f
         | B.Extend, [e ; f] -> binary "@@" e f
         | B.Print, [e ; v] -> nonfix "Print" [e ; v]
@@ -188,13 +209,13 @@ let rec pp_apply sd cx ff op args = match op.core with
         | B.RandomElement, [s] -> nonfix "RandomElement" [s]
         | B.Any, [] -> atomic "Any"
         | B.ToString, [v] -> nonfix "ToString" [v]
-
+        (* Internal operators *)
         | B.Unprimable, [e] ->
             pp_print_expr sd cx ff e
         | B.Irregular, [e] ->
             atomic (crypthash cx e)
         | _ ->
-            Util.eprintf ~at:op "arity mismatch@\n%a"
+            Util.eprintf ~at:op "isabelle.ml: arity mismatch@\n%a"
                          (Expr.Fmt.pp_print_expr (Deque.empty, cx))
                          (Tuple (op :: args) @@ op) ;
             failwith "Backend.Isabelle.pp_apply"

--- a/src/backend/prep.ml
+++ b/src/backend/prep.ml
@@ -325,9 +325,7 @@ let isabelle_prove ob org_ob tmo tac res_cont =
 
 let print_obligation ob =
     if ((Internal TRUE) <> ob.obl.core.active.core) then begin
-    let msg = (
-        "Proof obligation " ^ (string_of_int (Option.get ob.id)) ^
-        " :\n") in
+    let msg = Printf.sprintf "Proof obligation %d :\n" (Option.get ob.id) in
     let pr_obl fmt = ignore (
         let print = Expr.Fmt.pp_print_sequent in
         let cx = (Deque.empty, Ctx.dot) in
@@ -1388,12 +1386,12 @@ let ship ob fpout thyout record =
     in
     let p = lazy (normalize_expand (Lazy.force const_fp_ob)
             fpout thyout record
-            ~expand_enabled:expand_enabled
-            ~expand_cdot:expand_cdot
-            ~autouse:autouse
-            ~apply_lambdify:apply_lambdify
-            ~enabled_axioms:enabled_axioms
-            ~level_comparison:level_comparison)
+            ~expand_enabled
+            ~expand_cdot
+            ~autouse
+            ~apply_lambdify
+            ~enabled_axioms
+            ~level_comparison)
     in
     let prep_meth m =
       let ob = Lazy.force const_fp_ob in

--- a/src/backend/prep.ml
+++ b/src/backend/prep.ml
@@ -324,7 +324,6 @@ let isabelle_prove ob org_ob tmo tac res_cont =
 (****************************************************************************)
 
 let print_obligation ob =
-    if ((Internal TRUE) <> ob.obl.core.active.core) then begin
     let msg = Printf.sprintf "Proof obligation %d :\n" (Option.get ob.id) in
     let pr_obl fmt = ignore (
         let print = Expr.Fmt.pp_print_sequent in
@@ -334,10 +333,9 @@ let print_obligation ob =
     Util.printf
         ~at:ob.obl
         ~prefix:"[INFO]: "
-        "%s@\n  @[<b0>%t@]@." msg pr_obl ;
+        "%s@\n  @[<b0>%t@]@." msg pr_obl
     (* TODO: conditional printing in more verbose mode of `tlapm`. *)
     (* ignore (sequent_stats ob.obl.core) *)
-    end
 
 
 let log_info (msg: string) =

--- a/src/backend/prep.mli
+++ b/src/backend/prep.mli
@@ -21,4 +21,11 @@ val make_task :
 
 val expand_defs : ?what:(Expr.T.wheredef -> bool) -> obligation -> obligation
 
-val normalize : obligation -> obligation
+(*
+val normalize :
+    obligation ->
+    expand_enabled: bool ->
+    expand_cdot: bool ->
+    auto_expand_defs: bool ->
+        obligation
+*)

--- a/src/backend/schedule.ml
+++ b/src/backend/schedule.ml
@@ -48,7 +48,7 @@ type process = {
 let temp_buf = Bytes.create 4096;;
 let read_to_stdout fd =
   try
-    let r = Unix.read fd temp_buf 0 (String.length (Bytes.to_string temp_buf)) in
+    let r = Unix.read fd temp_buf 0 (Bytes.length temp_buf) in
     if r = 0 then raise End_of_file;
     output Stdlib.stdout temp_buf 0 r;
     flush Stdlib.stdout;

--- a/src/backend/schedule.ml
+++ b/src/backend/schedule.ml
@@ -48,10 +48,10 @@ type process = {
 let temp_buf = Bytes.create 4096;;
 let read_to_stdout fd =
   try
-    let r = Unix.read fd temp_buf 0 (String.length temp_buf) in
+    let r = Unix.read fd temp_buf 0 (String.length (Bytes.to_string temp_buf)) in
     if r = 0 then raise End_of_file;
-    output Pervasives.stdout temp_buf 0 r;
-    flush Pervasives.stdout;
+    output Stdlib.stdout temp_buf 0 r;
+    flush Stdlib.stdout;
   with Unix_error _ -> raise End_of_file
 ;;
 
@@ -61,7 +61,7 @@ let launch refid cmd t =
   System.harvest_zombies ();
   if !Params.verbose then begin
     Printf.eprintf "launching process: \"%s\"\n" cmd.line;
-    flush Pervasives.stderr;
+    flush Stdlib.stderr;
   end;
   let (pid, out_read) = System.launch_process cmd.line in
   let start_time = gettimeofday () in

--- a/src/backend/smt.ml
+++ b/src/backend/smt.ml
@@ -233,8 +233,8 @@ and fmt_expr (ecx:Ectx.t) e =
     | Tquant _ | Sub _ | Tsub _ | Fair _ ->
         unsupp "temporal logic"
     | _ ->
-        Errors.set e "Expression no supported yet";
-        Util.eprintf ~at:e "Expression no supported yet" ;
+        Errors.set e "Expression not supported yet";
+        Util.eprintf ~at:e "Expression not supported yet" ;
         failwith "Backend.SMT.fmt_expr"
 
 and pp_print_boundvar cx ff (v, _, _) = pp_print_string ff v
@@ -581,7 +581,8 @@ let encode_smtlib ?solver:(mode="SMTLIB") ff ob =
   fprintf ff ";;   generated from %s\n" (Util.location ~cap:false ob.obl);
   fprintf ff "\n";
 
-  fprintf ff "(set-logic UFNIA)\n"; (* This was formerly AUFNIRA. Arrays and real arithmetic are unimportant, but some obligations might be non-linear.  *)
+  fprintf ff "%s" ("(set-logic " ^ !Params.smt_logic ^ ")\n");
+    (* This was formerly AUFNIRA. *)
   List.iter (fprintf ff "(declare-sort %s 0)\n") sorts;
 
   fprintf ff ";; Standard TLA+ operators\n";

--- a/src/backend/toolbox.ml
+++ b/src/backend/toolbox.ml
@@ -132,6 +132,7 @@ if not really then ob else
 
 
 let print_old_res ob st really_print =
+  if !Params.toolbox then
   let really_print = !Params.printallobs || really_print in
    print_res_aux (normalize really_print ob) st (Some true) really_print ""
                  None

--- a/src/builtin.ml
+++ b/src/builtin.ml
@@ -18,7 +18,8 @@ type builtin =
   | Cup
     (* modal *)
   | Prime | StrongPrime | Leadsto | ENABLED | UNCHANGED | Cdot
-  | Actplus | Box of bool (* the bool indicates an applitcation of the Box to a
+  | Actplus  (* -+-> *)
+  | Box of bool (* the bool indicates an application of the Box to a
   non-temporal formula and is added in a post processing step *) | Diamond
     (* arithmetic *)
   | Nat | Int | Real | Plus | Minus | Uminus

--- a/src/builtin.mli
+++ b/src/builtin.mli
@@ -20,19 +20,19 @@ type builtin =
   | UNION
   | DOMAIN
   | Subseteq
-  | Mem
-  | Notmem
+  | Mem  (* \in *)
+  | Notmem  (* \notin *)
   | Setminus
   | Cap
   | Cup
     (* modal *)
   | Prime
   | StrongPrime
-  | Leadsto
+  | Leadsto  (* ~> *)
   | ENABLED
   | UNCHANGED
   | Cdot
-  | Actplus
+  | Actplus  (* -+-> *)
   | Box of bool
   | Diamond
     (* arithmetic *)

--- a/src/expr.ml
+++ b/src/expr.ml
@@ -1,5 +1,5 @@
 (*
- * Copyright (C) 2011  INRIA and Microsoft Corporation
+ * Copyright (C) 2011-2019  INRIA and Microsoft Corporation
  *)
 
 (* Packaging module for the modules that work on expressions *)
@@ -19,3 +19,7 @@ module Temporal_props = E_temporal_props;;
 module Elab = E_elab;;
 module Anon = E_anon;;
 module Parser = E_parser;;
+module Levels = E_levels;;
+module Action = E_action;;
+module SubstOp = E_substitutive;;
+module LevelComparison = E_level_comparison;;

--- a/src/expr/e_action.ml
+++ b/src/expr/e_action.ml
@@ -1,0 +1,1697 @@
+(*
+ * expr/e_action.ml --- expand action operators using quantification
+ *)
+
+
+(*
+
+
+References
+==========
+
+[1] Leslie Lamport, Specifying Systems, Addison-Wesley, 2002
+
+[2] Leslie Lamport, TLA+ Version 2: A Preliminary Guide, 2018
+
+[3] Leslie Lamport, TLA+2: A Preliminary Guide, 2014
+
+[4] Leslie Lamport, Proving safety properties, 2019
+
+[5] Leslie Lamport, LevelSpec specification, from the repository `tlaplus` at:
+    htpps://github.com/tlaplus/tlatools/src/tla2sany/semantic/LevelNode.java
+
+*)
+
+
+Revision.f "$Rev$"
+
+
+open Ext
+open Property
+
+module Subst = E_subst
+module T = E_t
+open E_t
+module Visit = E_visit
+
+
+type set = (string, unit) Hashtbl.t
+let temp_bound = "_"
+type bounds = (set * int) option
+let param_name = "r#"
+let enabled_op_name = "EnabledWrapper"
+    (* occurrences need to be renamed below if renamed here *)
+let cdot_op_name = "CdotWrapper"
+    (* occurrences need to be renamed below if renamed here *)
+let enabled_cdot_to_op_name op =
+    match op with
+    | Internal ENABLED -> enabled_op_name
+    | Internal Cdot -> cdot_op_name
+    | _ -> assert false
+
+
+(* Stores whether a (`\E` quantifier) node resulted from an `ENABLED` node. *)
+let is_enabled : bool pfuncs =
+    Property.make "Expr.Action.is_enabled"
+(* Stores whether a (`\E` quantifier) node resulted from a `\cdot` node. *)
+let is_cdot : bool pfuncs =
+    Property.make "Expr.Action.is_cdot"
+(* Stores the name of the variable that was replaced. *)
+let variable_name : string pfuncs =
+    Property.make "Expr.Action.variable_name"
+(* `is_enabled` functions *)
+let has_is_enabled x = Property.has x is_enabled
+let get_is_enabled x = Property.get x is_enabled
+let rm_is_enabled x = Property.remove x is_enabled
+(* `is_cdot` functions *)
+let has_is_cdot x = Property.has x is_cdot
+let get_is_cdot x = Property.get x is_cdot
+let rm_is_cdot x = Property.remove x is_cdot
+(* `variable_name` functions *)
+let has_variable_name x = Property.has x variable_name
+let get_variable_name x = Property.get x variable_name
+let rm_variable_name x = Property.remove x variable_name
+
+
+let assert_level_bounds (level: int) =
+    assert ((level = 1) || (level = 2))
+let init_level level init_value =
+    (* initialize level to `init_value`,
+    or minimum of `init_value` and `level`,
+    if already initialized.
+    *)
+    match level with
+    | None -> Some init_value
+    | Some level ->
+        assert_level_bounds level;
+        Some (min init_value level)
+let dec_level = function
+    (* decrement level value by 1, with minimum 1 *)
+    | None -> None
+    | Some level ->
+        assert_level_bounds level;
+        Some (max 1 (level - 1))
+
+
+exception SoundnessCheck
+
+
+let expand_definition hyp expr
+        ~(active_expansion: bool)
+        ~(opname: string)
+        ~(pfdirective: string) =
+    let df = match hyp.core with
+        | Defn (df, _, _, _) -> df
+        | _ -> assert false
+        in
+    let (name, def_expr) = match df.core with
+        | Operator (name, def_expr)
+        | Bpragma (name, def_expr, _) -> name.core, def_expr
+        | _ -> assert false
+        in
+    let hyp_locus = E_t.format_locus hyp in
+    let expr_locus = E_t.format_locus expr in
+    let msg = (
+        "Hidden definition of operator `" ^ name ^ "` needs expansion " ^
+        "for soundly expanding " ^ opname ^ " " ^
+        "(using rigid quantification).\n" ^
+        "The expansion of " ^ opname ^ " has been activated with the " ^
+        pfdirective ^ " from the module `TLAPS`.\n" ^
+        "The operator `" ^ name ^ "` is defined at: \n\t" ^ hyp_locus ^
+        "\nand the operator `" ^ name ^ "` occurs at: \n\t" ^ expr_locus ^
+        "\nUsing the proof directive `AutoUSE` from " ^
+        "the module `TLAPS`, or `BY DEF " ^ name ^
+        "` is expected to avoid this error.\n"
+        ) in
+    if (not active_expansion) then
+        begin
+        (Util.eprintf ~at:expr "%s" msg);
+        failwith msg  (* SoundnessCheck *)
+        end;
+    Util.printf ~at:expr ~prefix:"[INFO]: "
+        "Auto-expanding the definition of operator:  %s\n" name;
+    match expr.core with
+        | Apply ({core=Ix n}, args) ->
+            let op_expr = Subst.app_expr (Subst.shift n) def_expr in
+            let new_core = Subst.normalize op_expr args in
+            new_core @@ expr
+        | Ix n ->
+            let e_ = Subst.app_expr (Subst.shift n) def_expr in
+            e_.core @@ expr
+        | _ -> assert false
+
+
+class auto_expansion_of_defs =
+    object (self: 'self)
+    inherit [int option] Visit.map_visible_hyp as super
+
+    val mutable active_expansion: bool = false
+    val mutable _expand_enabled: bool = false
+    val mutable _expand_cdot: bool = false
+
+    method expand
+            (cx: E_t.ctx)
+            (e: E_t.expr)
+            ~(expand_enabled: bool)
+            ~(expand_cdot: bool)
+            ~(autouse: bool) =
+            (* calling with `autouse=false` is useful for
+            invoking the soundness checks *)
+        active_expansion <- autouse;
+        _expand_enabled <- expand_enabled;
+        _expand_cdot <- expand_cdot;
+        let level = None in
+        let scx = (level, cx) in
+        self#expr scx e
+
+    method expr (((level: int option), cx) as scx) e =
+        let (opname, pfdirective) = match (_expand_enabled, _expand_cdot) with
+            | (false, false) -> assert false
+            | (true, false) -> (
+                    "the operator `ENABLED`",
+                    "`ExpandENABLED` proof directive")
+            | (false, true) -> (
+                    "the operator `\\cdot`",
+                    "`ExpandCdot` proof directive")
+            | (true, true) -> (
+                    "the operators `ENABLED` and `\\cdot`",
+                    "the proof directives `ExpandENABLED` and `ExpandCdot`") in
+        let expand_def hyp expr = expand_definition
+            hyp expr
+            ~active_expansion:active_expansion
+            ~opname:opname
+            ~pfdirective:pfdirective
+            in
+        match e.core with
+        (* Assume that if an occurrence of `ENABLED` or `\cdot` has already
+        been lambdified, then all occurrences of `ENABLED` and `\cdot` in its
+        scope have been lambdified.
+
+        This case arises when sequents from instantiated theorems are
+        given to `lambdify` for a second time.
+
+        Recursing here leads to encountering the newly introduced `LAMBDA`
+        parameters, which are declared with kind `Unknown`.
+
+        An alternative approach (and more representative of the information
+        available in the syntax graph) is to declare in the first pattern
+        case the `Lambda` parameters as `Fresh` with `Constant` as `kind`.
+        Doing so avoids the errors when occurrences of these parameters are
+        encountered within the expression that is the argument of the `LAMBDA`.
+
+        Also, this is the only case of an occurrence of `LAMBDA` where the
+        recursion could proceed inside the `LAMBDA` without first expanding
+        the operator that takes the `LAMBDA` as argument (and applying
+        beta-reduction via `Expr.Subst.app_expr`).
+
+        This case arises due to using `ENABLED` and `\cdot` as second-order
+        operators (with the proof directive `Lambdify`).
+        *)
+        | Apply ({core=Internal (ENABLED | Cdot)},
+                [{core=Lambda _}]) ->
+            e
+        | Apply ({core=Opaque s}, [{core=Lambda _}])
+                when (s = enabled_op_name) || (s = cdot_op_name) ->
+            e
+        | Apply ({core=Internal Cdot} as op, [arg1; arg2]) ->
+            begin match level with
+                | None -> ()
+                    (* outside of scope of active expansion. *)
+                | Some _ ->
+                    if (not _expand_cdot) then begin
+                    Util.eprintf ~at:e "%s" (
+                        "Nested occurrence of the operator `\\cdot` found " ^
+                        "in scope of `ENABLED` when expanding `ENABLED`. " ^
+                        "Using the proof directive `ExpandCdot` from " ^
+                        "the module `TLAPS` is expected to avoid this error." ^
+                        "For example, writing `BY ExpandCdot`.");
+                    failwith "Expr.Action"
+                    end;
+                    assert _expand_cdot
+                (* raise error if expansion of \cdot inactive *)
+                (* this is a difference of a one-pass expansion before
+                any expansions of operators, as compared to interleaving
+                of expansions of nested operators and of definitions
+                *)
+                (* An alternative is to consider
+                expansion of nested occurrences of `\cdot` as active
+                when in the scope of an `ENABLED`. In this case,
+                `init_level` unless `None` above and `not _expand_cdot`.
+                *)
+                (* If `not _expand_cdot`,
+                then this call is from expansion of `ENABLED`,
+                and in case level of `arg1` < 2,
+                then sound to not expand `\cdot`. *)
+            end;
+            (* `arg1` *)
+            (* same effect on level as `ENABLED`
+            *)
+            (* The value `level = 1` results from a prime.
+            `\cdot` has level 2, so cannot be primed,
+            but can occur as `ENABLED ( (ENABLED (A \cdot B))' )`.
+            The outer `ENABLED` initializes `level = 2`, and the
+            prime changes this to `level = 1`.
+            *)
+            (* The same algorithm works if `A \cdot B` could
+            appear primed. *)
+            if _expand_cdot then
+                begin
+                let level_arg1 = init_level level 2 in
+                let scx_ = (level_arg1, cx) in
+                let arg1_ = self#expr scx_ arg1 in
+                (* `arg2` *)
+                let level_arg2 = Some 1 in
+                    (* could be optimized by tracking presence of
+                    unprimed variables *)
+                let scx_ = (level_arg2, cx) in
+                let arg2_ = self#expr scx_ arg2 in
+                (* result *)
+                Apply (op, [arg1_; arg2_]) @@ e
+                end
+            else
+                begin
+                let arg1_ = self#expr scx arg1 in
+                let arg2_ = self#expr scx arg2 in
+                Apply (op, [arg1_; arg2_]) @@ e
+                end
+        | Apply ({core=Internal ENABLED} as op, [arg]) ->
+            begin match level with
+                | None -> ()
+                | Some _ ->  (* see comments for `\cdot` *)
+                    if (not _expand_enabled) then begin
+                    Util.eprintf ~at:e "%s" (
+                        "Nested occurrence of the operator `ENABLED` found " ^
+                        "in scope of `\\cdot` when expanding `\\cdot`. " ^
+                        "Using the proof directive `ExpandENABLED` from " ^
+                        "the module `TLAPS` is expected to avoid this error." ^
+                        "For example, writing `BY ExpandENABLED`.");
+                    failwith "Expr.Action"
+                    end;
+                    assert _expand_enabled
+                    (* If `not _expand_enabled`,
+                    then this call is from expansion of `\cdot`,
+                    and in case not in unprimed scope and `arg` of level 2,
+                    then sound to not expand `ENABLED`.
+                    *)
+            end;
+            if _expand_enabled then
+                begin
+                let level_arg = init_level level 2 in
+                let scx_ = (level_arg, cx) in
+                let arg_ = self#expr scx_ arg in
+                Apply (op, [arg_]) @@ e
+                end
+            else
+                begin
+                let arg_ = self#expr scx arg in
+                Apply (op, [arg_]) @@ e
+                end
+        | Apply ({core=Internal Prime} as op, [arg]) ->
+            let level_arg = dec_level level in
+            let scx_ = (level_arg, cx) in
+            let arg_ = self#expr scx_ arg in
+            Apply (op, [arg_]) @@ e
+        | Apply ({core=Internal UNCHANGED} as op, [arg]) ->
+            let level_arg = dec_level level in
+            let scx_ = (level_arg, cx) in
+            let arg_ = self#expr scx_ arg in
+            Apply (op, [arg_]) @@ e
+        | Sub (modal_op, action, subscript) ->
+            let level_action = level in
+            let scx_ = (level_action, cx) in
+            let action_ = self#expr scx_ action in
+            (* count as prime *)
+            let level_subscript = dec_level level in
+            let scx_ = (level_subscript, cx) in
+            let subscript_ = self#expr scx_ subscript in
+            (* result *)
+            Sub (modal_op, action_, subscript_) @@ e
+        | Apply ({core=Ix n}, _)
+        | Ix n ->
+            assert (n >= 1);
+            begin match level with
+            | None -> e
+            | Some level_bound -> begin
+                E_levels.assert_has_correct_level e;
+                let e_level = E_levels.get_level e in
+                let hyp = E_t.get_val_from_id cx n in
+                begin match hyp.core with
+                | Fresh (op_name, shape, kind, _) ->
+                    (* parameter of unspecified expression level occurs in
+                    a scope where operators may need expansion
+                    (depending on their expression level) ?
+                    *)
+                    if kind = Unknown then
+                        let arity = E_t.shape_to_arity shape in
+                        let msg = (
+                            "Declared operator `" ^ op_name.core ^
+                            "` has unknown level and occurs within the " ^
+                            "scope of `ENABLED` or `\\cdot` where " ^
+                            "soundness requires expanding expressions " ^
+                            "of level >= " ^ (string_of_int level_bound) ^
+                            ".\n" ^
+                            "If a constant operator is substituted for " ^
+                            "this operator, then the expression that " ^
+                            "results from applying " ^
+                            "this declared operator has expression level " ^
+                            (string_of_int e_level) ^
+                            ".\n May need expansion. " ^
+                            "A declared operator cannot be expanded.\n" ^
+                            "The operator `" ^ op_name.core ^
+                            "` is declared at:\n" ^ (format_locus hyp) ^
+                            "\n and has arity: " ^ (string_of_int arity)
+                            )
+                            in
+                        Util.eprintf ~at:e "%s" msg;
+                    assert (kind <> Unknown)
+                | _ -> () end;
+                if (e_level >= level_bound) then
+                    (* expand *)
+                    begin
+                    assert (e_level <= 2);
+                    match hyp.core with
+                        | Fact _ -> assert false
+                        | Flex _  -> assert (e.core = Ix n); e
+                        | Fresh (op_name, shape, kind, _) ->
+                            (* Note: Even if the declared operator
+                            has lower level than the level of expression `e`,
+                            we cannot expand the operator in the expression,
+                            because this is a declared operator.
+                            *)
+                            let arity = E_t.shape_to_arity shape in
+                            let op_level = E_levels.kind_to_level kind in
+                                (* see assertion above that
+                                `kind <> Unknown`
+                                *)
+                            let msg = (
+                                "The expression that results from applying " ^
+                                "the declared operator `" ^
+                                op_name.core ^ "` has expression level " ^
+                                (string_of_int e_level) ^ " within the " ^
+                                "scope of `ENABLED` or `\\cdot` where " ^
+                                "soundness requires expanding expressions " ^
+                                "of level >= " ^ (string_of_int level_bound) ^
+                                ". A declared operator cannot be expanded.\n" ^
+                                "The operator `" ^ op_name.core ^
+                                "` is declared at:\n" ^ (format_locus hyp) ^
+                                "\n and has level: " ^
+                                (string_of_int op_level) ^
+                                "\n and arity: " ^ (string_of_int arity)
+                                )
+                                in
+                            Util.eprintf ~at:e "%s" msg;
+                            (* raise SoundnessCheck *)
+                            failwith msg
+                                (* because:
+                                    assert (e_level < level_bound) *)
+                        | Defn (df, _, visibility, scope) ->
+                            let e_ = expand_def hyp e in
+                            let e_ = noprops e_.core in
+                            let e_ = E_levels.rm_expr_level cx e_ in
+                            let e_ = E_levels.compute_level cx e_ in
+                            self#expr scx e_
+                    end
+                else
+                    begin
+                    e
+                    end
+                end
+            end
+        | _ -> super#expr scx e
+end
+
+
+let expand_definitions cx e
+        ~(expand_enabled: bool)
+        ~(expand_cdot: bool)
+        ~(autouse: bool) =
+    (* Expand definitions with one traversal of the syntax tree,
+    by propagating the least level of expressions that need to be
+    expanded. `ENABLED` sets this to `min(current, 2)`,
+    same for the first argument of `\cdot`,
+    the second argument of `\cdot` sets this to 1, and
+    `prime` reduces the level to 1 by `max(current - 1, 1)`.
+    *)
+    let visitor = new auto_expansion_of_defs in
+    visitor#expand cx e
+        ~expand_enabled:expand_enabled
+        ~expand_cdot:expand_cdot
+        ~autouse:autouse
+
+
+let expand_propositional_action_operators e =
+    (* Expand the operators `UNCHANGED`, `[A]_v`, `<<A>>_v`
+    by calling the function `Expr.Tla_norm.rewrite_unch` that
+    rewrites `UNCHANGED` using prime and propositional logic.
+    *)
+    match e.core with
+    | Apply ({core=Internal Builtin.UNCHANGED}, [a]) ->
+        E_tla_norm.rewrite_unch a
+    | Sub (Box, a, b) ->
+        begin
+            let op = Internal Builtin.Disj @@ e in
+            let unchanged = E_tla_norm.rewrite_unch b in
+            let args = [a; unchanged] in
+            Apply (op, args) @@ e
+        end
+    | Sub (Dia, a, b) ->
+        begin
+            let op = Internal Builtin.Conj @@ e in
+            let unchanged = E_tla_norm.rewrite_unch b in
+            let changed =
+                let op = Internal Builtin.Neg @@ e in
+                Apply (op, [unchanged]) @@ e in
+            let args = [a; changed] in
+            Apply (op, args) @@ e
+        end
+    | _ ->
+        Util.eprintf ~at:e "unexpected action operator to expand\n";
+        assert false
+
+
+let var_to_fresh
+        (nesting: int)
+        (name: string):
+            string =
+    (* Return a fresh identifier for a constant bound by `\E`. *)
+    assert (nesting >= 0);
+    (* "enabled" is used here both for constants bound by quantifiers
+    that are introduced for representing `ENABLED`, and
+    for constants bound by quantifiers that are introduced for
+    representing `\cdot`.
+    *)
+    name ^ "#enabled#prime" ^ (string_of_int nesting)
+
+
+let flex_to_fresh_opaque
+        (nesting: int)
+        (cx: T.ctx)
+        (e: expr)
+        (h: set):
+            expr =
+    (* Return fresh constant as `Opaque`, if `e` references a variable.
+    Store the name of the fresh constant in `h`.
+    *)
+    assert (nesting >= 1);
+    let n = match e.core with
+        | Ix n -> assert (n >= 1); n
+        | _ -> assert false
+        in
+    let hyp = T.get_val_from_id cx n in
+    match hyp.core with
+        | Flex name ->
+            let fresh = var_to_fresh nesting name.core in
+            if not (Hashtbl.mem h fresh) then
+                Hashtbl.add h fresh ();
+            let expr = Opaque fresh @@ e in  (* could use `noprops` *)
+            assign expr variable_name name.core
+        | Fact _ -> assert false
+        | _ -> e
+
+
+let apply_conj (args: expr list): expr = match args with
+    (* Conjoin `args`. Return head if `args` is a singleton. *)
+    | [] -> assert false
+    | [arg] -> arg
+    | _ ->
+        (*
+        let op = noprops (Internal Conj) in
+        let conj = Apply (op, args) in
+        *)
+        let conj = List (And, args) in
+        noprops conj
+
+
+let mk_bounds
+        (fresh_names: string list):
+            E_t.bounds =
+    let mk_bound_hint (name: string): Util.hint =
+        noprops name in
+    let mk_bound (name: string): E_t.bound =
+        let a = mk_bound_hint name in
+        let b = Constant in
+        let c = No_domain in
+        (a, b, c)
+    in
+    List.map mk_bound fresh_names
+
+
+let annotate_bounds bounds signature =
+    let params = List.map (fun (p, _) -> p) signature in
+    let annotate_bound (bound: E_t.bound) (h: Util.hint) =
+        let (name, b, c) = bound in
+        assert (has_variable_name h);
+        let flex_name = get_variable_name h in
+        let name = assign name variable_name flex_name in
+        let bound = (name, b, c) in
+        bound in
+    List.map2 annotate_bound bounds params
+
+
+(* This implementation of `make_quantifier` differs in that that shifting of
+indices is applied after all new quantifiers have been introduced,
+by calling the function `shift_indices` below, instead of calling the
+function `app_expr` when each quantifier is introduced, which would
+result in quadratic (instead of linear) time complexity.
+*)
+let make_quantifier
+        (fresh_names: string list)
+        (expr: expr):
+            expr =
+    (* Return quantified expression `\E fresh_names:  expr`. *)
+    if (List.length fresh_names) = 0 then
+        expr  (* no bound constants *)
+    else begin
+        let temp_names = temp_bound :: fresh_names in
+        let bounds = mk_bounds temp_names in
+        (*
+        (* This call to `app_expr` is present in `Expr.Action` and
+        `Expr.Action_iter`.
+        The effect of this call to `app_expr` is obtained by calling the
+        function `shift_indices` below and the method `E_anon.anon#expr`
+        from the method `expansion_of_action_operators#expand` below.
+        *)
+        let n_bounds = List.length bounds in
+        let new_expr = app_expr (shift n_bounds) expr in
+        let core = Quant (Exists, bounds, new_expr) in
+        *)
+        let core = Quant (Exists, bounds, expr) in
+        noprops core
+        (* TODO: consider representing as a location that
+            this node replaces an expression `Apply (op, expr)`. *)
+    end
+
+
+class check_arity =
+    object (self: 'self)
+    inherit [unit] Visit.iter_visible_hyp as super
+
+    method expr (((), cx) as scx) e =
+        match e.core with
+        | Apply ({core=Internal Cdot}, [arg]) ->
+            (match arg.core with
+                | Lambda _ -> ()
+                | _ ->
+                    E_t.print_cx cx;
+                    print_string (E_fmt.string_of_expr cx arg);
+                    assert false)
+        | _ -> super#expr scx e
+end
+
+
+class commute_exists_disjunction =
+    object (self: 'self)
+    inherit [unit] Visit.map_visible_hyp as super
+
+    method expr (((), cx) as scx) e =
+        match e.core with
+        | Quant (Exists, bounds, expr) ->
+            begin match expr.core with
+            | List (Or, exprs) ->
+                let exprs_ = List.map
+                    (fun x -> Quant (Exists, bounds, x) @@ e) exprs in
+                let e_ = List (Or, exprs_) @@ expr in
+                self#expr scx e_
+            | Apply ({core=Internal Disj} as op, exprs) ->
+                assert ((List.length exprs) = 2);
+                let exprs_ = List.map
+                    (fun x -> Quant (Exists, bounds, x) @@ e) exprs in
+                let e_ = Apply (op, exprs_) @@ expr in
+                self#expr scx e_
+            | _ -> super#expr scx e end
+        | _ -> super#expr scx e
+end
+
+
+let commute_exists_disjunction cx expr =
+    let visitor = new commute_exists_disjunction in
+    visitor#expr ((), cx) expr
+
+
+class inverse_mapping =
+    object (self: 'self)
+    inherit [unit] Visit.map_visible_hyp as super
+
+    method expr (((), cx) as scx) e =
+        match e.core with
+        | Quant (Exists, bounds, expr) when has_is_enabled e ->
+            (* map `bounds_` *)
+            let rename_bound bound =
+                let (name, b, c) = bound in
+                assert (has_variable_name name);
+                let flex_name = get_variable_name name in
+                let flex_name = List.hd (String.split_on_char '#' flex_name) in
+                let flex_name = flex_name ^ "__Primed" in
+                let name = noprops flex_name in
+                (* Could assign param name.
+                The param name is known by the index in the parameter list,
+                so normalization of signature could be re-applied.
+                *)
+                (name, b, c) in
+            let bounds_ = List.map rename_bound bounds in
+            (* `expr` has indices referring to the bounds,
+            so no renaming needed there
+            *)
+            Quant (Exists, bounds_, expr) @@ e
+        | _ -> super#expr scx e
+end
+
+
+let invert_renaming cx expr =
+    let visitor = new inverse_mapping in
+    let expr_ = visitor#expr ((), cx) expr in
+    commute_exists_disjunction cx expr_
+
+
+let mk_lambda_signature
+        (fresh_names: string list):
+            (Util.hint * shape) list =
+    let mk_parameter name =
+        let h = noprops name in
+        let shp = Shape_expr in
+        (h, shp) in
+    List.map mk_parameter fresh_names
+
+
+let make_lambda
+    (fresh_names: string list)
+    (expr: expr):
+        expr =
+    if (List.length fresh_names) = 0 then begin
+        (* quantify over a constant that does not occur in `expr`,
+        to in all cases return a `Lambda` (with nonempty signature).
+        Returning a `Lambda` signifies that lambdification has occurred.
+
+        `expr` may include operators that could be substituted by variables.
+
+        Currently, this case would raise an error in definition expansion.
+        The case of length 0 means that no variables have been bound in `expr`,
+        so it would be sound to not raise errors for occurrences of operators.
+
+        (Also, for the case of instantiation, if the variables bound in `expr`
+        could not occur in expressions substituted for operators within the
+        instantiating module, then it would be sound to not raise errors for
+        operators in definition expansion.)
+
+        Using a `Lambda` in the case of length 0 signifies that if variables
+        occur in operator substitutions, binding and replacement by quantifiers
+        would be needed.
+
+        Returning in all cases a `Lambda` reduces the number of pattern cases
+        needed for detecting lambdified forms.
+        *)
+        let temp_names = [temp_bound; param_name ^ "0"] in
+        let signature = mk_lambda_signature temp_names in
+        let core = Lambda (signature, expr) in
+        noprops core
+            (* when binding primed variables before instantiation,
+            this trasformation occurs even when `ExpandENABLED` and
+            `ExpandCdot` are not given by the user.
+
+            So the operators `ENABLED` and `\cdot` remain then in place
+            even if there are no primed/unprimed variable occurrences to bind,
+            because lambdification keeps the operators until
+            replacement by quantification, which is active only if
+            `ExpandENABLED` or `ExpandCdot` are given by the user.
+            *)
+        end
+    else begin
+        let temp_names = temp_bound :: fresh_names in
+            (* `temp_bound` used to avoid double index shifts in
+            `shift_indices_after_lambdify` *)
+        let signature = mk_lambda_signature temp_names in
+        let core = Lambda (signature, expr) in
+        noprops core
+    end
+
+
+let lambdify_action_operator
+        (op: expr)
+        (fresh_names: string list)
+        (expr: expr):
+            expr_ =
+    begin match op.core with
+        | Internal (ENABLED | Cdot) -> ()
+        | _ -> assert false
+    end;
+    let lambda_expr = make_lambda fresh_names expr in
+    let core = Apply (op, [lambda_expr]) in
+    core
+
+
+class shift_indices_after_lambdify =
+    object (self: 'self)
+    inherit Subst.map_visible_hyp as super
+
+    method expr
+            (s: Subst.sub)
+            (oe: expr):
+                expr =
+        match oe.core with
+        | Apply ({core=Internal (ENABLED | Cdot)} as op,
+                [{core=Lambda ((nm, _) :: signature, expr)}])
+                    when nm.core = temp_bound ->
+            let n = List.length signature in
+            assert (n >= 1);
+            let s = Subst.compose s (Subst.shift n) in
+            let expr_ = self#expr s expr in
+            let lambda = Lambda (signature, expr_) in
+            let expr_ = noprops lambda in
+            let core = Apply (op, [expr_]) in
+            noprops core
+        | Apply ({core=Internal (ENABLED | Cdot)},
+                [{core=Lambda _}]) ->  (* avoid duplicating index shifts *)
+            oe
+        | Apply ({core=Internal (ENABLED | Cdot)}, _) -> assert false
+        | _ -> super#expr s oe
+end
+
+
+let shift_indices_after_lambdify (e: expr): expr =
+    (* Wraps the class `shift_indices_after_lambdify`. *)
+    let visitor = new shift_indices_after_lambdify in
+    let s = Subst.shift 0 in
+    visitor#expr s e
+
+
+let normalize_lambda_signature signature =
+    let n = List.length signature in
+    assert (n >= 1);
+    let names = List.init n (fun i -> param_name ^ string_of_int i) in
+    let params = List.map (fun (p, _) -> p.core) signature in
+    let mk_parameter name flex_name =
+        let h = noprops name in
+        (* store name for inverse renaming *)
+        let h = assign h variable_name flex_name in
+        let shp = Shape_expr in
+        (h, shp) in
+    List.map2 mk_parameter names params
+
+
+class normalize_lambda_param_names =
+    (* Rename the bound variables using indexing by position in signature.
+
+    This renaming is applied after anonymization to ensure that the names
+    collected in `Lambda` signatures match the opaque names introduced in
+    place of primed occurrences of `VARIABLES`.
+
+    When using only lambdification (without replacement by quantifiers),
+    this parameter name normalization is sound for occurrences of `ENABLED`
+    and `\cdot` that are not nested.
+    *)
+    object (self: 'self)
+    inherit [unit] Visit.map_visible_hyp as super
+
+    method expr
+            (((), (cx: T.ctx)) as scx)
+            (e: expr):
+                expr =
+        match e.core with
+        | Apply ({core=Internal (ENABLED | Cdot)} as op,
+                [{core=Lambda (signature, expr)}]) ->
+            let (fst, _) = List.hd signature in
+            assert (fst.core <> temp_bound);
+            let expr_ = self#expr scx expr in
+            let signature = normalize_lambda_signature signature in
+            let lambda = Lambda (signature, expr_) in
+            let expr_ = noprops lambda in
+            (* without renaming, even without coalescing,
+            the operator `ENABLED` is unsupported by first-order backends.
+            *)
+            let op_name = enabled_cdot_to_op_name op.core in
+                (* This substitution also ensures arity correctness of
+                applications of the operator `Internal Cdot`.
+                Otherwise, errors would be raised at assertions about arity.
+                *)
+            let op = Opaque op_name @@ op in
+            let core = Apply (op, [expr_]) in
+            noprops core
+        | Apply ({core=Internal (ENABLED | Cdot)}, _) -> assert false
+        | _ -> super#expr scx e
+end
+
+
+(* Binding or lambdification step  --->  Replacement by quantifiers step *)
+
+
+class lambdify_action_operators =
+    object (self: 'self)
+    inherit [bounds * bounds] Visit.map_visible_hyp as super
+
+    val mutable _lambdify_enabled: bool = false
+    val mutable _lambdify_cdot: bool = false
+
+    (* This class does not introduce quantifiers, it only binds occurrences
+    of variables in the scope of primes within `ENABLED` and the first
+    argument of `\cdot`, and outside primes within the second argument of
+    `\cdot`. The bound occurrences are represented as fresh identifiers,
+    bound as `LAMBDA` parameters
+    (in a traversal of the syntax graph, these parameters would be declared
+    in the context as `Fresh` with kind `Constant`).
+
+    The `LAMBDA` is introduced fresh, as the argument of `ENABLED`,
+    which is thus used as a second-order operator. In effect, the `ENABLED` is
+    replaced with an (unexpanded) reference to the following first-order
+    operator `ApplyE` that takes a single operator argument `Op` of
+    unspecified arity >= 1, and quantifies existentially its parameters:
+
+    (For the case of arity 0 (no primed variables in `ENABLED`, or
+    no primed variables in the first argument of `\cdot` and no unprimed
+    variables in the second argument of `\cdot`), the `ENABLED` or `\cdot`
+    can be eliminated from the syntax graph.)
+
+    ```tla
+    ApplyE(Op(_, _, ...)) = \E c1, c2, ...:  Op(c1, c2, ...)
+    ```
+
+    The `Lambda` node introduced by this class formalizes the
+    effect obtained by `"_"` in the class `expansion_of_action_operators`.
+    The result is less efficient (by a constant), because of the additional
+    nodes being created. The function `shift_indices` has been rewritten in
+    the same way, detecting the pattern:
+
+    ```ocaml
+    Apply({core=Internal ENABLED}, [arg])
+        when arg.core = Lambda (sig, expr)
+    ```
+
+    instead of a quantifier with `"_"` as first bound constant.
+    The function result is the function `shift_indices_after_lambdify`
+    that replaces the application and `Lambda` nodes with a `Quant` node.
+
+    This arrangement of the two steps as binding of primed variables
+    / lambdification (in effect alpha-conversion of primed variables) and
+    quantification (in effect beta-reduction, when viewed as applying
+    `ENABLED` to the `LAMBDA` argument) formalizes the transformation,
+    and allows for moving the lambdification earlier, to apply it before
+    instantiation (flattening of instance statements in `Module.Elab`.
+
+    Lambdification before substitutions performed by instantiation is
+    described in [1] for defining the meaning of instantiation
+    (in particular of `ENABLED`, `\cdot`, and `-+->`
+    when instantiating a module).
+
+    The step that was shifting of indices, and the introduction of quantifiers
+    need not be performed in one graph traversal. The shifting of indices is
+    necessary to complete the lambdification, and forms a separate traversal
+    only for reasons of efficiency (namely to reduce time complexity from
+    quadratic to linear). So shifting of indices is performed as the last
+    step of lambdification, without replacing `ENABLED` and `LAMBDA` by
+    quantifiers (`Quant(Exists, ...)`).
+
+    Replacement by quantifiers is described as a separate step in [1],
+    and is performed in this way, after instantiation (substitutions)
+    takes place, and after expanding all definitions as needed for soundness.
+
+    Note that lambdification cannot occur without expansion of definitions,
+    so the relevant soundness checks need to be performed before instantiation,
+    and in all cases (so also when `ExpandENABLED` and `ExpandCdot` are not
+    given by the user, which answers the question of whether ensuring soundness
+    requires performing any soundness checks in all cases, even if
+    substitutivity of operators is taken into account correctly for coalescing).
+
+    The auto-expansion of definitions need not occur in all cases,
+    but if not, then the soundness checks will raise an error before
+    instantiation. The user will then need to provide the directive
+    `AutoUSE`, even if the user does not provide `ExpandENABLED` or
+    `ExpandCdot`. Rephrased, the user may need to expand definitions
+    (and one way is to invoke `AutoUSE`) for lambdification, and not for
+    replacement of `ENABLED` and `\cdot` by quantification.
+
+    The quantification step then reduces to a single graph traversal that
+    replaces all occurrences of `Apply({core=Internal ENABLED},
+    [{core=Lambda (sig, expr)}])` with `Quant (Exists, bounds, expr)`.
+
+    The lambdification step transforms an expression with `ENABLED` or
+    `\cdot` to a constant-level expression, even without quantification.
+    This change of expression level simplifies reasoning,
+    because the `ENABLED` and `\cdot` from that point further could be
+    regarded as constant operators.
+    *)
+
+    method expand
+            (cx: T.ctx)
+            (e: expr)
+            ~(lambdify_enabled: bool)
+            ~(lambdify_cdot: bool):
+                expr =
+        _lambdify_enabled <- lambdify_enabled;
+        _lambdify_cdot <- lambdify_cdot;
+        let e_ =
+            let scope = (None, None) in
+            self#expr (scope, cx) e in
+        let e_ = shift_indices_after_lambdify e_ in
+        let e_ = E_anon.anon#expr ([], cx) e_ in
+        let e_ =
+            let visitor = new normalize_lambda_param_names in
+            visitor#expr ((), cx) e_ in
+        e_
+
+    method expr (((a, b), cx) as scx) e =
+        let get_depth = function
+            | None -> 0
+            | Some (_, depth) -> depth in
+        let a_depth = get_depth a in
+        let b_depth = get_depth b in
+        let inscope = ((a, b) <> (None, None)) in
+        assert (a_depth >= 0);
+        assert (b_depth >= 0);
+        assert ((not inscope) || a_depth <> b_depth);
+        let depth = max a_depth b_depth in
+        assert (depth >= 0);
+        let depth_ = depth + 1 in
+        assert (depth_ >= 1);
+        let make_pair h = Some (h, depth_)
+            in
+        let recurse_ a b = function
+            | None -> []
+            | Some arg ->
+                let scope = (a, b) in
+                [self#expr (scope, cx) arg] in
+        let expand arg1 arg2 op =
+            let h: set = Hashtbl.create 16 in
+                (* same set used for both arguments of `\cdot`,
+                so that no need to compute a union of two sets
+                that would result from recursing for the two arguments
+                of `\cdot`.
+                *)
+            let t = make_pair h in
+            let arg1_ = recurse_ a t arg1 in
+            let arg2_ = recurse_ t b arg2 in
+            let fresh_names = E_visit.set_to_list h in
+            let expr = apply_conj (List.append arg1_ arg2_) in
+            (* make_quantifier fresh_names expr *)
+            let core = lambdify_action_operator op fresh_names expr in
+            core @@ e  (* properties of `e` used because `op` below
+                (`ENABLED` or `\cdot`) remains after lambdification.
+                The operator is replaced when replacing by quantification.
+                At that replacement `noprops` is used to annotate the
+                quantifier syntax nodes.
+                *)
+            in
+        match e.core with
+        | Apply ({core=Internal (ENABLED | Cdot)},
+                [{core=Lambda _}]) ->
+            e
+        | Apply ({core=Opaque s}, [{core=Lambda _}])
+                when (s = enabled_op_name) || (s = cdot_op_name) ->
+            e
+        | Apply ({core=Internal ENABLED} as op, [arg1])
+                when _lambdify_enabled ->
+            expand (Some arg1) None op
+        | Apply ({core=Internal Cdot} as op, [arg1; arg2])
+                when _lambdify_cdot ->
+            expand (Some arg1) (Some arg2) op
+        | Apply ({core=Internal ENABLED}, _) when inscope ->
+            (* Expansion of definitions is expected to have raised error
+            for this case. *)
+            assert ((not _lambdify_enabled) && (_lambdify_cdot));
+            Util.eprintf ~at:e "%s" (
+                "Nested occurrence of the operator `ENABLED` found " ^
+                "in scope of `\\cdot` when expanding `\\cdot`. " ^
+                "Using the proof directive `ExpandENABLED` from " ^
+                "the module `TLAPS` is expected to avoid this error." ^
+                "For example, writing `BY ExpandENABLED`.");
+            failwith "Expr.Action"
+        | Apply ({core=Internal Cdot}, _) when inscope ->
+            (* Expansion of definitions is expected to have raised error
+            for this case. *)
+            assert ((not _lambdify_cdot) && (_lambdify_enabled));
+            Util.eprintf ~at:e "%s" (
+                "Nested occurrence of the operator `\\cdot` found " ^
+                "in scope of `ENABLED` when expanding `ENABLED`. " ^
+                "Using the proof directive `ExpandCdot` from " ^
+                "the module `TLAPS` is expected to avoid this error. " ^
+                "For example, writing `BY ExpandCdot`.");
+            failwith "Expr.Action"
+        | Apply ({core=Internal Prime} as op, [arg]) -> begin
+            let arg_ =
+                let scope = (b, None) in
+                self#expr (scope, cx) arg in
+            match b with
+            | None -> Apply (op, [arg_]) @@ e
+            | _ -> arg_  (* omit prime *)
+            end
+        | Ix n -> begin match a with
+            | None -> e
+            | Some (h, depth) -> assert (depth >= 1);
+                flex_to_fresh_opaque depth cx e h
+            end
+        | Apply ({core=Internal UNCHANGED}, _)
+        | Sub _  (* unexpanded outside scope of `ENABLED` and `\cdot` *)
+                when inscope ->
+            let e_ = expand_propositional_action_operators e in
+            self#expr scx e_
+        | Apply ({core=Opaque name}, _) ->
+            Util.eprintf ~at:e
+                "Named operator `%s` unexpected after anonymization."
+                name;
+            assert false
+        | _ -> super#expr scx e
+end
+
+
+class replace_action_operators_with_quantifiers =
+    object (self: 'self)
+    inherit [bool] Visit.map_visible_hyp as super
+
+    val mutable _expand_enabled: bool = false
+    val mutable _expand_cdot: bool = false
+
+    method replace cx expr
+            ~(expand_enabled:bool)
+            ~(expand_cdot:bool) =
+        _expand_enabled <- expand_enabled;
+        _expand_cdot <- expand_cdot;
+        self#expr (false, cx) expr
+
+    method expr ((scope, cx) as scx) e =
+        let to_expand op =
+            (_expand_enabled && (op = Internal ENABLED)) ||
+            (_expand_cdot && (op = Internal Cdot)) in
+        let inscope = scope in  (* for readability *)
+        let replace_with_quantifier op_name signature expr =
+            assert ((List.length signature) >= 1);
+            let fresh_names = List.map (fun (h, _) -> h.core) signature in
+            let bounds = mk_bounds fresh_names in
+            let bounds = annotate_bounds bounds signature in
+            let scope = true in
+            let cx_ =
+                let lambda_hyps = List.map
+                    (fun (name, shp) ->
+                        Fresh (name, shp, Unknown, Unbounded) @@ name)
+                    signature in
+                Deque.append_list cx lambda_hyps in
+            let expr_ = self#expr (scope, cx_) expr in
+            let core = Quant (Exists, bounds, expr_) in
+            let expr_ = noprops core in
+            let expr_ = if op_name = enabled_op_name then
+                    assign expr_ is_enabled true
+                else
+                    assign expr_ is_cdot true
+                in
+            expr_ in
+        match e.core with
+        | Apply ({core=Opaque op_name},
+                [{core=Lambda (signature, expr)}])
+                    when _expand_enabled && (op_name = enabled_op_name) ->
+            replace_with_quantifier op_name signature expr
+        | Apply ({core=Opaque op_name},
+                [{core=Lambda (signature, expr)}])
+                    when _expand_cdot && (op_name = cdot_op_name) ->
+            replace_with_quantifier op_name signature expr
+        | Apply ({core=Ix n},
+                [{core=Lambda (signature, expr)}])
+                    when _expand_enabled || _expand_cdot ->
+            let hyp = E_t.get_val_from_id cx n in
+            begin match hyp.core with
+            | Defn ({core=Operator (op_name, _)}, _, _, _)
+                    when (op_name.core = enabled_op_name) ||
+                         (op_name.core = cdot_op_name) ->
+                    replace_with_quantifier op_name.core signature expr
+            | _ -> super#expr scx e
+            end
+        | Apply ({core=((Internal (ENABLED | Cdot)) as op)},
+                [{core=Lambda (signature, expr)}])
+                    when to_expand op ->
+            let op_name = enabled_cdot_to_op_name op in
+            replace_with_quantifier op_name signature expr
+        | Apply ({core=((Internal (ENABLED | Cdot)) as op)}, [arg])
+                when to_expand op ->
+            (* This pattern case corresponds to no occurrences of
+            primed variables in `ENABLED`, or
+            no occurrences of primed variables in the first argument of `\cdot`
+            and no occurrences of unprimed variables in the second argument of
+            `\cdot`.
+            *)
+            (* eliminate the operator `ENABLED` or `\cdot` *)
+            let scope = true in
+            self#expr (scope, cx) arg
+        (* The warnings in the following two pattern cases are the same
+        in the class `expansion_of_action_operators`.
+        *)
+        | Apply ({core=Internal ENABLED}, _) when inscope ->
+            (* Expansion of definitions is expected to have raised error
+            for this case. *)
+            assert ((not _expand_enabled) && (_expand_cdot));
+            Util.eprintf ~at:e "%s" (
+                "Nested occurrence of the operator `ENABLED` found " ^
+                "in scope of `\\cdot` when expanding `\\cdot`. " ^
+                "Using the proof directive `ExpandENABLED` from " ^
+                "the module `TLAPS` is expected to avoid this error." ^
+                "For example, writing `BY ExpandENABLED`.");
+            failwith "Expr.Action"
+        | Apply ({core=Internal Cdot}, _) when inscope ->
+            (* Expansion of definitions is expected to have raised error
+            for this case. *)
+            assert ((not _expand_cdot) && (_expand_enabled));
+            Util.eprintf ~at:e "%s" (
+                "Nested occurrence of the operator `\\cdot` found " ^
+                "in scope of `ENABLED` when expanding `ENABLED`. " ^
+                "Using the proof directive `ExpandCdot` from " ^
+                "the module `TLAPS` is expected to avoid this error. " ^
+                "For example, writing `BY ExpandCdot`.");
+            failwith "Expr.Action"
+        | _ -> super#expr scx e
+end
+
+
+class shift_indices =
+    object (self: 'self)
+    inherit Subst.map_visible_hyp as super
+    (* Add to de Bruijn indices shift from newly introduced quantifiers. *)
+
+    (* In the call to the normalization step in `Subst.map#expr`,
+    in the pattern case for `Apply`, if `Lambda`s have been already normalized,
+    then `self#expr` is not recursively called.
+    *)
+
+    method expr
+            (s: Subst.sub)
+            (oe: expr):
+                expr =
+        match oe.core with
+        | Quant (Exists, (nm, _, _) :: bs, expr)
+                when nm.core = temp_bound ->
+            assert ((List.length bs) >= 1);
+            let n = List.length bs in
+            let s = Subst.compose s (Subst.shift n) in
+            (*
+            let oe_ = Quant (Exists, bs, expr) @@ oe in
+            super#expr s oe_
+
+            The above two lines were an error, because `super#expr`
+            will modify only indices that are larger than `n`
+            (see the first pattern case for `Bump` in `Expr.Subst.app_ix`),
+            as if the indices were already counting the bounds in `bs`.
+            This is due to the `bumpn n s` in `super#bounds`.
+            *)
+            (* `bs` is unchanged because there are no domain bounds in `bs`. *)
+            (* Note that `self#expr` is called on `expr`,
+            instead of `super#expr`. *)
+            let expr_ = self#expr s expr in
+            let core = Quant (Exists, bs, expr_) in
+            noprops core
+        | _ -> super#expr s oe
+end
+
+
+let shift_indices (e: expr): expr =
+    (* Wraps the class `shift_indices`. *)
+    let visitor = new shift_indices in
+    let s = Subst.shift 0 in
+    visitor#expr s e
+
+
+(* Replace the operators `ENABLED` and `\cdot` with `\E` quantifiers. *)
+class expansion_of_action_operators =
+    object (self: 'self)
+    inherit [bounds * bounds] Visit.map_visible_hyp as super
+
+    val mutable _expand_enabled: bool = false
+    val mutable _expand_cdot: bool = false
+
+    method expand
+            (cx: T.ctx)
+            (e: expr)
+            ~(expand_enabled: bool)
+            ~(expand_cdot: bool):
+                expr =
+        assert (expand_enabled || expand_cdot);
+        _expand_enabled <- expand_enabled;
+        _expand_cdot <- expand_cdot;
+        let e_ =
+            let scope = (None, None) in
+            self#expr (scope, cx) e in
+        let e_ = shift_indices e_ in
+        E_anon.anon#expr ([], cx) e_
+
+    method expr (((a, b), cx) as scx) e =
+        let get_depth = function
+            | None -> 0
+            | Some (_, depth) -> depth in
+        let a_depth = get_depth a in
+        let b_depth = get_depth b in
+        let inscope = ((a, b) <> (None, None)) in
+        assert (a_depth >= 0);
+        assert (b_depth >= 0);
+        assert ((not inscope) || a_depth <> b_depth);
+        let depth = max a_depth b_depth in
+        assert (depth >= 0);
+        let depth_ = depth + 1 in
+        assert (depth_ >= 1);
+        let make_pair h = Some (h, depth_) in
+        (*
+        (* `recurse` is used by the commented pattern cases. *)
+        let recurse a b arg =
+            let scope = (a, b) in
+            self#expr (scope, cx) arg in
+        *)
+        let recurse_ a b = function
+            | None -> []
+            | Some arg ->
+                let scope = (a, b) in
+                [self#expr (scope, cx) arg] in
+        let expand arg1 arg2 =
+            let h: set = Hashtbl.create 16 in
+                (* same set used for both arguments of `\cdot`,
+                so that no need to compute a union of two sets
+                that would result from recursing for the two arguments
+                of `\cdot`.
+                *)
+                (* (depth + 1) is needed in first argument because
+                otherwise `ENABLED (x' /\ ENABLED x')` results in:
+                `\E x#1:  x#1 /\ \E x#1:  x#1`
+                because the incrementing would be performed only at primes.
+
+                The depth is paired with the set of bounds because of
+                the above example and the example
+                `ENABLED (TRUE \cdot x')`
+                which would increment depth in the second argument of `\cdot`,
+                and then need to decrement depth in order to bind the `x'`
+                correctly by `ENABLED`.
+                *)
+            let t = make_pair h in
+            let arg1_ = recurse_ a t arg1 in
+            let arg2_ = recurse_ t b arg2 in
+            let fresh_names = E_visit.set_to_list h in
+            let expr = apply_conj (List.append arg1_ arg2_) in
+            make_quantifier fresh_names expr
+            in
+        match e.core with
+        | Apply ({core=Internal ENABLED}, [arg1]) when _expand_enabled ->
+            expand (Some arg1) None
+        | Apply ({core=Internal Cdot}, [arg1; arg2]) when _expand_cdot ->
+            expand (Some arg1) (Some arg2)
+        (*
+        (* This pattern case is equivalent to the first two cases. *)
+        | Apply ({core=Internal ((ENABLED | Cdot) as op)}, arg1 :: args)
+                when ((op = ENABLED) && _expand_enabled) ||
+                     ((op = Cdot) && _expand_cdot) -> begin
+            let h: set = Hashtbl.create 16 in
+            let t = make_pair h in
+            let arg1_ = recurse a t arg1 in
+            let expr = match op with
+                | ENABLED -> assert (args = []); arg1_
+                | Cdot -> assert ((List.length args) = 1);
+                    let arg2_ = recurse t b (List.hd args) in
+                    apply_conj [arg1_; arg2_]
+                | _ -> assert false in
+            let fresh_names = E_visit.set_to_list h in
+            make_quantifier fresh_names expr
+            end
+        *)
+        (*
+        (* This pattern case is equivalent to the first pattern case. *)
+        | Apply ({core=Internal ENABLED}, [arg1])
+                when _expand_enabled -> begin
+            let h: set = Hashtbl.create 16 in
+            let t = make_pair h in
+            let expr = recurse a t arg1 in
+            let fresh_names = E_visit.set_to_list h in
+            make_quantifier fresh_names expr
+            end
+            (* Expression levels are not needed here,
+            because definition expansion has been completed by this point.
+            Level information could be removed or recomputed before returning
+            from the root of the recursion.
+            *)
+        *)
+        | Apply ({core=Internal ENABLED}, _) when inscope ->
+            (* Expansion of definitions is expected to have raised error
+            for this case. *)
+            assert ((not _expand_enabled) && (_expand_cdot));
+            Util.eprintf ~at:e "%s" (
+                "Nested occurrence of the operator `ENABLED` found " ^
+                "in scope of `\\cdot` when expanding `\\cdot`. " ^
+                "Using the proof directive `ExpandENABLED` from " ^
+                "the module `TLAPS` is expected to avoid this error." ^
+                "For example, writing `BY ExpandENABLED`.");
+            failwith "Expr.Action"
+        (* This pattern case is equivalent to the second pattern case. *)
+        (*
+        | Apply ({core=Internal Cdot}, [arg1; arg2])
+                when _expand_cdot -> begin
+            let h: set = Hashtbl.create 16 in
+            let t = make_pair h in
+            let arg1_ = recurse a t arg1 in
+            let arg2_ = recurse t b arg2 in
+            let expr = apply_conj [arg1_; arg2_] in
+            let fresh_names = E_visit.set_to_list h in
+            make_quantifier fresh_names expr
+            end
+        *)
+        (*
+        (* This pattern case is equivalent to the second pattern case. *)
+        | Apply ({core=Internal Cdot}, [arg1; arg2])
+                when _expand_cdot -> begin
+            let arg2_a: set = Hashtbl.create 16 in
+            let arg1_b: set = Hashtbl.create 16 in
+            (* replace primed vars in `arg1` *)
+            let arg1_ = recurse a (make_pair arg1_b) arg1 in
+            (* replace unprimed vars in `arg2` *)
+            let arg2_ = recurse (make_pair arg2_a) b arg2 in
+            let expr = apply_conj [arg1_; arg2_] in
+            (* merge the sets `arg2_a` and `arg1_b` *)
+            let union h1 h2 =
+                let add x _ =
+                    if not (Hashtbl.mem h1 x) then Hashtbl.add h1 x () in
+                Hashtbl.iter add h2 in
+            union arg2_a arg1_b;
+            let fresh_names = E_visit.set_to_list arg2_a in
+            (* replace `\cdot` with `\E` and conjunction *)
+            make_quantifier fresh_names expr
+            end
+        *)
+        | Apply ({core=Internal Cdot}, _) when inscope ->
+            (* Expansion of definitions is expected to have raised error
+            for this case. *)
+            assert ((not _expand_cdot) && (_expand_enabled));
+            Util.eprintf ~at:e "%s" (
+                "Nested occurrence of the operator `\\cdot` found " ^
+                "in scope of `ENABLED` when expanding `ENABLED`. " ^
+                "Using the proof directive `ExpandCdot` from " ^
+                "the module `TLAPS` is expected to avoid this error. " ^
+                "For example, writing `BY ExpandCdot`.");
+            failwith "Expr.Action"
+        | Apply ({core=Internal Prime} as op, [arg]) -> begin
+            let arg_ =
+                let scope = (b, None) in
+                self#expr (scope, cx) arg in
+            match b with
+            | None -> Apply (op, [arg_]) @@ e
+            | _ -> arg_  (* omit prime *)
+            end
+        | Ix n -> begin match a with
+            | None -> e
+            | Some (h, depth) -> assert (depth >= 1);
+                flex_to_fresh_opaque depth cx e h
+            end
+        | Apply ({core=Internal UNCHANGED}, _)
+        | Sub _  (* unexpanded outside scope of `ENABLED` and `\cdot` *)
+                when inscope ->
+            let e_ = expand_propositional_action_operators e in
+            self#expr scx e_
+        | Apply ({core=Opaque name}, _) ->
+            Util.eprintf ~at:e
+                "Named operator `%s` unexpected after anonymization."
+                name;
+            assert false
+        | _ -> super#expr scx e
+end
+
+
+let implication_to_enabled cx expr =
+    let expr = E_levels.compute_level cx expr in
+    let found = ref false in
+    let found_a_type = ref false in
+    let found_b_type = ref false in
+    let check_context hyps a b rule =
+        let a = Option.get a in
+        let b = Option.get b in
+        let visitor = object (self: 'self)
+            inherit [unit] E_visit.iter_visible_hyp
+
+            method hyp (((), cx2) as scx) h =
+                let shift_n = (Deque.size hyps) - (Deque.size cx2) in
+                let shift = E_subst.shift shift_n in
+                begin match h.core with
+                    | Fact (expr, Visible, _) ->
+                        begin match expr.core with
+                        | Apply ({core=Internal ENABLED}, [{core=
+                                    Apply ({core=Internal Conj}, [p; q])
+                                }]) when
+                                    let p_ = E_subst.app_expr shift p in
+                                    let q_ = E_subst.app_expr shift q in
+                                    (E_eq.expr p_ a) && (E_eq.expr q_ b) &&
+                                    (rule = "pconj")
+                                ->
+                            found := true
+                        | Apply ({core=Internal ENABLED}, [{core=
+                                    Apply ({core=Internal Disj}, [p; q])
+                                }]) when
+                                    let p_ = E_subst.app_expr shift p in
+                                    let q_ = E_subst.app_expr shift q in
+                                    (E_eq.expr p_ a) && (E_eq.expr q_ b) &&
+                                    (rule = "abdisj")
+                                ->
+                            found := true
+                        | Apply ({core=Internal Disj}, [
+                                    {core=Apply ({core=Internal ENABLED}, [p])};
+                                    {core=Apply ({core=Internal ENABLED}, [q])}
+                                ]) when
+                                    let p_ = E_subst.app_expr shift p in
+                                    let q_ = E_subst.app_expr shift q in
+                                    (E_eq.expr p_ a) && (E_eq.expr q_ b) &&
+                                    (rule = "abdisj_inverse")
+                                ->
+                            found := true
+                        | Apply ({core=Internal ENABLED}, [{core=
+                                    Apply ({core=Internal Conj}, [p; q])
+                                }]) when
+                                    let p_ = E_subst.app_expr shift p in
+                                    let q_ = E_subst.app_expr shift q in
+                                    (E_eq.expr p_ a) && (E_eq.expr q_ b) &&
+                                    (rule = "abconj")
+                                ->
+                            found := true
+                        | Apply ({core=Internal Conj}, [
+                                    {core=Apply ({core=Internal ENABLED}, [p])};
+                                    {core=Apply ({core=Internal ENABLED}, [q])}
+                                ]) when
+                                    let p_ = E_subst.app_expr shift p in
+                                    let q_ = E_subst.app_expr shift q in
+                                    (E_eq.expr p_ a) && (E_eq.expr q_ b) &&
+                                    ((rule = "abconj_inverse") ||
+                                     (rule = "pconj_inverse"))
+                                ->
+                            found := true
+                        | Apply ({core=Internal Conj}, [p; {core=
+                                Apply ({core=Internal ENABLED}, [q])}]) when
+                                let p_ = E_subst.app_expr shift p in
+                                let q_ = E_subst.app_expr shift q in
+                                (E_eq.expr p_ a) && (E_eq.expr q_ b) &&
+                                (rule = "pconj_inverse") ->
+                            found := true
+                        | Apply ({core=Internal Equiv}, [p; q]) when
+                                let p_ = E_subst.app_expr shift p in
+                                let q_ = E_subst.app_expr shift q in
+                                (E_eq.expr p_ a) && (E_eq.expr q_ b) &&
+                                (rule = "equiv") ->
+                            found := true;
+                            found_a_type := true;
+                            found_b_type := true
+                        | Apply ({core=Internal Eq}, [p; q]) when
+                                let p_ = E_subst.app_expr shift p in
+                                let q_ = E_subst.app_expr shift q in
+                                (E_eq.expr p_ a) && (E_eq.expr q_ b) &&
+                                (rule = "equiv") ->
+                            found := true
+                        | Apply ({core=Internal Mem},
+                                    [p; {core=Internal BOOLEAN}]) when
+                                let p_ = E_subst.app_expr shift p in
+                                (E_eq.expr p_ a) ->
+                            found_a_type := true
+                        | Apply ({core=Internal Mem},
+                                    [q; {core=Internal BOOLEAN}]) when
+                                let q_ = E_subst.app_expr shift q in
+                                (E_eq.expr q_ b) ->
+                            found_b_type := true
+                        | Apply ({core=Internal Implies}, [p; q]) when
+                                (*
+                                print_string "\n";
+                                print_string (E_fmt.string_of_expr cx2 expr);
+                                print_string (E_fmt.string_of_expr cx2 p);
+                                print_string (E_fmt.string_of_expr cx2 q);
+                                *)
+                                let p_ = E_subst.app_expr shift p in
+                                let q_ = E_subst.app_expr shift q in
+                                (E_eq.expr p_ a) && (E_eq.expr q_ b) &&
+                                (rule = "implies") ->
+                            found := true
+                        | _ -> () end
+                    | _ -> ()
+                end;
+                E_visit.adj scx h
+        end in
+        let (_, cx3) = visitor#hyps ((), cx) hyps in
+        ignore cx3
+        (*
+        print_string (E_fmt.string_of_expr cx3 a);
+        print_string (E_fmt.string_of_expr cx3 b);
+        *)
+        in
+    let check_active cx_goal expr =
+        match expr.core with
+        | Apply ({core=Internal ENABLED}, [{core=
+                    Apply ({core=Internal Disj}, [a; b])
+                }]) ->
+            let a_level = E_levels.get_level a in
+            let b_level = E_levels.get_level b in
+            assert (a_level <= 2);
+            assert (b_level <= 2);
+            (Some a, Some b, "abdisj_inverse")
+        | Apply ({core=Internal Disj}, [
+                    {core=Apply ({core=Internal ENABLED}, [a])};
+                    {core=Apply ({core=Internal ENABLED}, [b])}
+                ]) ->
+            let a_level = E_levels.get_level a in
+            let b_level = E_levels.get_level b in
+            assert (a_level <= 2);
+            assert (b_level <= 2);
+            (Some a, Some b, "abdisj")
+        | Apply ({core=Internal ENABLED}, [{core=
+                    Apply ({core=Internal Conj}, [a; b])
+                }]) ->
+            let a_variables = E_visit.collect_primed_vars cx_goal a in
+            let b_variables = E_visit.collect_primed_vars cx_goal b in
+            let cap = List.filter
+                        (fun x -> List.mem x a_variables) b_variables in
+            let isempty = (List.length cap) = 0 in
+            let a_level = E_levels.get_level a in
+            let b_level = E_levels.get_level b in
+            assert (a_level <= 2);
+            assert (b_level <= 2);
+            if isempty then
+                begin
+                if (a_level = 2) then
+                    (Some a, Some b, "abconj_inverse")
+                else
+                    (Some a, Some b, "pconj_inverse")
+                end
+            else
+                begin
+                (None, None, " ")
+                end
+        | Apply ({core=Internal Conj}, [
+                    {core=Apply ({core=Internal ENABLED}, [a])};
+                    {core=Apply ({core=Internal ENABLED}, [b])}
+                ]) ->
+            let a_variables = E_visit.collect_primed_vars cx_goal a in
+            let b_variables = E_visit.collect_primed_vars cx_goal b in
+            let cap = List.filter
+                        (fun x -> List.mem x a_variables) b_variables in
+            let isempty = (List.length cap) = 0 in
+            if isempty then
+                begin
+                (Some a, Some b, "abconj")
+                end
+            else
+                begin
+                (None, None, " ")
+                end
+        | Apply ({core=Internal Conj}, [p; {core=
+                Apply ({core=Internal ENABLED}, [a])}]) ->
+            let p_level = E_levels.get_level p in
+            let a_level = E_levels.get_level a in
+            if (p_level <= 1) && (a_level <= 2) then
+                (Some p, Some a, "pconj")
+            else
+                (None, None, " ")
+        | Apply ({core=Internal Equiv}, [
+            {core=Apply ({core=Internal ENABLED}, [a])};
+            {core=Apply ({core=Internal ENABLED}, [b])}
+            ]) -> (Some a, Some b, "equiv")
+        | Apply ({core=Internal Implies}, [
+            {core=Apply ({core=Internal ENABLED}, [a])};
+            {core=Apply ({core=Internal ENABLED}, [b])}
+            ]) -> (Some a, Some b, "implies")
+        | Apply ({core=Internal Eq}, [
+            {core=Apply ({core=Internal ENABLED}, [a])};
+            {core=Apply ({core=Internal ENABLED}, [b])}
+            ]) -> (Some a, Some b, "equiv")
+        | _ -> (None, None, " ")
+        in
+    match expr.core with
+    | Sequent sq -> begin
+        let hyps = sq.context in
+        let active = sq.active in
+        let visitor = object (self: 'self)
+            inherit [unit] E_visit.iter_visible_hyp
+        end in
+        let (_, cx_goal) = visitor#hyps ((), cx) hyps in
+        let (a, b, rule) = check_active cx_goal active in
+        if a <> None then begin
+            check_context hyps a b rule
+        end;
+        let proved = !found && !found_a_type && !found_b_type in
+        begin if proved then
+            Util.printf ~at:expr ~prefix:"[INFO]" "%s"
+                ("\nProved " ^ rule ^ "\n")
+        else
+            failwith "ENABLEDaxioms proof directive did not succeed.\n" end;
+        let core = (if proved then Internal TRUE else expr.core) in
+        let active = noprops core in
+        let sq = {sq with active=active} in
+        noprops (Sequent sq)
+        end
+    | _ -> assert false
+
+
+let lambdify cx e
+        ~(lambdify_enabled:bool)
+        ~(lambdify_cdot:bool)
+        ~(autouse:bool) =
+    let e = E_levels.rm_expr_level cx e in
+    let e = E_levels.compute_level cx e in
+    let e = expand_definitions cx e
+        ~expand_enabled:lambdify_enabled
+        ~expand_cdot:lambdify_cdot
+        ~autouse:autouse in
+    let visitor = new lambdify_action_operators in
+    let e = visitor#expand cx e
+        ~lambdify_enabled:lambdify_enabled
+        ~lambdify_cdot:lambdify_cdot in
+    let visitor = new check_arity in
+    visitor#expr ((), cx) e;
+    e
+
+
+let quantify
+        (cx: T.ctx)
+        (e: expr)
+        ~(expand_enabled: bool)
+        ~(expand_cdot: bool):
+            expr =
+    let visitor = new replace_action_operators_with_quantifiers in
+    visitor#replace cx e
+        ~expand_enabled:expand_enabled
+        ~expand_cdot:expand_cdot
+
+
+let expand_action_operators
+        (cx: T.ctx)
+        (e: expr)
+        ~(expand_enabled: bool)
+        ~(expand_cdot: bool)
+        ~(autouse: bool):
+            expr =
+    assert (expand_enabled || expand_cdot);
+    (* compute expression level information *)
+    let e_ = E_levels.rm_expr_level cx e in
+    let e_ = E_levels.compute_level cx e_ in
+    (* auto-expand definitions as needed *)
+    let e_ = expand_definitions cx e_
+        ~expand_enabled:expand_enabled
+        ~expand_cdot:expand_cdot
+        ~autouse:autouse in
+    (* replace `ENABLED` and `\cdot` with `\E` *)
+    (*
+    let visitor = new expansion_of_action_operators in
+    visitor#expand cx e_
+        ~expand_enabled:expand_enabled
+        ~expand_cdot:expand_cdot
+    *)
+    let visitor = new lambdify_action_operators in
+    (* Not lambdifying an operator is expected to raise the same errors that
+    not passing `expand_operator` does for the class
+    `expansion_of_action_operators`.
+    *)
+    let e_ = visitor#expand cx e_
+        ~lambdify_enabled:expand_enabled
+        ~lambdify_cdot:expand_cdot in
+    let visitor = new replace_action_operators_with_quantifiers in
+    let e_ = visitor#replace cx e_
+        ~expand_enabled:expand_enabled
+        ~expand_cdot:expand_cdot in
+    commute_exists_disjunction cx e_

--- a/src/expr/e_action.mli
+++ b/src/expr/e_action.mli
@@ -1,0 +1,42 @@
+(*
+ * expr/e_action.mli --- expand action operators using quantification
+ *
+ *
+ *)
+open E_t
+
+
+val expand_definition:
+    hyp -> expr ->
+    active_expansion:bool ->
+    opname:string ->
+    pfdirective:string ->
+        expr
+val var_to_fresh: int -> string -> string
+val mk_bounds: string list -> bounds
+val invert_renaming: ctx -> expr -> expr
+val expand_definitions:
+    ctx -> expr ->
+    expand_enabled:bool ->
+    expand_cdot:bool ->
+    autouse:bool ->
+        expr
+val expand_propositional_action_operators: expr -> expr
+val implication_to_enabled: ctx -> expr -> expr
+val lambdify:
+    ctx -> expr ->
+    lambdify_enabled:bool ->
+    lambdify_cdot:bool ->
+    autouse:bool ->
+        expr
+val quantify:
+    ctx -> expr ->
+    expand_enabled:bool ->
+    expand_cdot:bool ->
+        expr
+val expand_action_operators:
+    ctx -> expr ->
+    expand_enabled:bool ->
+    expand_cdot:bool ->
+    autouse:bool ->
+        expr

--- a/src/expr/e_constness.ml
+++ b/src/expr/e_constness.ml
@@ -72,7 +72,9 @@ class virtual const_visitor = object (self : 'self)
                     | _ ->
                         false
                   end
-                | _ -> Errors.bug ~at:e "Expr.Constness.propagate#expr: Ix"
+                | _ ->
+                    Util.printf ~at:e "\n%s\n" (E_fmt.string_of_expr cx e);
+                    Errors.bug ~at:e "Expr.Constness.propagate#expr: Ix"
             end
           |  Opaque _ ->
               true

--- a/src/expr/e_constness.mli
+++ b/src/expr/e_constness.mli
@@ -13,18 +13,4 @@ val is_const : 'a Property.wrapped -> bool
 (* checks if const was already computed for this term *)
 val has_const : 'a Property.wrapped -> bool
 
-class virtual const_visitor : object
-  inherit [unit] E_visit.map
-  method expr     : unit scx -> expr -> expr
-  method pform    : unit scx -> pform -> pform
-  method sel      : unit scx -> sel -> sel
-  method sequent  : unit scx -> sequent -> unit scx * sequent
-  method defn     : unit scx -> defn -> defn
-  method defns    : unit scx -> defn list -> unit scx * defn list
-  method bounds   : unit scx -> bound list -> unit scx * bound list
-  method bound    : unit scx -> bound -> unit scx * bound
-  method exspec   : unit scx -> exspec -> exspec
-  method instance : unit scx -> instance -> instance
-  method hyp      : unit scx -> hyp -> unit scx * hyp
-  method hyps     : unit scx -> hyp Deque.dq -> unit scx * hyp Deque.dq
-end
+class virtual const_visitor : [unit] E_visit.map

--- a/src/expr/e_deref.ml
+++ b/src/expr/e_deref.ml
@@ -243,8 +243,12 @@ and deref_num cx (ds, e) n =
         let se = spin 0 sq.context in
         if has_negix se then begin
           Errors.warning := true;
-          Errors.set e  "Subexpression of ASSUME/PROVE uses identifiers declared therein\n\nTlapm does not handle yet such subexpression namings.";
-          Util.eprintf ~at:e "subexpression of ASSUME/PROVE uses identifiers declared therein" ;
+          Errors.set e (
+            "Subexpression of ASSUME/PROVE uses identifiers declared " ^
+            "therein\n\nTlapm does not handle yet such subexpression namings.");
+          Util.eprintf ~at:e "%s" (
+            "subexpression of ASSUME/PROVE uses identifiers declared therein" ^
+            "\nTlapm does not handle yet such subexpression namings.");
           failwith "Expr.Deref.deref_num"
         end else (ds, se)
       end

--- a/src/expr/e_elab.ml
+++ b/src/expr/e_elab.ml
@@ -66,7 +66,9 @@ let non_temporal =
       | Fact (_, Hidden,_) -> scx
       | _ -> super#hyp scx h
     method expr (good, _ as scx) oe = match oe.core with
-      | ( Apply ({core = Internal (B.Box _ | B.Diamond | B.Actplus | B.Cdot)}, _)
+      | ( Apply ({core = Internal (B.Box _ | B.Diamond | B.Actplus |
+            B.Leadsto | B.Cdot
+            )}, _)
         | Tsub _ | Fair _
         ) ->
           good := false

--- a/src/expr/e_eq.ml
+++ b/src/expr/e_eq.ml
@@ -112,7 +112,7 @@ let rec expr e f = match e.core, f.core with
   | String x, String y -> x = y
   | Num (i, j), Num (k, l) ->
       i = k && j = l
-  | At b, At c -> b = c 
+  | At b, At c -> b = c
   | ec, fc ->
       false
 

--- a/src/expr/e_fmt.ml
+++ b/src/expr/e_fmt.ml
@@ -443,6 +443,8 @@ and fmt_apply (hx, vx as cx) op args = match op.core, args with
             else top
         | Opaque s ->
             let top = Optable.lookup s in
+            (* coalescing leads to this case, prepending "?" to the newly
+            introduced identifiers. *)
             { top with Optable.name = "?" ^ top.Optable.name }
         | Internal b ->
             Optable.standard_form b
@@ -504,8 +506,11 @@ and fmt_apply (hx, vx as cx) op args = match op.core, args with
                 )
               )
           | _ ->
-              Util.eprintf ~at:op "arity mismatch";
-              failwith "arity mismatch"
+              Util.eprintf ~at:op "%s" (
+                  "`Expr.Fmt`: arity mismatch for operator `" ^
+                  top.Optable.name ^ "`, with " ^
+                  (string_of_int (List.length args)) ^ " arguments.\n");
+              failwith "`Expr.Fmt`: arity mismatch"
       end
 
 and fmt_bounds cx bs =

--- a/src/expr/e_level_comparison.ml
+++ b/src/expr/e_level_comparison.ml
@@ -12,13 +12,11 @@ open E_t
 
 module StringMap = Util.Coll.Sm
 
-module M = Map.Make (String)
-
 let digest l =
-  List.fold_right (fun (v, t) m -> M.add v t m) l M.empty
+  List.fold_right (fun (v, t) m -> StringMap.add v t m) l StringMap.empty
 
 let digestv l =
-  List.fold_right (fun (v, t) m -> M.add v.core t m) l M.empty
+  List.fold_right (fun (v, t) m -> StringMap.add v.core t m) l StringMap.empty
 
 
 (* The level comparison algorithm works by comparing the sequents and
@@ -365,7 +363,7 @@ class level_comparison = object (self : 'self)
         | Rect fs, Rect gs ->
             let fmap = digest fs in
             let gmap = digest gs in
-              M.equal (self#expr cx1 cx2) fmap gmap
+              StringMap.equal (self#expr cx1 cx2) fmap gmap
         (*
         | Rect fs ->
             Rect (List.map (fun (s, e) -> (s, self#expr scx e)) fs) @@ oe
@@ -373,7 +371,7 @@ class level_comparison = object (self : 'self)
         | Record fs, Record gs ->
             let fmap = digest fs in
             let gmap = digest gs in
-              M.equal (self#expr cx1 cx2) fmap gmap
+              StringMap.equal (self#expr cx1 cx2) fmap gmap
         (*
         | Record fs ->
             Record (List.map (fun (s, e) -> (s, self#expr scx e)) fs) @@ oe
@@ -665,7 +663,7 @@ class level_comparison = object (self : 'self)
     method sub cx1 cx2 ss tt =
       let umap = digestv ss in
       let tmap = digestv tt in
-        M.equal (self#expr cx1 cx2) umap tmap
+        StringMap.equal (self#expr cx1 cx2) umap tmap
 
     method sel cx1 cx2 s t = match s, t with
         | Sel_down, Sel_down -> true

--- a/src/expr/e_level_comparison.ml
+++ b/src/expr/e_level_comparison.ml
@@ -464,7 +464,7 @@ class level_comparison = object (self : 'self)
           && self#exprs cx1 cx2 es fs
       | _ -> false
 
-    method bounds_cx cx bs = (* TODO *)
+    method bounds_cx cx bs =
         let f (v, k, _) = Fresh (v, Shape_expr, k, Unbounded) @@ v in
         let hs = List.map f bs in
         let cx_ = Deque.append_list cx hs in

--- a/src/expr/e_level_comparison.ml
+++ b/src/expr/e_level_comparison.ml
@@ -1,0 +1,761 @@
+(*
+ * expr/level_compare.ml --- expression level comparison
+ *
+ *
+ * Copyright (C) 2008-2010  INRIA and Microsoft Corporation
+ *)
+
+Revision.f "$Rev$";;
+
+open Property
+open E_t
+
+module StringMap = Util.Coll.Sm
+
+module M = Map.Make (String)
+
+let digest l =
+  List.fold_right (fun (v, t) m -> M.add v t m) l M.empty
+
+let digestv l =
+  List.fold_right (fun (v, t) m -> M.add v.core t m) l M.empty
+
+
+(* The level comparison algorithm works by comparing the sequents and
+expressions found in the hypotheses of a proof obligation to the goal of
+the proof obligation. Assuming a proof obligation of the form
+
+ASSUME
+    declarations1,
+    expr1,
+    ASSUME declarations2
+    PROVE expr2,
+    declarations3
+PROVE
+    goal
+
+the algorithm checks that goal results from expr1 or expr2 by a renaming of
+identifiers that does not increase the levels of the identifiers.
+
+If an identifier is renamed, then it is assumed that the identifier before
+renaming is declared in declarations2. This ensures correct instantiation
+of universal quantifiers, outside of the quantifier scope.
+
+If an identifier is not renamed, then the original identifier can occur in
+either declarations1 or declarations2. If the identifier occurs in declarations1
+then the identifier is the same declaration in both expr1 and goal or
+expr2 and goal. There is no substitution for that identifier in this case.
+
+If the original identifier occurs in declarations2, then the identical
+identifier in goal is from declarations3, and the substitution is sound.
+
+*)
+class level_comparison = object (self : 'self)
+
+    val mutable ctx1: ctx = Deque.empty
+    val mutable ctx2: ctx = Deque.empty
+    val mutable op_mapping: string StringMap.t = StringMap.empty
+
+    method compare ctx1_ ctx2_ expr1 expr2 =
+        ctx1 <- ctx1_;
+        ctx2 <- ctx2_;
+        op_mapping <- StringMap.empty;
+        let res = self#expr ctx1_ ctx2_ expr1 expr2 in
+        let all = ref true in
+        let check (key: string) (value: string) =
+            if not (key = value) then begin
+                let found = ref false in
+                Deque.iter begin
+                    fun i hyp ->
+                        match hyp.core with
+                        | Fresh (nm, _, _, _)
+                        | Flex nm
+                        | Defn ({core=Operator (nm, _)}, _, _, _) ->
+                            found := !found || (nm.core = key)
+                        | Fact _ -> ()
+                        | _ -> assert false
+                            (* Defn ( Recursive | Instance | Bpragrama ) *)
+                end ctx1;
+                all := !all && !found
+            end in
+        StringMap.iter check op_mapping;
+        res && !all
+
+    method expr cx1 cx2 e f =
+        (* print_string (E_fmt.string_of_expr cx1 e);
+        print_string "\n";
+        print_string (E_fmt.string_of_expr cx2 f);
+        print_string "\n"; *)
+        match e.core, f.core with
+        | Parens (e, _), _ -> self#expr cx1 cx2 e f
+        | _, Parens (f, _) -> self#expr cx1 cx2 e f
+        | Ix m, Ix n ->
+            let get_hyp cx n = begin
+                let hyp = get_val_from_id cx n in
+                match hyp.core with
+                | Fresh (nm, shp, kind, dom) ->
+                    let name = nm.core in
+                    begin match kind with
+                    | Constant -> (name, "CONSTANT", 0)
+                    | State -> (name, "STATE", 1)
+                    | Action -> (name, "ACTION", 2)
+                    | Temporal -> (name, "TEMPORAL", 3)
+                    | Unknown -> (name, "Unknown", -1)
+                    end
+                | Flex nm ->
+                    (nm.core, "VARIABLE", 1)
+                | Defn ({core=Operator (nm, expr)}, wd, vsb, _) ->
+                    let cx_ = E_t.cx_front cx n in
+                    let expr = E_levels.compute_level cx_ expr in
+                    let level = E_levels.get_level expr in
+                    (nm.core, "DEFINITION", level)
+                | Fact _ -> assert false
+                | _ -> assert false
+                    (* Defn ( Recursive | Instance | Bpragrama ) *)
+                end in
+            let (name1, kind1, level1) = get_hyp cx1 m in
+            let (name2, kind2, level2) = get_hyp cx2 n in
+            begin match kind1 with
+            | "CONSTANT" ->
+                ((kind2 = "CONSTANT")
+                || (kind2 = "DEFINITION" &&
+                    level2 = 0)) &&
+                if StringMap.mem name1 op_mapping then
+                    (StringMap.find name1 op_mapping) = name2
+                else begin
+                    op_mapping <- StringMap.add name1 name2 op_mapping;
+                    true end
+            | "STATE" ->
+                ((kind2 = "CONSTANT")
+                || (kind2 = "STATE")
+                || (kind2 = "DEFINITION" &&
+                    level2 <= 1)) &&
+                if StringMap.mem name1 op_mapping then
+                    (StringMap.find name1 op_mapping) = name2
+                else begin
+                    op_mapping <- StringMap.add name1 name2 op_mapping;
+                    true end
+            | "ACTION" ->
+                ((kind2 = "CONSTANT")
+                || (kind2 = "STATE")
+                || (kind2 = "ACTION")
+                || (kind2 = "DEFINITION" &&
+                    level2 <= 2)) &&
+                if StringMap.mem name1 op_mapping then
+                    (StringMap.find name1 op_mapping) = name2
+                else begin
+                    op_mapping <- StringMap.add name1 name2 op_mapping;
+                    true end
+            | "TEMPORAL" ->
+                ((kind2 = "CONSTANT")
+                || (kind2 = "STATE")
+                || (kind2 = "ACTION")
+                || (kind2 = "TEMPORAL")
+                || (kind2 = "DEFINITION" &&
+                    level2 <= 3)) &&
+                if StringMap.mem name1 op_mapping then
+                    (StringMap.find name1 op_mapping) = name2
+                else begin
+                    op_mapping <- StringMap.add name1 name2 op_mapping;
+                    true end
+            | "Unknown" -> n = m
+            | "VARIABLE" ->
+                name1 = name2
+                && kind2 = "VARIABLE"
+            | "DEFINITION" ->
+                name1 = name2
+                && kind2 = "DEFINITION"
+            | _ -> assert false
+            end
+        | Opaque p, Opaque q ->
+            p = q
+        | Internal b, Internal c ->
+            b = c
+        | Lambda (rs, e), Lambda (vs, f) ->
+            let mk_param (v, shp) = Fresh (
+                v, shp, Unknown, Unbounded) @@ v in
+            let cx1_ext = List.map mk_param rs in
+            let cx2_ext = List.map mk_param vs in
+            let cx1 = Deque.append_list cx1 cx1_ext in
+            let cx2 = Deque.append_list cx2 cx2_ext in
+            List.length rs = List.length vs &&
+                self#expr cx1 cx2 e f
+        (*
+        | Lambda (vs, e) ->
+          let scx = self#adjs scx
+              (List.map
+                  (fun (v, shp) -> Fresh (v, shp, Unknown, Unbounded) @@ v)
+                  vs) in
+          Lambda (vs, self#expr scx e) @@ oe
+        *)
+        | Apply (p, es), Apply (q, fs) ->
+            self#expr cx1 cx2 p q &&
+            self#exprs cx1 cx2 es fs
+        (*
+        | Apply (op, es) ->
+            Apply (self#expr scx op, List.map (self#expr scx) es) @@ oe
+        *)
+        | Sequent s, Sequent t ->
+            self#sequent cx1 cx2 s t
+        (*
+        | Sequent sq ->
+            let (_, sq) = self#sequent scx sq in
+            Sequent sq @@ oe
+        *)
+        | Bang (e, ss), Bang (f, tt) ->
+            self#expr cx1 cx2 e f &&
+            List.for_all2 (self#sel cx1 cx2) ss tt
+        (*
+        | Bang (e, sels) ->
+            Bang (self#expr scx e, List.map (self#sel scx) sels) @@ oe
+        *)
+        | With (e, _), With (f, _) ->
+            self#expr cx1 cx2 e f
+        (*
+        | With (e, m) ->
+            With (self#expr scx e, m) @@ oe
+        *)
+        | Let (xi, a), Let (phi, b) ->
+            let cx1_ = self#defns_cx cx1 xi in
+            let cx2_ = self#defns_cx cx2 phi in
+            self#defns cx1 cx2 xi phi &&
+            self#expr cx1_ cx2_ a b
+        (*
+        | Let (ds, e) ->
+            let (scx, ds) = self#defns scx ds in
+            Let (ds, self#expr scx e) @@ oe
+        *)
+        | If (c1, t1, e1), If (c2, t2, e2) ->
+            self#expr cx1 cx2 c1 c2
+            && self#expr cx1 cx2 t1 t2
+            && self#expr cx1 cx2 e1 e2
+        (*
+        | If (e, f, g) ->
+            If (self#expr scx e, self#expr scx f, self#expr scx g) @@ oe
+        *)
+        | List (q, es), List (r, fs) ->
+            q = r
+            && self#exprs cx1 cx2 es fs
+        (*
+        | List (q, es) ->
+            List (q, List.map (self#expr scx) es) @@ oe
+        *)
+        | Quant (q, bs, e), Quant (r, cs, f) ->
+            let cx1_ = self#bounds_cx cx1 bs in
+            let cx2_ = self#bounds_cx cx2 bs in
+            q = r
+            && self#bounds cx1 cx2 bs cs
+            && self#expr cx1_ cx2_ e f
+        (*
+        | Quant (q, bs, e) ->
+            let (scx, bs) = self#bounds scx bs in
+            Quant (q, bs, self#expr scx e) @@ oe
+        *)
+        | Tquant (q, rs, e), Tquant (r, vs, f) ->
+            let g v = Flex v @@ v in
+            let cx1_ext = List.map g rs in
+            let cx2_ext = List.map g vs in
+            let cx1_ = Deque.append_list cx1 cx1_ext in
+            let cx2_ = Deque.append_list cx2 cx2_ext in
+            q = r
+            && rs = vs
+            && self#expr cx1_ cx2_ e f
+        (*
+        | Tquant (q, vs, e) ->
+            let scx = self#adjs scx (List.map (fun v -> Flex v @@ v) vs) in
+            Tquant (q, vs, self#expr scx e) @@ oe
+        *)
+        | Choose (ve, Some edom, e), Choose (vf, Some fdom, f) ->
+            let g v dom = Fresh (v, Shape_expr, Constant,
+                                 Bounded (dom, Visible)) @@ v in
+            let h1 = g ve edom in
+            let h2 = g vf fdom in
+            let cx1_ = Deque.snoc cx1 h1 in
+            let cx2_ = Deque.snoc cx2 h2 in
+            self#expr cx1 cx2 edom fdom
+            && self#expr cx1_ cx2_ e f
+        | Choose (ve, None, e), Choose (vf, None, f) ->
+            let g v = Fresh (v, Shape_expr, Constant, Unbounded) @@ v in
+            let h1 = g ve in
+            let h2 = g vf in
+            let cx1_ = Deque.snoc cx1 h1 in
+            let cx2_ = Deque.snoc cx2 h2 in
+            self#expr cx1_ cx2_ e f
+        (*
+        | Choose (v, optdom, e) ->
+            let optdom = Option.map (self#expr scx) optdom in
+            let h = match optdom with
+              | None -> Fresh (v, Shape_expr, Constant, Unbounded) @@ v
+              | Some dom -> Fresh (v, Shape_expr, Constant,
+                                    Bounded (dom, Visible)) @@ v
+            in
+            let scx = self#adj scx h in
+            let e = self#expr scx e in
+            Choose (v, optdom, e) @@ oe
+        *)
+        | SetSt (ve, edom, e), SetSt (vf, fdom, f) ->
+            let g v dom = Fresh (v, Shape_expr, Constant,
+                            Bounded (dom, Visible)) @@ v in
+            let h1 = g ve edom in
+            let h2 = g vf fdom in
+            let cx1_ = Deque.snoc cx1 h1 in
+            let cx2_ = Deque.snoc cx2 h2 in
+            self#expr cx1 cx2 edom fdom
+            && self#expr cx1_ cx2_ e f
+        (*
+        | SetSt (v, dom, e) ->
+            let dom = self#expr scx dom in
+            let scx = self#adj scx
+                  (Fresh (v, Shape_expr, Constant,
+                          Bounded (dom, Visible)) @@ v) in
+            let e = self#expr scx e in
+            SetSt (v, dom, e) @@ oe
+        *)
+        | SetOf (e, bs), SetOf (f, cs) ->
+            let cx1_ = self#bounds_cx cx1 bs in
+            let cx2_ = self#bounds_cx cx2 cs in
+            self#expr cx1_ cx2_ e f
+            && self#bounds cx1 cx2 bs cs
+        (*
+        | SetOf (e, bs) ->
+            let (scx, bs) = self#bounds scx bs in
+            SetOf (self#expr scx e, bs) @@ oe
+        *)
+        | SetEnum es, SetEnum fs ->
+            self#exprs cx1 cx2 es fs
+        (*
+        | SetEnum es ->
+            SetEnum (List.map (self#expr scx) es) @@ oe
+        *)
+        | Arrow (a, b), Arrow (c, d) ->
+            self#expr cx1 cx2 a c
+            && self#expr cx1 cx2 b d
+        (*
+        | Arrow (a, b) ->
+            Arrow (self#expr scx a, self#expr scx b) @@ oe
+        *)
+        | Fcn (bs, e), Fcn (cs, f) ->
+            let cx1_ = self#bounds_cx cx1 bs in
+            let cx2_ = self#bounds_cx cx2 cs in
+            self#bounds cx1 cx2 bs cs
+            && self#expr cx1_ cx2_ e f
+        (*
+        | Fcn (bs, e) ->
+            let (scx, bs) = self#bounds scx bs in
+            Fcn (bs, self#expr scx e) @@ oe
+        *)
+        | FcnApp (f, es), FcnApp (g, fs) ->
+            self#exprs cx1 cx2 (f :: es) (g :: fs)
+        (*
+        | FcnApp (f, es) ->
+            FcnApp (self#expr scx f, List.map (self#expr scx) es) @@ oe
+        *)
+        | Tuple es, Tuple fs ->
+            self#exprs cx1 cx2 es fs
+        (*
+        | Tuple es ->
+            Tuple (List.map (self#expr scx) es) @@ oe
+        *)
+        | Product es, Product fs ->
+            self#exprs cx1 cx2 es fs
+        (*
+        | Product es ->
+            Product (List.map (self#expr scx) es) @@ oe
+        *)
+        | Rect fs, Rect gs ->
+            let fmap = digest fs in
+            let gmap = digest gs in
+              M.equal (self#expr cx1 cx2) fmap gmap
+        (*
+        | Rect fs ->
+            Rect (List.map (fun (s, e) -> (s, self#expr scx e)) fs) @@ oe
+        *)
+        | Record fs, Record gs ->
+            let fmap = digest fs in
+            let gmap = digest gs in
+              M.equal (self#expr cx1 cx2) fmap gmap
+        (*
+        | Record fs ->
+            Record (List.map (fun (s, e) -> (s, self#expr scx e)) fs) @@ oe
+        *)
+        | Except (e, xs), Except (f, ys) ->
+            let rec exspecs cx1 cx2 xs ys = match xs, ys with
+              | [], [] -> true
+              | x :: xs, y :: ys ->
+                  exspec cx1 cx2 x y
+                  && exspecs cx1 cx2 xs ys
+              | _ -> false
+            and exspec cx1 cx2 (tr, e) (ur, f) =
+              trail cx1 cx2 tr ur
+              && self#expr cx1 cx2 e f
+            and trail cx1 cx2 tr ur = match tr, ur with
+              | [], [] -> true
+              | Except_dot x :: tr, Except_dot y :: ur ->
+                  x = y
+                  && trail cx1 cx2 tr ur
+              | Except_apply e :: tr, Except_apply f :: ur ->
+                  self#expr cx1 cx2 e f
+                  && trail cx1 cx2 tr ur
+              | _ -> false
+            in
+              self#expr cx1 cx2 e f
+              && exspecs cx1 cx2 xs ys
+        (*
+        | Except (e, xs) ->
+            Except (self#expr scx e, List.map (self#exspec scx) xs) @@ oe
+        *)
+        | Dot (e, x), Dot (f, y) ->
+            self#expr cx1 cx2 e f
+            && x = y
+        (*
+        | Dot (e, f) ->
+            Dot (self#expr scx e, f) @@ oe
+        *)
+        | Sub (m, e, f), Sub (n, g, h) ->
+            m = n
+            && self#expr cx1 cx2 e g
+            && self#expr cx1 cx2 f h
+        (*
+        | Sub (s, e, f) ->
+            Sub (s, self#expr scx e, self#expr scx f) @@ oe
+        *)
+        | Tsub (m, e, f), Tsub (n, g, h) ->
+            m = n
+            && self#expr cx1 cx2 e g
+            && self#expr cx1 cx2 f h
+        (*
+        | Tsub (s, e, f) ->
+            Tsub (s, self#expr scx e, self#expr scx f) @@ oe
+        *)
+        | Fair (m, e, f), Fair (n, g, h) ->
+            m = n
+            && self#expr cx1 cx2 e g
+            && self#expr cx1 cx2 f h
+        (*
+        | Fair (fop, e, f) ->
+            Fair (fop, self#expr scx e, self#expr scx f) @@ oe
+        *)
+        | Case (is, o), Case (js, p) ->
+            let arms cx1 cx2 is js = match is, js with
+              | [], [] -> true
+              | (e, f) :: is, (g, h) :: js ->
+                  self#expr cx1 cx2 e g
+                  && self#expr cx1 cx2 f h
+              | _ -> false
+            in
+              arms cx1 cx2 is js
+              && self#opt_expr cx1 cx2 o p
+        (*
+        | Case (arms, oth) ->
+            Case (List.map (fun (e, f) -> (self#expr scx e, self#expr scx f)) arms,
+                  Option.map (self#expr scx) oth) @@ oe
+        *)
+        | String x, String y -> x = y
+        | Num (i, j), Num (k, l) ->
+            i = k
+            && j = l
+        | At b, At c -> b = c
+        | ec, fc -> false
+
+    method exprs cx1 cx2 es fs = match es, fs with
+      | [], [] -> true
+      | e :: es, f :: fs ->
+          self#expr cx1 cx2 e f
+          && self#exprs cx1 cx2 es fs
+      | _ -> false
+
+    method bounds_cx cx bs = (* TODO *)
+        let f (v, k, _) = Fresh (v, Shape_expr, k, Unbounded) @@ v in
+        let hs = List.map f bs in
+        let cx_ = Deque.append_list cx hs in
+        cx_
+    (*
+    method bounds scx bs =
+      let bs = List.map begin
+        fun (v, k, dom) -> match dom with
+          | Domain d -> (v, k, Domain (self#expr scx d))
+          | _ -> (v, k, dom)
+      end bs in
+      let hs = List.map begin
+        fun (v, k, _) -> Fresh (v, Shape_expr, k, Unbounded) @@ v
+      end bs in
+      let scx = self#adjs scx hs in
+      (scx, bs)
+
+    method bound scx b =
+      match self#bounds scx [b] with
+        | (scx, [b]) -> (scx, b)
+        | _ -> assert false
+    *)
+
+    method bounds cx1 cx2 bs cs = match bs, cs with
+      | [], [] -> true
+      | b :: bs, c :: cs ->
+          self#bound cx1 cx2 b c
+          && self#bounds cx1 cx2 bs cs
+      | _ -> false
+
+    method bound cx1 cx2 (_, j, jd) (_, k, kd) =
+    j = k
+    && self#bdom cx1 cx2 jd kd
+
+    method bdom cx1 cx2 d e = match d, e with
+      | No_domain, No_domain -> true
+      | Domain d, Domain e -> self#expr cx1 cx2 d e
+      | Ditto, Ditto -> true
+      | _ -> false
+
+    method opt_expr cx1 cx2 eo fo = match eo, fo with
+      | None, None -> true
+      | Some e, Some f -> self#expr cx1 cx2 e f
+      | _ -> false
+
+    (*
+    method defns scx = function
+      | [] -> (scx, [])
+      | df :: dfs ->
+          let df = self#defn scx df in
+          let scx = self#adj scx (Defn (df, User, Visible, Local) @@ df) in
+          let (scx, dfs) = self#defns scx dfs in
+          (scx, df :: dfs)
+    *)
+
+    method defns_cx cx ds = (* TODO *)
+        match ds with
+        | [] -> cx
+        | df :: dfs ->
+            (* TODO: Hidden ? if called after visible definitions
+            have been expanded.
+            *)
+            let hyp = Defn (df, User, Visible, Local) @@ df in
+            let cx = Deque.snoc cx hyp in
+            let cx = self#defns_cx cx dfs in
+            cx
+
+    method defns cx1 cx2 ds es = match ds, es with
+      | [], [] -> true
+      | d :: ds, e :: es ->
+          self#defn cx1 cx2 d e
+          && self#defns cx1 cx2 ds es
+      | _ -> false
+
+    method defn cx1 cx2 d e = match d.core, e.core with
+      | Operator (_, e), Operator (_, f) ->
+          self#expr cx1 cx2 e f
+      | Instance (_, i), Instance (_, j) ->
+          self#instance cx1 cx2 i j
+      | Bpragma (_, e, _), Bpragma (_, f, _) ->
+    			self#expr cx1 cx2 e f
+      | _ -> false
+
+    (*
+    method defn scx df =
+      let df = match df.core with
+        | Recursive (nm, shp) -> df
+        | Operator (nm, e) ->
+            { df with core = Operator (nm, self#expr scx e) }
+        | Instance (nm, i) ->
+            { df with core = Instance (nm, self#instance scx i) }
+        | Bpragma(nm,e,l) ->
+            { df with core = Bpragma (nm, self#expr scx e, l) }
+      in
+      df
+    *)
+
+    method sequent cx1 cx2 s t =
+        let cx1_ = self#hyps_cx cx1 s.context in
+        let cx2_ = self#hyps_cx cx2 t.context in
+        self#context cx1 cx2 s.context t.context
+        && self#expr cx1_ cx2_ s.active t.active
+    (*
+    method sequent scx sq =
+      let (scx, hyps) = self#hyps scx sq.context in
+      (scx, { context = hyps ; active = self#expr scx sq.active })
+    *)
+
+    method context cx1 cx2 cx dx =
+        match Deque.front cx, Deque.front dx with
+        | None, None -> true
+        | Some (h, cx), Some (g, dx) ->
+            let cx1_ = self#hyp_cx cx1 h in
+            let cx2_ = self#hyp_cx cx2 g in
+            self#hyp cx1 cx2 h g
+            && self#context cx1_ cx2_ cx dx
+        | _ -> false
+
+    method hyps_cx cx hyps =
+        match Deque.front hyps with
+        | None -> cx
+        | Some (h, hs) ->
+            let cx = Deque.snoc cx h in
+            let cx = self#hyps_cx cx hs in
+            cx
+
+    (*
+    method hyps scx hs = match Dq.front hs with
+      | None -> (scx, Dq.empty)
+      | Some (h, hs) ->
+          let (scx, h) = self#hyp scx h in
+          let (scx, hs) = self#hyps scx hs in
+          (scx, Dq.cons h hs)
+    *)
+
+    method hyp cx1 cx2 h g = match h.core, g.core with
+      | Fresh (_, hsh, l, b), Fresh (_, gsh, m, c) ->
+          l = m
+          && hsh = gsh
+          && begin
+            match b, c with
+              | Unbounded, Unbounded -> true
+              | Bounded (b, _), Bounded (c, _) -> self#expr cx1 cx2 b c
+              | _ -> false
+          end
+      | Flex _, Flex _ -> true
+      | Defn (d, _, _, dx), Defn (e, _, _, ex) ->
+          self#defn cx1 cx2 d e
+          && dx = ex
+      | Fact (e, _, _), Fact (f, _, _) ->
+          self#expr cx1 cx2 e f
+      | _ -> false
+
+    method hyp_cx cx h =
+        Deque.snoc cx h
+
+    (*
+    method hyp scx h = match h.core with
+      | Fresh (nm, shp, lc, dom) ->
+          let dom = match dom with
+            | Unbounded -> Unbounded
+            | Bounded (r, rvis) -> Bounded (self#expr scx r, rvis)
+          in
+          let h = Fresh (nm, shp, lc, dom) @@ h in
+          (self#adj scx h, h)
+      | Flex s ->
+          let h = Flex s @@ h in
+          (self#adj scx h, h)
+      | Defn (df, wd, vis, ex) ->
+          let df = self#defn scx df in
+          let h = Defn (df, wd, vis, ex) @@ h in
+          (self#adj scx h, h)
+      | Fact (e, vis, tm) ->
+          let h = Fact (self#expr scx e, vis, tm) @@ h in
+          (self#adj scx h, h)
+    *)
+
+    method instance cx1 cx2 i j =
+        let f cx v = Deque.snoc cx (
+            Fresh (v, Shape_expr, Unknown, Unbounded) @@ v) in
+        let cx1_ = List.fold_left f cx1 i.inst_args in
+        let cx2_ = List.fold_left f cx2 j.inst_args in
+        i.inst_args = j.inst_args
+        && i.inst_mod = j.inst_mod
+        && self#sub cx1_ cx2_ i.inst_sub j.inst_sub
+
+    (*
+    method instance scx i =
+      let scx = List.fold_left begin
+        fun scx v ->
+          self#adj scx (Fresh (v, Shape_expr, Unknown, Unbounded) @@ v)
+      end scx i.inst_args in
+      { i with inst_sub = List.map
+        (fun (v, e) -> (v, self#expr scx e))
+        i.inst_sub }
+    *)
+
+    method sub cx1 cx2 ss tt =
+      let umap = digestv ss in
+      let tmap = digestv tt in
+        M.equal (self#expr cx1 cx2) umap tmap
+
+    method sel cx1 cx2 s t = match s, t with
+        | Sel_down, Sel_down -> true
+        | Sel_num n, Sel_num m -> n = m
+        | Sel_left, Sel_left
+        | Sel_right, Sel_right
+        | Sel_at, Sel_at -> true
+        | Sel_inst es, Sel_inst fs ->
+            self#exprs cx1 cx2 es fs
+        | Sel_lab (s, es), Sel_lab (t, fs) ->
+            s = t
+            && self#exprs cx1 cx2 es fs
+        | _ -> false
+    (*
+    method sel scx sel = match sel with
+      | Sel_inst args ->
+          Sel_inst (List.map (self#expr scx) args)
+      | Sel_lab (l, args) ->
+          Sel_lab (l, List.map (self#expr scx) args)
+      | _ -> sel
+      *)
+end
+
+
+(*
+method pform scx pf = pf
+
+method exspec scx (trail, res) =
+  let do_trail = function
+    | Except_dot s -> Except_dot s
+    | Except_apply e -> Except_apply (self#expr scx e)
+  in
+  (List.map do_trail trail, self#expr scx res)
+*)
+
+
+let check_level_change cx expr =
+    let expr = E_levels.compute_level cx expr in
+    let found = ref false in
+    let check_context checker hyps =
+        (* f cx_hyps hyp *)
+        let visitor = object (self: 'self)
+            inherit [unit] E_visit.iter_visible_hyp
+
+            method hyp (((), cx2) as scx) h =
+                begin match h.core with
+                    | Fact (expr, Visible, _) ->
+                        begin match expr.core with
+                        | Sequent sq ->
+                            let hyps = sq.context in
+                            let active = sq.active in
+                            let visitor = object (self: 'self)
+                                inherit [unit] E_visit.iter_visible_hyp
+                            end in
+                            let (_, cx_goal) = visitor#hyps ((), cx2) hyps in
+                            found := !found || (checker cx_goal active)
+                        | _ ->
+                            found := !found || (checker cx2 expr)
+                        end
+                    | _ -> ()
+                end;
+                E_visit.adj scx h
+        end in
+        let (_, cx3) = visitor#hyps ((), cx) hyps in
+        ignore cx3
+        (*
+        print_string (E_fmt.string_of_expr cx3 a);
+        print_string (E_fmt.string_of_expr cx3 b);
+        *)
+        in
+    match expr.core with
+    | Sequent sq -> begin
+        let hyps = sq.context in
+        let active = sq.active in
+        let visitor = object (self: 'self)
+            inherit [unit] E_visit.iter_visible_hyp
+        end in
+        let (_, cx_goal) = visitor#hyps ((), cx) hyps in
+        let visitor = new level_comparison in
+        let f cx_hyps hyp = visitor#compare cx_hyps cx_goal hyp active in
+        check_context f hyps;
+        let proved = !found in
+        begin if proved then
+            Util.printf ~at:expr ~prefix:"[INFO]" "%s"
+                ("\nProved level comparison\n")
+        else
+            failwith "LevelComparison proof directive did not succeed.\n" end;
+        let core = (if proved then Internal TRUE else expr.core) in
+        let active = noprops core in
+        let sq = {sq with active=active} in
+        noprops (Sequent sq)
+        end
+    | _ -> assert false

--- a/src/expr/e_level_comparison.mli
+++ b/src/expr/e_level_comparison.mli
@@ -1,0 +1,36 @@
+open Property
+open Util
+open E_t
+
+
+class level_comparison : object
+    method compare : ctx -> ctx -> expr -> expr -> bool
+
+    method expr : ctx -> ctx -> expr -> expr -> bool
+    method exprs : ctx -> ctx -> expr list -> expr list -> bool
+
+    method bounds_cx : ctx -> bounds -> ctx
+    method bounds : ctx -> ctx -> bounds -> bounds -> bool
+    method bound : ctx -> ctx -> bound -> bound -> bool
+    method bdom : ctx -> ctx -> bound_domain -> bound_domain -> bool
+
+    method opt_expr : ctx -> ctx -> expr option -> expr option -> bool
+
+    method defns_cx : ctx -> defn list -> ctx
+    method defns : ctx -> ctx -> defn list -> defn list -> bool
+    method defn : ctx -> ctx -> defn -> defn -> bool
+
+    method sequent : ctx -> ctx -> sequent -> sequent -> bool
+    method context : ctx -> ctx -> ctx -> ctx -> bool
+    method hyps_cx : ctx -> ctx -> ctx
+    method hyp : ctx -> ctx -> hyp -> hyp -> bool
+    method hyp_cx : ctx -> hyp -> ctx
+
+    method instance : ctx -> ctx -> instance -> instance -> bool
+    method sub : ctx -> ctx ->
+        (hint * expr) list -> (hint * expr) list -> bool
+    method sel : ctx -> ctx -> sel -> sel -> bool
+end
+
+
+val check_level_change : ctx -> expr -> expr

--- a/src/expr/e_levels.ml
+++ b/src/expr/e_levels.ml
@@ -733,7 +733,7 @@ class virtual ['s] level_computation = object (self : 'self)
             assign new_e exprlevel level_info
         | FcnApp (f, es) ->  (* f[x] *)
                 (* function `f` *)
-            let fes = List.append [f] es in
+            let fes = f :: es in
             let (level_info, fes_) = level_info_from_args scx fes in
             let f_ = List.hd fes_ in
             let es_ = List.tl fes_ in
@@ -743,6 +743,7 @@ class virtual ['s] level_computation = object (self : 'self)
         | Arrow (a, b) ->
             let args = [a; b] in
             let (level_info, args_) = level_info_from_args scx args in
+            assert (List.length args_ = 2);
             let a_ = List.hd args_ in
             let b_ = List.nth args_ 1 in
             let new_arrow = Arrow (a_, b_) in

--- a/src/expr/e_levels.ml
+++ b/src/expr/e_levels.ml
@@ -1,0 +1,1073 @@
+(*
+ * expr/e_levels.ml --- compute expression levels
+ *)
+
+
+(*
+
+
+References
+==========
+
+[1] Leslie Lamport, Specifying Systems, Addison-Wesley, 2002
+
+[2] Leslie Lamport, TLA+ Version 2: A Preliminary Guide, 2018
+
+[3] Leslie Lamport, LevelSpec specification, from the repository `tlaplus` at:
+    htpps://github.com/tlaplus/tlatools/src/tla2sany/semantic/LevelNode.java
+
+[4] Leslie Lamport, Proving safety properties, 2019
+
+*)
+
+
+(* See Section 17.2 on pages 321--324 of Specifying Systems.
+See `LevelSpec.tla` in `tla2sany.semantic.LevelNode`.
+
+level numbers:
+    0 = constant
+    1 = state
+    2 = action
+    3 = temporal
+
+A relevant computation is in the module `e_constness.ml`.
+*)
+Revision.f "$Rev$"
+
+open Ext
+open Property
+open Util
+
+open E_t
+open E_visit
+
+
+module Dq = Deque
+module Visit = E_visit
+module StringSet = Set.Make(String)
+
+
+type level_info =  (* Stores information for computing the
+        levels of syntax tree nodes *)
+    LevelInfo of
+        int *  (* operator level *)
+            (* `OpDefNode.level`, `OpApplNode.level`, ... *)
+        bool list *  (* weights of operator arguments *)
+            (* `OpDefNode.weights` *)
+        StringSet.t  (* set of argument names that the level depends on *)
+            (* `LevelConstraintFields.levelParams` *)
+
+
+let exprlevel : level_info pfuncs =
+    Property.make "Expr.Levels.exprlevel"
+let assert_is_level (level: int) =
+    assert ((level >= 0) && (level <= 3))
+    (* The value 4 signifies that the notion of level is undefined for
+    the syntax node. *)
+let assert_is_arity (arity: int) =
+    assert (arity >= 0)
+
+let has_level x = Property.has x exprlevel
+let get_level_info x = Property.get x exprlevel
+let get_level x =
+    let level_info = get_level_info x in
+    let level = match level_info with
+        | LevelInfo (level, _, _) -> level
+    in
+    level
+let rm_level x = Property.remove x exprlevel
+let get_level_weights x =
+    let level_info = get_level_info x in
+    let weights = match level_info with
+        | LevelInfo (_, weights, _) -> weights
+    in
+    weights
+let get_level_args x =
+    let level_info = get_level_info x in
+    let level_args = match level_info with
+        | LevelInfo (_, _, level_args) -> level_args
+    in
+    level_args
+
+let make_level_info (level: int) =
+    assert_is_level level;
+    let level_args = StringSet.empty in
+    let weights = [] in
+    LevelInfo (level, weights, level_args)
+let make_undefined_level_info =  (* separate function to
+        include assertion in `make_level_info` *)
+    let level_args = StringSet.empty in
+    let weights = [] in
+    LevelInfo (4, weights, level_args)
+let make_weights (arity: int) =
+    assert_is_arity arity;
+    List.init arity (fun x -> true)
+let make_level_info_arity (level: int) (arity: int) =
+    assert_is_level level;
+    assert_is_arity arity;
+    let level_args = StringSet.empty in
+    let weights = make_weights arity in
+    LevelInfo (level, weights, level_args)
+
+
+let assert_has_correct_level expr =
+    let (e_level: int) = get_level expr in
+    (match expr.core with
+        | Sequent _ -> assert (e_level = 4)
+            (* notion of level undefined *)
+        | _ -> assert_is_level e_level)
+
+
+let kind_to_level (kind: kind): int =
+    (* Return expression level of declared identifier with `kind`. *)
+    match kind with
+    | Constant -> 0
+    | State -> 1
+    | Action -> 2
+    | Temporal -> 3
+    | Unknown -> assert false
+
+
+(*
+The level property is stored in the syntax tree nodes.
+Therefore, the level computation is recursive over the syntax tree structure.
+This ensures the presence of level information (as a property that annotates
+each relevant syntax node) so that it can be used later, without further
+calls to invoke level computation.
+(It is also a form of memoization of intermediate results.)
+
+Note: Expanding declarations has linear complexity, but expanding definitions
+could have exponential complexity.
+*)
+class virtual ['s] level_computation = object (self : 'self)
+    inherit ['s] Visit.map as super
+
+    method expr ((_, cx) as scx) e =
+        if (has_level e) then
+            e
+        else
+        begin
+        let max_args_level scx args = (
+            let es_ = List.map (self#expr scx) args in
+            let es_levels = List.map get_level es_ in
+            let e_level = List.fold_left max 0 es_levels in
+            let level_args_sets = List.map get_level_args es_ in
+            let level_args = List.fold_left StringSet.union
+                StringSet.empty level_args_sets in
+            (e_level, level_args, es_)
+            ) in
+        let level_info_from_args scx args = (
+            let (level, level_args, es_) = max_args_level scx args in
+            let level_info = LevelInfo (level, [], level_args) in
+            (level_info, es_)
+            ) in
+        let bounds_level scx (bs: bounds) = (
+            (* `bs` is a list of domain expressions (`Domain (expr)`),
+            one expression for each constant bound by the quantifier.
+            The expressions in `bs` contain level information.
+
+            This function is called only for bound constants.
+            *)
+            let (e_scx, bs) = self#bounds scx bs in
+            let (dom_es, bs_levels, level_args_sets) =
+                let prev_dom = ref e in
+                let bs_levels = ref [] in
+                let level_args_sets = ref [] in
+                let f ((v: hint),
+                       (k: kind),
+                       (dom: bound_domain)):
+                        bound = begin
+                    match dom with
+                    | Domain d ->
+                        begin
+                        begin
+                        match k with
+                        | Constant -> ()
+                        | _ -> assert false
+                        end;
+                        let d_ = self#expr scx d in
+                        let d_level = get_level d_ in
+                        bs_levels := d_level :: !bs_levels;
+                        let d_level_args = get_level_args d_ in
+                        level_args_sets := d_level_args :: !level_args_sets;
+                        prev_dom := d_;
+                        (v, k, Domain d_)
+                        end
+                    | Ditto -> (v, k, Ditto)
+                    | No_domain ->  (* `\E x:` yields
+                            no level constraints. *)
+                        (v, k, No_domain)
+                    end
+                in
+                (List.map f bs, !bs_levels, !level_args_sets) in
+            let doms_level = List.fold_left max 0 bs_levels in
+            let level_args = List.fold_left
+                StringSet.union StringSet.empty level_args_sets in
+            (e_scx, dom_es, doms_level, level_args)
+            ) in
+        let apply_operator op_ es =
+            begin
+            assert ((List.length es) >= 1);
+            (* operator `op` *)
+            let op_level = get_level op_ in
+            let op_level_args = get_level_args op_ in
+            let op_weights = get_level_weights op_ in
+            (* expressions `es` of operator arguments *)
+            let es_ = List.map (self#expr scx) es in
+            let es_levels = List.map get_level es_ in
+            let es_level_args_list = List.map get_level_args es_ in
+            (* combine level info *)
+            (*
+            Interaction between parameters of second-order operators occurs
+            when a parameter of positive arity is applied to another parameter
+            (necessarily of arity 0, because parameters can be up to
+            first-order). This interaction is taken into account by using
+            a weights array with all elements equal to `true` for operator
+            parameters, as declared in `self#hyp` below.
+            *)
+            let f weights values op c =
+                let pairs = List.combine weights values in
+                let w (weight, value) = if weight then value else c in
+                let values = List.map w pairs in
+                List.fold_left op c values
+                in
+            (* levels based on weights *)
+            let es_level = f op_weights es_levels max 0 in
+            (* level args based on weights *)
+            let es_level_args = f op_weights es_level_args_list
+                StringSet.union StringSet.empty in
+            let level = max op_level es_level in
+            let level_args = StringSet.union
+                op_level_args es_level_args in
+            let weights = [] in
+            let level_info = LevelInfo (level, weights, level_args) in
+            (* returned expression *)
+            let new_apply = Apply (op_, es_) in
+            let new_e = new_apply @@ e in
+            assign new_e exprlevel level_info
+            end
+            in
+        let e_ = match e.core with
+        | Ix n -> begin
+            assert (n >= 1);
+            let hyp = E_t.get_val_from_id cx n in
+            let e_level_info = match hyp.core with
+                | Fresh _
+                | Flex _
+                | Defn _ ->
+                    (* For definitions, this call can recurse in the body
+                    of the definition. If the level computation has been
+                    called on a sequent, then level information for all
+                    definitions in the context `cx` has been computed,
+                    so this call will return after finding the level
+                    information in the property that annotates the
+                    definition. *)
+                    let hyp_scx = E_t.scx_front scx n in
+                    let (_, e_) = self#hyp hyp_scx hyp in
+                    get_level_info e_
+                | Fact (e_, _, _) ->
+                    (*
+                    E_t.print_cx cx;
+                    print_string "Index in context:\n";
+                    print_int n;
+                    Util.eprintf ~at:e "%s"
+                        (let hyp_cx = E_t.cx_front cx n in
+                        (E_fmt.string_of_expr hyp_cx e));
+                    *)
+                    let hyp_scx = E_t.scx_front scx n in
+                    let (_, e_) = self#hyp hyp_scx hyp in
+                    get_level_info e_
+                    (*
+                    assert false  (* A de Bruijn index
+                        refers to a declared or defined operator.
+                        *)
+                    *)
+                in
+            assign e exprlevel e_level_info
+            end
+        | Internal b -> begin
+            let e_level_info = match b with
+            (* Logic *)
+            | Builtin.TRUE | Builtin.FALSE -> make_level_info 0
+            | Builtin.Implies | Builtin.Equiv
+            | Builtin.Conj | Builtin.Disj ->
+                make_level_info_arity 0 2
+            | Builtin.Neg ->
+                make_level_info_arity 0 1
+            | Builtin.Eq | Builtin.Neq ->
+                make_level_info_arity 0 2
+            (* Sets *)
+            | Builtin.STRING | Builtin.BOOLEAN ->
+                make_level_info 0
+            | Builtin.SUBSET | Builtin.UNION | Builtin.DOMAIN ->
+                make_level_info_arity 0 1
+            | Builtin.Subseteq | Builtin.Mem | Builtin.Notmem
+            | Builtin.Setminus | Builtin.Cap | Builtin.Cup ->
+                make_level_info_arity 0 2
+            (* Modal *)
+            | Builtin.Actplus ->
+                make_level_info_arity 0 1
+            | Builtin.Box _ | Builtin.Diamond ->
+                make_level_info_arity 3 1
+                (* The operators:
+                    Prime, StrongPrime, ENABLED, UNCHANGED, Leadsto, Cdot
+                are implemented separately at
+                operator application below, but included here to
+                annotate the operator nodes. *)
+            | Builtin.Prime | Builtin.StrongPrime ->
+                make_level_info_arity 2 1
+            | Builtin.ENABLED ->
+                make_level_info_arity 1 1
+            | Builtin.UNCHANGED ->
+                make_level_info_arity 2 1
+            | Builtin.Leadsto ->
+                make_level_info_arity 3 2
+            | Builtin.Cdot ->
+                make_level_info_arity 2 2
+            (* Arithmetic *)
+            | Builtin.Nat | Builtin.Int
+            | Builtin.Real | Builtin.Infinity ->
+                make_level_info 0
+            | Builtin.Plus | Builtin.Minus
+            | Builtin.Times | Builtin.Ratio | Builtin.Quotient
+            | Builtin.Remainder | Builtin.Exp | Builtin.Divides
+            | Builtin.Lteq | Builtin.Lt
+            | Builtin.Gteq | Builtin.Gt
+            | Builtin.Range ->
+                make_level_info_arity 0 2
+            | Builtin.Uminus ->
+                make_level_info_arity 0 1
+            (* Sequences *)
+            | Builtin.Seq | Builtin.Len ->
+                make_level_info_arity 0 1
+            | Builtin.BSeq ->
+                make_level_info_arity 0 2
+            | Builtin.Cat | Builtin.Append ->
+                make_level_info_arity 0 2
+            | Builtin.Head | Builtin.Tail ->
+                make_level_info_arity 0 1
+            | Builtin.SubSeq ->
+                make_level_info_arity 0 3
+            | Builtin.SelectSeq ->
+                make_level_info_arity 0 2
+            | Builtin.OneArg ->  (* :> *)
+                make_level_info_arity 0 1
+            | Builtin.Extend -> (* @@ *)
+                make_level_info_arity 0 2
+            | Builtin.Print ->
+                make_level_info_arity 0 2
+            | Builtin.PrintT ->
+                make_level_info_arity 0 1
+            | Builtin.Assert ->
+                make_level_info_arity 0 2
+            | Builtin.JavaTime ->
+                make_level_info_arity 0 0
+            | Builtin.TLCGet ->
+                make_level_info_arity 0 1
+            | Builtin.TLCSet ->
+                make_level_info_arity 0 2
+            | Builtin.Permutations ->
+                make_level_info_arity 0 1
+            | Builtin.SortSeq ->
+                make_level_info_arity 0 2
+                (* LevelInfo (0, [true, [...]],
+                    StringSet.empty) *)
+            | Builtin.RandomElement ->
+                make_level_info_arity 0 1
+            | Builtin.Any ->
+                make_level_info_arity 0 0
+            | Builtin.ToString ->
+                make_level_info_arity 0 1
+              (* special *)
+            | Builtin.Unprimable ->
+                make_level_info_arity 0 1
+            | Builtin.Irregular -> assert false
+                (* make_level_info_arity 0 1 *)
+            in
+            assign e exprlevel e_level_info
+            end
+        | Apply ({core=Opaque name} as op, args) ->
+            (* case of opaque operator with arity <_, ... > . *)
+            let arity = List.length args in
+            let level_info = make_level_info_arity 0 arity in
+            let op = assign op exprlevel level_info in
+            apply_operator op args
+        | Opaque name ->
+            (* Opaque operator with arity `_` *)
+            let level_info = make_level_info 0 in
+            assign e exprlevel level_info
+        | Bang (e, sels) -> assert false  (* subexpression references are
+                expanded before expanding `ENABLED` and `\cdot`. *)
+        | Lambda (vs, e) ->
+            (* Note: 2nd-order operators (signified via `shp` below) are
+            handled by the declarations in `e_scx` below and the call to
+            the method `self#hyp` in the pattern case `Apply (op, es)` below.
+            *)
+            (* extend context with `vs` *)
+            let e_scx = Visit.adjs scx
+                (List.map
+                    (fun (v, shp) ->
+                        Fresh (v, shp, Unknown, Unbounded)
+                        @@ v)
+                    vs) in
+            (* expression `e` *)
+            let e_ = self#expr e_scx e in
+            let e_level = get_level e_ in
+            (*
+            if e_level > 2 then
+                begin
+                let msg = (
+                    "The `Lambda` with signature:\n" ^
+                        (String.concat ", " (List.map
+                            (fun (h, _) -> h.core) vs)) ^
+                    "\n and body `e`:\n" ^
+                        (let cx = snd e_scx in
+                        E_fmt.string_of_expr cx e) ^
+                    "\n has a body with expression level:\n" ^
+                    (string_of_int e_level) ) in
+                Util.eprintf ~at:e ~prefix:"[INFO]: " "%s" msg
+                end;
+            *)
+            assert ((e_level <= 3) || (e_level = 4));
+                (* The case `e_level = 4` corresponds to sequents that
+                represent theorems that result from parameteric
+                module instantiation.
+
+                The case `e_level = 3` corresponds to a `LAMBDA` with
+                a temporal expression. For example, `LAMBDA P:  [] P`.
+                *)
+            let e_level_args = get_level_args e_ in
+            (* `vs` as level args *)
+            let vs_list = List.map (fun (v, shp) -> v.core) vs in
+            let vs_set = StringSet.of_list vs_list in
+            (* combine level arg info *)
+            let level_args = StringSet.diff e_level_args vs_set in
+            (* weights *)
+            let level_weights = List.map
+                (fun v -> StringSet.mem v e_level_args)
+                vs_list
+                in
+            (* The level of a defined operator is defined to correspond to
+            the case with all formal parameters in `vs` having constant level.
+            *)
+            let level_info = LevelInfo (e_level, level_weights, level_args) in
+            let new_lambda = Lambda (vs, e_) in
+            let new_e = new_lambda @@ e in
+            assign new_e exprlevel level_info
+        | String s ->
+            let level_info = make_level_info 0 in
+            assign e exprlevel level_info
+        | Num (m, n) ->
+            let level_info = make_level_info 0 in
+            assign e exprlevel level_info
+        | Apply ({core=Internal Builtin.Prime} as op, [arg]) ->
+            begin
+            let op_ = self#expr scx op in
+            let arg_ = self#expr scx arg in
+            let arg_level = get_level arg_ in
+            assert (arg_level <= 1);
+            let level_info = make_level_info_arity 2 1 in
+                (* the level of a primed expression is 2
+                (so independent of level parameters of `arg`) *)
+            let new_apply = Apply (op_, [arg_]) in
+            let new_e = new_apply @@ e in
+            assign new_e exprlevel level_info
+            end
+        | Apply ({core=Internal Builtin.StrongPrime} as op, [arg]) ->
+            begin
+            (* assume that level correctness has been checked by SANY *)
+            let op_ = self#expr scx op in
+            let arg_ = self#expr scx arg in
+            let arg_level = get_level arg_ in
+            assert (arg_level <= 1);
+            let level_info = make_level_info_arity 2 1 in
+                (* level is independent of level parameters of `arg` *)
+            let new_apply = Apply (op_, [arg_]) in
+            let new_e = new_apply @@ e in
+            assign new_e exprlevel level_info
+            end
+        | Apply ({core=Internal Builtin.ENABLED} as op, [arg]) ->
+            begin
+            (* assume that level correctness has been checked by SANY *)
+            let op_ = self#expr scx op in
+            let arg_ = self#expr scx arg in
+            let arg_level = get_level arg_ in
+            assert (arg_level <= 2);
+            let level_args = get_level_args arg_ in
+            let level = 1 in
+            let weights = [] in
+            let level_info = LevelInfo (level, weights, level_args) in
+            let new_enabled = Apply (op_, [arg_]) in
+            let new_e = new_enabled @@ e in
+            assign new_e exprlevel level_info
+            end
+        | Apply ({core=Internal Builtin.UNCHANGED} as op, [arg]) ->
+            let op_ = self#expr scx op in
+            let arg_ = self#expr scx arg in
+            let arg_level = get_level arg_ in
+            assert (arg_level <= 1);
+            let level_args = get_level_args arg_ in
+            let level = 2 in
+            let weights = [] in
+            let level_info = LevelInfo (level, weights, level_args) in
+            let new_unchanged = Apply (op_, [arg_]) in
+            let new_e = new_unchanged @@ e in
+            assign new_e exprlevel level_info
+        | Apply ({core=Internal Builtin.Cdot} as op, args) ->
+            begin
+            assert ((List.length args) = 2);
+            let op_ = self#expr scx op in
+            let args_ = List.map (self#expr scx) args in
+            (* let arg_levels = List.map get_level args_ in
+            let op_level = get_level op_ in
+            let level = List.fold_left max op_level arg_levels in *)
+            let level = 2 in  (* SANY appears to assign level 2 to
+                `\cdot` for any levels of the arguments.
+                If changed here, remember to update also the
+                pattern case for `Internal.Builtin` leaf nodes above.
+                *)
+            assert (level <= 2);
+            let weights = [] in
+            (* `\cdot` is of level 2 *)
+            (*
+            let a_level_args = get_level_args (List.nth args_ 1) in
+            *)
+                (* The level of `A \cdot B` depends on only unprimed
+                level parameters from action `A`. *)
+            (* let level_info = LevelInfo (level, weights, a_level_args) in *)
+            (* `\cdot` is of level 2, so level does not depend on params *)
+            let level_args = StringSet.empty in
+            let level_info = LevelInfo (level, weights, level_args) in
+            let new_cdot = Apply (op_, args_) in
+            let new_e = new_cdot @@ e in
+            assign new_e exprlevel level_info
+            end
+        (* Temporal operators *)
+        | Apply ({core=Internal Builtin.Leadsto} as op, args) ->
+            assert ((List.length args) == 2);
+            let op_ = self#expr scx op in
+            let level_info = make_level_info_arity 3 2 in
+            let args_ = List.map (self#expr scx) args in
+            let new_leadsto = Apply (op_, args_) in
+            let new_e = new_leadsto @@ e in
+            assign new_e exprlevel level_info
+        (* Operator application *)
+        | Apply (op, es) ->
+            let op_ = self#expr scx op in
+            assert ((List.length es) >= 1);
+            apply_operator op_ es
+        | Sequent sq ->
+            begin
+            let (_, sq_) = self#sequent scx sq in
+            (* A sequent has expression level equal to the maximum
+            expression level over antecedents and consequent.
+            *)
+            let rec hyps_level hs =
+                match Dq.front hs with
+                | None -> 0
+                | Some (h, hs) ->
+                    let h_level = get_level h in
+                    let hs_level = hyps_level hs in
+                    max h_level hs_level
+                in
+            let level_hyps = hyps_level sq_.context in
+            let level_active = get_level sq_.active in
+            let level = max level_hyps level_active in
+            (* store the level info *)
+            let new_sq = Sequent sq_ in
+            let new_e = new_sq @@ e in
+            let level_info = make_level_info level in
+            assign new_e exprlevel level_info
+            end
+        | With (expr, m) ->
+            let expr_ = self#expr scx expr in
+            let level_info = get_level_info expr_ in
+            let new_with = With (expr_, m) in
+            let new_e = new_with @@ e in
+            assign new_e exprlevel level_info
+        | Let (ds, e) ->
+            let (e_scx, ds_) = self#defns scx ds in
+            let e_ = self#expr e_scx e in
+            let level_info = get_level_info e_ in
+            let new_let = Let (ds_, e_) in
+            let new_e = new_let @@ e in
+            assign new_e exprlevel level_info
+        | If (e, f, g) ->
+            let es = [e; f; g] in
+            let (level_info, es_) = level_info_from_args scx es in
+            let e_ = List.nth es_ 0 in
+            let f_ = List.nth es_ 1 in
+            let g_ = List.nth es_ 2 in
+            let new_if = If (e_, f_, g_) in
+            let new_e = new_if @@ e in
+            assign new_e exprlevel level_info
+        | List (q, es) ->
+            let (level_info, es_) = level_info_from_args scx es in
+            let new_list = List (q, es_) in
+            let new_e = new_list @@ e in
+            assign new_e exprlevel level_info
+        | Quant (q, bs, e) ->
+            (* The expression `\E x:  P(x)` has the same level as `P(x)`.
+            So the expression `\E x \in S:  P(x)` has the same level as the
+            expression `P(x) /\ (x \in S)`.
+            The expression `P(x) /\ (x \in S)` has level = max of levels of
+            `P(x)` and `(x \in S)`, and the level of `(x \in S)` equals the
+            level of `S` (because in this case `x` is a constant).
+            *)
+            (* domain bounds `bs` *)
+            let (e_scx, bs_, doms_level, doms_level_args) =
+                bounds_level scx bs in
+            (* expression `e` *)
+            let e_ = self#expr e_scx e in
+            let e_level = get_level e_ in
+            let e_level_args = get_level_args e_ in
+            (* combine level info *)
+            let level = max e_level doms_level in
+            let level_args = StringSet.union e_level_args doms_level_args in
+            let level_info = LevelInfo (level, [], level_args) in
+            let new_quant = Quant (q, bs_, e_) in
+            let new_e = new_quant @@ e in
+            assign new_e exprlevel level_info
+        | Tquant (q, vs, e) ->
+            let new_tquant =
+                let scx = adjs scx (List.map (fun v -> Flex v @@ v) vs) in
+                let e = self#expr scx e in
+                Tquant (q, vs, e) in
+            let new_e = new_tquant @@ e in
+            let level_info = make_level_info_arity 3 0 in
+            assign new_e exprlevel level_info
+        | Choose (v, optdom, e) ->  (* 0, 1, 2 *)
+            (* extend context with bound constant *)
+            let optdom_ = Option.map (self#expr scx) optdom in
+            let dom = match optdom_ with
+                | None -> Unbounded
+                | Some dom -> Bounded (dom, Visible)
+                in
+            let h = Fresh (v, Shape_expr, Constant, dom) @@ v in
+            let e_scx = adj scx h in
+            (* expression `e` *)
+            let e_ = self#expr e_scx e in
+            let e_level = get_level e_ in
+            let e_level_args = get_level_args e_ in
+            (* domain `dom` *)
+            let (dom_level, dom_level_args) = match optdom_ with
+                | None -> (0, StringSet.empty)
+                | Some dom ->
+                    let dom_ = self#expr scx dom in
+                    let dom_level = get_level dom_ in
+                    let dom_level_args = get_level_args dom_ in
+                    (dom_level, dom_level_args)
+                in
+            (* combine level info *)
+            let level = max dom_level e_level in
+            let level_args = StringSet.union
+                dom_level_args e_level_args in
+            let level_info = LevelInfo (level, [], level_args) in
+            let new_choose = Choose (v, optdom_, e_) in
+            let new_e = new_choose @@ e in
+            assign new_e exprlevel level_info
+        | SetSt (v, dom, e) ->  (* {x \in S:  P(x)} *)
+            (* domain bound `dom` *)
+            let dom_ = self#expr scx dom in
+            let dom_level = get_level dom_ in
+            let dom_level_args = get_level_args dom_ in
+            (* expression `e` *)
+            let e_scx = adj scx (
+                Fresh (v, Shape_expr, Constant,
+                       Bounded (dom, Visible)) @@ v) in
+            let e_ = self#expr e_scx e in
+            let e_level = get_level e_ in
+            let e_level_args = get_level_args e_ in
+            (* combine level info *)
+            let level = max dom_level e_level in
+            let level_args = StringSet.union
+                dom_level_args e_level_args in
+            let level_info = LevelInfo (level, [], level_args) in
+            let new_setst = SetSt (v, dom_, e_) in
+            let new_e = new_setst @@ e in
+            assign new_e exprlevel level_info
+        | SetOf (e, bs) ->  (* {f(x):  x \in S} *)
+                (* There is one bound constant in the expression
+                `{x \in S:  P(x)}`, so the constructor `SetSt` takes
+                one domain `dom`.
+                There can be multiple bound constants in the expression
+                `{f(x, ...):  x \in S, ...}`, so the constructor `SetOf`
+                takes multiple domain bounds.
+                *)
+            (* domain bounds `bs` *)
+            let (e_scx, bs_, doms_level, doms_level_args) =
+                bounds_level scx bs in
+            (* expression `e` *)
+            let e_ = self#expr e_scx e in
+            let e_level = get_level e_ in
+            let e_level_args = get_level_args e_ in
+            (* combine level info *)
+            let level = max e_level doms_level in
+            let level_args = StringSet.union
+                e_level_args doms_level_args in
+            let level_info = LevelInfo (level, [], level_args) in
+            let new_setof = SetOf (e_, bs_) in
+            let new_e = new_setof @@ e in
+            assign new_e exprlevel level_info
+        | SetEnum es -> (* {1, 2, 3} *)
+            let (level, level_args, es_) = max_args_level scx es in
+            let level_info = LevelInfo (level, [], level_args) in
+            let new_setenum = SetEnum es_ in
+            let new_e = new_setenum @@ e in
+            assign new_e exprlevel level_info
+        | Fcn (bs, e) ->  (* [x \in S |-> P(x)] *)
+            (* domain bounds `bs` *)
+            let (e_scx, bs_, doms_level, doms_level_args) =
+                bounds_level scx bs in
+            (* expression `e` *)
+            let e_ = self#expr e_scx e in
+            let e_level = get_level e_ in
+            let e_level_args = get_level_args e_ in
+            (* combine level info *)
+            let level = max e_level doms_level in
+            let level_args = StringSet.union
+                e_level_args doms_level_args in
+            let level_info = LevelInfo (level, [], level_args) in
+            let new_fcn = Fcn (bs_, e_) in
+            let new_e = new_fcn @@ e in
+            assign new_e exprlevel level_info
+        | FcnApp (f, es) ->  (* f[x] *)
+                (* function `f` *)
+            let fes = List.append [f] es in
+            let (level_info, fes_) = level_info_from_args scx fes in
+            let f_ = List.hd fes_ in
+            let es_ = List.tl fes_ in
+            let new_fcnapp = FcnApp (f_, es_) in
+            let new_e = new_fcnapp @@ e in
+            assign new_e exprlevel level_info
+        | Arrow (a, b) ->
+            let args = [a; b] in
+            let (level_info, args_) = level_info_from_args scx args in
+            let a_ = List.hd args_ in
+            let b_ = List.nth args_ 1 in
+            let new_arrow = Arrow (a_, b_) in
+            let new_e = new_arrow @@ e in
+            assign new_e exprlevel level_info
+        | Product es ->
+            let (level_info, es_) = level_info_from_args scx es in
+            let new_product = Product es_ in
+            let new_e = new_product @@ e in
+            assign new_e exprlevel level_info
+        | Tuple es ->
+            let (level_info, es_) = level_info_from_args scx es in
+            let new_tuple = Tuple es_ in
+            let new_e = new_tuple @@ e in
+            assign new_e exprlevel level_info
+        | Rect fs ->
+            let (ps, es) = List.split fs in
+            let (level_info, es_) = level_info_from_args scx es in
+            let fs_ = List.combine ps es_ in
+            let new_rect = Rect fs_ in
+            let new_e = new_rect @@ e in
+            assign new_e exprlevel level_info
+        | Record fs ->
+            let (ps, es) = List.split fs in
+            let (level_info, es_) = level_info_from_args scx es in
+            let fs_ = List.combine ps es_ in
+            let new_record = Record fs_ in
+            let new_e = new_record @@ e in
+            assign new_e exprlevel level_info
+        | Except (e, xs) ->
+            (* e *)
+            let e_ = self#expr scx e in
+            let e_level = get_level e_ in
+            let e_level_args = get_level_args e_ in
+            (* xs *)
+            let (xs_level, xs_level_args, xs_) = (
+                let f (trail, res) = (
+                    let trail_arg_level = function
+                        | Except_dot s ->
+                            ((0, StringSet.empty),
+                            Except_dot s)
+                        | Except_apply e ->
+                            let e_ = self#expr scx e in
+                            let e_level = get_level e_ in
+                            let e_level_args = get_level_args e_ in
+                            ((e_level, e_level_args),
+                            Except_apply e_)
+                    in
+                    let r = List.map trail_arg_level trail in
+                    let (trail_levels, trail_) = List.split r in
+                    let (trail_level, trail_level_args) = List.fold_left
+                        (fun (xy: int * StringSet.t)
+                             (uv: int * StringSet.t) ->
+                            let (x, y) = xy in
+                            let (u, v) = uv in
+                            let r = max x u in
+                            let w = StringSet.union y v in
+                            (r, w)
+                            )
+                        (0, StringSet.empty) trail_levels in
+                    let res_ = self#expr scx res in
+                    let res_level = get_level res_ in
+                    let res_level_args = get_level_args res_ in
+                    let level = max res_level trail_level in
+                    let level_args = StringSet.union
+                        res_level_args trail_level_args in
+                    ((level, level_args), (trail_, res_))
+                    ) in
+                let trail_levels_xs_ = List.map f xs in
+                let (trail_levels, xs_) = List.split trail_levels_xs_ in
+                let (xs_level, xs_level_args) = List.fold_left
+                    (fun (xy: (int * StringSet.t))
+                         (uv: (int * StringSet.t)) ->
+                        let (x, y) = xy in
+                        let (u, v) = uv in
+                        (max x u, StringSet.union y v))
+                    (0, StringSet.empty) trail_levels
+                    in
+                (xs_level, xs_level_args, xs_)
+                ) in
+            (* combine level info *)
+            let level = max e_level xs_level in
+            let level_args = StringSet.union e_level_args xs_level_args in
+            let level_info = LevelInfo (level, [], level_args) in
+            let new_except = Except (e_, xs_) in
+            let new_e = new_except @@ e in
+            assign new_e exprlevel level_info
+        (* Record field operator:  r.a *)
+        | Dot (e, f) ->
+            let e_ = self#expr scx e in
+            let level_info = get_level_info e_ in
+            let new_dot = Dot (e_, f) in
+            let new_e = new_dot @@ e in
+            assign new_e exprlevel level_info
+        (* The subscript in the action-level expression:  [A]_v *)
+        | Sub (s, e, f) ->
+            let level = 2 in
+            let (_, level_args, ef_) = max_args_level scx [e; f] in
+            assert ((List.length ef_) == 2);
+            let e_ = List.nth ef_ 0 in
+            let f_ = List.nth ef_ 1 in
+            let level_info = LevelInfo (level, [], level_args) in
+            let new_sub = Sub (s, e_, f_) in
+            let new_e = new_sub @@ e in
+            assign new_e exprlevel level_info
+        (* The subscript in the temporal-level expression:  [][A]_v *)
+        | Tsub (s, e, f) ->
+            let level_info = make_level_info 3 in
+            let e_ = self#expr scx e in
+            let f_ = self#expr scx f in
+            let new_tsub = Tsub (s, e_, f_) in
+            let new_e = new_tsub @@ e in
+            assign new_e exprlevel level_info
+        | Fair (fop, e, f) ->
+            let level_info = make_level_info 3 in
+            let e_ = self#expr scx e in
+            let f_ = self#expr scx f in
+            let new_fair = Fair (fop, e_, f_) in
+            let new_e = new_fair @@ e in
+            assign new_e exprlevel level_info
+        | Case (efs, oth) ->
+            let (es, fs) = List.split efs in
+            (* let esfs = List.append es fs in
+            let (efs_level, efs_level_args, es_) =
+                max_args_level scx esfs in *)
+            let es_ = List.map (self#expr scx) es in
+            let fs_ = List.map (self#expr scx) fs in
+            let efs_ = List.combine es_ fs_ in
+            let esfs = List.append es_ fs_ in
+            let (efs_level, efs_level_args, es_) =
+                (* level already computed, so the
+                computation is not repeated for elements
+                of `esfs`. *)
+                max_args_level scx esfs in
+            let (oth_, oth_level, oth_level_args) =
+                match oth with
+                | Some e ->
+                    let e_ = self#expr scx e in
+                    let level = get_level e_ in
+                    let level_args = get_level_args e_ in
+                    (Some e_, level, level_args)
+                | None -> (None, 0, StringSet.empty)
+            in
+            let level = max efs_level oth_level in
+            let level_args = StringSet.union
+                efs_level_args oth_level_args in
+            let level_info = LevelInfo (level, [], level_args) in
+            let new_case = Case (efs_, oth_) in
+            let new_e = new_case @@ e in
+            assign new_e exprlevel level_info
+        | At b ->
+            assert false
+            (*
+            let level_info = make_level_info 0 in
+            let new_at = At b in
+            let new_e = new_at @@ e in
+            assign new_e exprlevel level_info
+            *)
+        | Parens (e, pf) ->
+            let e_ = self#expr scx e in
+            let e_level_info = get_level_info e_ in
+            (* `super#pform` returns `pf` *)
+            let pf_ = self#pform scx pf in
+            let new_parens = Parens (e_, pf_) in
+            let new_e = new_parens @@ e in
+            assign new_e exprlevel e_level_info
+        in
+        e_
+        end
+
+    method defn scx df =
+        match df.core with
+        | Recursive (nm, shp) ->
+                Util.eprintf ~at:df "%s" (
+                    "Recursive operator definitions are " ^
+                    "not supported. ");
+                assert false
+            (* Reasoning about recursive operator definitions
+            is unimplemented. *)
+        | Operator (nm, e) ->
+            (* Operator signatures are represented as `Lambda`.
+            So the `Lambda` parameters will have kind `Unknown`.
+            This kind is assumed to be constant for computing the
+            level of an operator, and this level is used together
+            with the argument weights and levels of arguments to
+            compute the level of an application of the operator to
+            specific expressions as arguments.
+            *)
+            let e_ = self#expr scx e in
+            let core = Operator (nm, e_) in
+            let df_ = {df with core = core} in
+            let level_info = get_level_info e_ in
+            assign df_ exprlevel level_info
+        | Bpragma (nm, e, args) ->  (* similar to pattern case for
+                `Operator` above *)
+            let e_ = self#expr scx e in
+            let core = Bpragma (nm, e_, args) in
+            let df_ = {df with core = core} in
+            let level_info = get_level_info e_ in
+            assign df_ exprlevel level_info
+        | Instance (nm, i) -> assert false
+            (* Operators from instantiation are expanded before
+            generating proof obligations. See the function
+            `normalize` in the module `module/m_elab`.
+            *)
+
+    method hyp scx h =
+        let level_info = begin match h.core with
+            (* declared variable *)
+            | Flex _ -> make_level_info 1
+            (* declared operator of any arity *)
+            | Fresh (name, op_shape, kind, _) -> begin
+                let level = match kind with
+                    | Constant -> 0
+                        (* Using the following levels for identifiers
+                        declared as `STATE`, `ACTION`, `TEMPORAL`
+                        ensures soundness when using the computed level. *)
+                    | State -> 1
+                    | Action -> 2
+                    | Temporal -> 3
+                    | Unknown -> 0
+                        (* Describes the kind of arguments of
+                        `LAMBDA` (see case for `Lambda` below),
+                        and of parameters of instantiation
+                        (see `super#instance`).
+                        Has level 0 by comment in `BoundSymbolNode` and
+                        comment about what the level of a syntax tree node
+                        means. See also comment of
+                        `OpDefOrDeclNodeFields.level`. *)
+                    in
+                let weights = match op_shape with
+                    | Shape_expr -> []  (* declared operator of arity 0 *)
+                    | Shape_op arity ->  (* declared operator of positive arity
+                        This case of arity of declared operators includes
+                        parameters of a second-order operator that have
+                        positive arity. Thus, second-order operators are
+                        handled here.
+                        *)
+                        assert (arity >= 1);
+                        make_weights arity
+                    in
+                let level_args = StringSet.singleton name.core in
+                LevelInfo (level, weights, level_args)
+                end
+            (* defined operator of any arity *)
+            | Defn (df, _, _, _) ->
+                let df_ = self#defn scx df in
+                get_level_info df_
+            | Fact (e, _, _) ->
+                let e_ = self#expr scx e in
+                begin
+                if (has_level e_) then
+                    get_level_info e_
+                else
+                    (* For example, the notion of expression level is
+                    undefined for theorems. *)
+                    make_undefined_level_info
+                end
+            end in
+        (* Hidden definitions need to be visited to
+        have level information available for computing the
+        level of expressions where the operator occurs. *)
+        let (scx_, e_) = match h.core with
+            | Fresh (nm, shp, lc, dom) ->
+                let dom = match dom with
+                  | Unbounded -> Unbounded
+                  | Bounded (r, rvis) ->
+                        Bounded (self#expr scx r, rvis)
+                in
+                let h = Fresh (nm, shp, lc, dom) @@ h in
+                (adj scx h, h)
+            | Flex s ->
+                let h = Flex s @@ h in
+                (adj scx h, h)
+            | Defn (df, wd, vis, ex) ->
+                let df = self#defn scx df in
+                let h = Defn (df, wd, vis, ex) @@ h in
+                (adj scx h, h)
+            | Fact (e, vis, tm) ->
+                let h = Fact (self#expr scx e, vis, tm) @@ h in
+                (adj scx h, h)
+            in
+        let e_ = assign e_ exprlevel level_info in
+        (scx_, e_)
+
+end
+
+
+let compute_level cx expr =
+    let visitor = object
+        inherit [unit] level_computation
+    end in
+    let scx = ((), cx) in
+    visitor#expr scx expr
+
+
+class virtual ['s] _rm_expr_level = object (self : 'self)
+    (* Recursively remove level information from an expression. *)
+    inherit ['s] Visit.map_visible_hyp as super
+
+    method expr (s, cx) e =
+        let scx_ = (s, cx) in
+        let e_ = super#expr scx_ e in
+        rm_level e_
+
+    method pform scx pf =
+        let pf_ = super#pform scx pf in
+        rm_level pf_
+
+    method defn scx df =
+        let df_ = super#defn scx df in
+        rm_level df_
+
+    (* level info removed from context because the
+        context is stored in sequents *)
+    method hyp scx h =
+        let (scx_, h_) = super#hyp scx h in
+        let h_ = rm_level h_ in
+        (scx_, h_)
+end
+
+
+let rm_expr_level cx expr =
+    let visitor = object
+        inherit [unit] _rm_expr_level
+    end in
+    let scx = ((), cx) in
+    visitor#expr scx expr

--- a/src/expr/e_levels.mli
+++ b/src/expr/e_levels.mli
@@ -1,0 +1,33 @@
+(*
+ * expr/e_levels.mli --- compute expression levels
+ *
+ *
+ *)
+open Property
+
+open E_t
+open E_visit
+
+
+module StringSet: Set.S with type elt = string
+
+
+type level_info = LevelInfo of int * bool list * StringSet.t
+
+
+val exprlevel: level_info pfuncs
+val has_level: 'a Property.wrapped -> bool
+val rm_level: 'a Property.wrapped -> 'a Property.wrapped
+val get_level_info: 'a Property.wrapped -> level_info
+val get_level: 'a Property.wrapped -> int
+val get_level_weights: 'a Property.wrapped -> bool list
+val get_level_args: 'a Property.wrapped -> StringSet.t
+val assert_has_correct_level: expr -> unit
+val kind_to_level: kind -> int
+
+
+class virtual ['s] level_computation : ['s] E_visit.map
+class virtual ['s] _rm_expr_level : ['s] E_visit.map_visible_hyp
+
+val compute_level: ctx -> expr -> expr
+val rm_expr_level: ctx -> expr -> expr

--- a/src/expr/e_subst.ml
+++ b/src/expr/e_subst.ml
@@ -2,7 +2,7 @@
  * expr/subst.ml --- expressions (substitution)
  *
  *
- * Copyright (C) 2008-2010  INRIA and Microsoft Corporation
+ * Copyright (C) 2008-2019  INRIA and Microsoft Corporation
  *)
 
 Revision.f "$Rev$";;
@@ -11,6 +11,7 @@ open Ext
 open Property
 open E_t
 
+module Dq = Deque
 module Fmt = E_fmt;;
 
 type sub =
@@ -51,7 +52,7 @@ let rec app_expr s oe = match oe.core with
   | If (e, f, g) ->
       If (app_expr s e, app_expr s f, app_expr s g) @@ oe
   | List (q, es) ->
-      List (q, List.map (app_expr s) es) @@ oe
+      List (q, app_exprs s es) @@ oe
   | Quant (q, bs, e) ->
       let (s, bs) = app_bounds s bs in
       Quant (q, bs, app_expr s e) @@ oe
@@ -66,18 +67,18 @@ let rec app_expr s oe = match oe.core with
       let (s, bs) = app_bounds s bs in
       SetOf (app_expr s e, bs) @@ oe
   | SetEnum es ->
-      SetEnum (List.map (app_expr s) es) @@ oe
+      SetEnum (app_exprs s es) @@ oe
   | Arrow (a, b) ->
       Arrow (app_expr s a, app_expr s b) @@ oe
   | Fcn (bs, e) ->
       let (s, bs) = app_bounds s bs in
       Fcn (bs, app_expr s e) @@ oe
   | FcnApp (f, es) ->
-      FcnApp (app_expr s f, List.map (app_expr s) es) @@ oe
+      FcnApp (app_expr s f, app_exprs s es) @@ oe
   | Product es ->
-      Product (List.map (app_expr s) es) @@ oe
+      Product (app_exprs s es) @@ oe
   | Tuple es ->
-      Tuple (List.map (app_expr s) es) @@ oe
+      Tuple (app_exprs s es) @@ oe
   | Rect fs ->
       Rect (List.map (fun (v, e) -> (v, app_expr s e)) fs) @@ oe
   | Record fs ->
@@ -157,11 +158,14 @@ and app_x s (trail, res) =
 (* [PERF] this is the hottest function in the PM (ignoring GC) *)
 and app_ix s n = match s with
   | Shift m -> Ix (m + n.core) @@ n
-  | Cons (op, _) when n.core = 1 -> op.core @@ n
-  | Cons (_, s) -> app_ix s (n.core - 1 @@ n)
+  | Cons (op, _) when n.core = 1 -> op.core @@ n  (* app_ix Cons(op, s) (1 @@ oe) = op.core @@ oe *)
+  | Cons (_, s) -> app_ix s (n.core - 1 @@ n)  (* app_ix Cons(op, s) (i @@ oe) = app_ix s ((i - 1) @@ oe) *)
   | Compose (ss, tt) -> app_expr ss (app_ix tt n)
+    (* `app_ix` returns `Ix` so could call `app_ix` directly,
+    instead of `app_expr` *)
   | Bump (k, ss) when n.core <= k -> Ix n.core @@ n
   | Bump (k, ss) -> app_expr (Shift k) (app_ix ss (n.core - k @@ n))
+    (* could call `app_ix` directly, instead of `app_expr` *)
 
 and app_defn s d =
   { d with core = app_defn_ s d.core }
@@ -251,3 +255,232 @@ let extract sq k =
     } in
     Some (sq, e)
   end with _ -> None
+
+
+let bump s = bumpn 1 s  (* distinguish from `E_fmt.bump` *)
+
+
+class map = object (self : 'self)
+    (* Apply a substitution to an expression.
+
+    This class is equivalent to the recursive functions defined above.
+    It allows subclassing to modify methods for those pattern cases needed.
+    *)
+
+  method expr (s: sub) (oe: E_t.expr): expr = match oe.core with
+    | Ix n ->
+        app_ix s (n @@ oe)
+    | Internal b ->
+        Internal b @@ oe
+    | Opaque o ->
+        Opaque o @@ oe
+    | Bang (e, sels) ->
+        Bang (self#expr s e, self#sels s sels) @@ oe
+    | Lambda (vs, e) ->
+        let s = (bumpn (List.length vs) s) in
+        Lambda (vs, self#expr s e) @@ oe
+    | String t ->
+        String t @@ oe
+    | Num (m, n) ->
+        Num (m, n) @@ oe
+    | Apply (op, es) ->
+        self#normalize (self#expr s op) (self#exprs s es) @@ oe
+    | Sequent sq ->
+        let (_, sq) = self#sequent s sq in
+        Sequent sq @@ oe
+    | With (e, m) ->
+        With (self#expr s e, m) @@ oe
+    | Let (ds, e) ->
+        let (s, ds) = self#defns s ds in
+        Let (ds, self#expr s e) @@ oe
+    | If (e, f, g) ->
+        If (self#expr s e, self#expr s f, self#expr s g) @@ oe
+    | List (q, es) ->
+        List (q, self#exprs s es) @@ oe
+    | Quant (q, bs, e) ->
+        let (s, bs) = self#bounds s bs in
+        Quant (q, bs, self#expr s e) @@ oe
+    | Tquant (q, vs, e) ->
+        let s = bumpn (List.length vs) s in
+        Tquant (q, vs, self#expr s e) @@ oe
+    | Choose (v, optdom, e) ->
+        let optdom = Option.map (self#expr s) optdom in
+        let s = bump s in
+        let e = self#expr s e in
+        Choose (v, optdom, e) @@ oe
+    | SetSt (v, dom, expr) ->
+        let dom = self#expr s dom in
+        let s = bump s in
+        let e = self#expr s expr in
+        SetSt (v, dom, e) @@ oe
+    | SetOf (e, bs) ->
+        let (s, bs) = self#bounds s bs in
+        SetOf (self#expr s e, bs) @@ oe
+    | SetEnum es ->
+        SetEnum (self#exprs s es) @@ oe
+    | Fcn (bs, e) ->
+        let (s, bs) = self#bounds s bs in
+        Fcn (bs, self#expr s e) @@ oe
+    | FcnApp (f, es) ->
+        FcnApp (self#expr s f, self#exprs s es) @@ oe
+    | Arrow (a, b) ->
+        Arrow (self#expr s a, self#expr s b) @@ oe
+    | Product es ->
+        Product (self#exprs s es) @@ oe
+    | Tuple es ->
+        Tuple (self#exprs s es) @@ oe
+    | Rect fs ->
+        Rect (List.map (fun (v, e) -> (v, self#expr s e)) fs) @@ oe
+    | Record fs ->
+        Record (List.map (fun (v, e) -> (v, self#expr s e)) fs) @@ oe
+    | Except (e, xs) ->
+        Except (self#expr s e, List.map (self#exspec s) xs) @@ oe
+    | Dot (e, f) ->
+        Dot (self#expr s e, f) @@ oe
+    | Sub (modal_op, e, f) ->
+        Sub (modal_op, self#expr s e, self#expr s f) @@ oe
+    | Tsub (modal_op, e, f) ->
+        Tsub (modal_op, self#expr s e, self#expr s f) @@ oe
+    | Fair (fop, e, f) ->
+        Fair (fop, self#expr s e, self#expr s f) @@ oe
+    | Case (arms, oth) ->
+        Case (List.map (fun (e, f) -> (self#expr s e, self#expr s f)) arms,
+              Option.map (self#expr s) oth) @@ oe
+    | At b ->
+        At b @@ oe
+    | Parens (e, pf) ->
+        Parens (self#expr s e, self#pform s pf) @@ oe
+
+  method exprs s es = List.map (self#expr s) es
+
+  method pform s pf = pf
+
+  method sels s sels = List.map (self#sel s) sels
+
+  method sel s sel = match sel with
+    | Sel_inst args ->
+        Sel_inst (self#exprs s args)
+    | Sel_lab (l, args) ->
+        Sel_lab (l, self#exprs s args)
+    | _ -> sel
+
+  method sequent s sq =
+    let (s, hyps) = self#hyps s sq.context in
+    (s, { context = hyps;
+          active = self#expr s sq.active })
+
+  method defn s df =
+    let df = match df.core with
+      | Recursive (nm, shp) -> df
+      | Operator (nm, e) ->
+          { df with core = Operator (nm, self#expr s e) }
+      | Instance (nm, i) ->
+          { df with core = Instance (nm, self#instance s i) }
+      | Bpragma(nm, e, l) ->
+          { df with core = Bpragma (nm, self#expr s e, l) }
+    in
+    (* incremental bumping *)
+    (bump s, df)
+
+  method defns s dfs =
+    match dfs with
+    | [] -> (s, [])
+    | df :: dfs ->
+        let (s, df) = self#defn s df in
+        let (s, dfs) = self#defns s dfs in
+        (s, df :: dfs)
+
+  method bounds s bs =
+    (* TODO: need to update `s` from bound to bound ? *)
+    let bs = List.map (self#bound s) bs in
+    let n = List.length bs in
+    let s = bumpn n s in
+    (s, bs)
+
+  method bound s b =
+    let (v, k, dom) = b in
+    let dom = match dom with
+        (* TODO: need to bump by 1 incrementally
+        in each consecutive domain bound ? *)
+        | Domain d -> Domain (self#expr s d)
+        | _ -> dom
+        in
+    (v, k, dom)
+
+  method exspec s (trail, res) =
+    let do_trail = function
+      | Except_dot s -> Except_dot s
+      | Except_apply e -> Except_apply (self#expr s e)
+    in
+    (List.map do_trail trail, self#expr s res)
+
+  method instance s i =
+    let s = bumpn (List.length i.inst_args) s in
+    { i with inst_sub =
+        List.map (fun (v, e) -> (v, self#expr s e))
+            i.inst_sub }
+
+  method hyp s h =
+    let h = begin match h.core with
+    | Fresh (nm, shp, lc, dom) ->
+        let dom = match dom with
+          | Unbounded -> Unbounded
+          | Bounded (r, rvis) -> Bounded (self#expr s r, rvis)
+        in
+        Fresh (nm, shp, lc, dom) @@ h
+    | Flex v -> Flex v @@ h
+    | Defn (df, wd, vis, ex) ->
+        let (s, df) = self#defn s df in
+        assert (s = bump s);
+        Defn (df, wd, vis, ex) @@ h
+    | Fact (e, vis, tm) ->
+        Fact (self#expr s e, vis, tm) @@ h
+    end in
+    (* incremental bumping, as in `self#defn` *)
+    (bump s, h)
+
+  method hyps s hs = match Dq.front hs with
+    | None -> (s, Dq.empty)
+    | Some (h, hs) ->
+        let (s, h) = self#hyp s h in
+        let (s, hs) = self#hyps s hs in
+        (s, Dq.cons h hs)
+
+  method normalize ?(cx = Deque.empty) op args = match op.core with
+    | Lambda (vs, e) ->
+      if List.length vs <> List.length args then begin
+        Util.eprintf ~at:op
+          "@[<v0>Arity mismatch:@,op =@,  %a@,args =@,  @[<v0>%a@]@]@."
+          (Fmt.pp_print_expr (cx, Ctx.dot)) op
+          (Fmtutil.pp_print_delimited
+             (Fmt.pp_print_expr (cx, Ctx.dot))) args ;
+        failwith "Expr.Subst.map#normalize"
+      end else begin
+        let sub = List.fold_left ssnoc (shift 0) args in
+        (self#expr sub e).core
+      end
+    | Apply (op, oargs) ->
+      Apply (op, oargs @ args)
+    | _ -> begin
+      match args with
+        | [] -> op.core
+        | _ -> Apply (op, args)
+    end
+
+end
+
+
+class map_visible_hyp = object (self: 'self)
+    inherit map as super
+    (* Apply a substitution to an expression,
+    visiting only visible hypotheses in a sequent's context.
+    *)
+
+    method hyp s h =
+      begin match h.core with
+      | Fresh _ | Flex _ -> super#hyp s h
+      | Defn (_, _, Hidden, _)
+      | Fact (_, Hidden, _) -> (bump s, h)
+      | Defn _ | Fact _ -> super#hyp s h
+      end
+end

--- a/src/expr/e_subst.ml
+++ b/src/expr/e_subst.ml
@@ -391,7 +391,6 @@ class map = object (self : 'self)
         (s, df :: dfs)
 
   method bounds s bs =
-    (* TODO: need to update `s` from bound to bound ? *)
     let bs = List.map (self#bound s) bs in
     let n = List.length bs in
     let s = bumpn n s in
@@ -400,8 +399,6 @@ class map = object (self : 'self)
   method bound s b =
     let (v, k, dom) = b in
     let dom = match dom with
-        (* TODO: need to bump by 1 incrementally
-        in each consecutive domain bound ? *)
         | Domain d -> Domain (self#expr s d)
         | _ -> dom
         in

--- a/src/expr/e_subst.mli
+++ b/src/expr/e_subst.mli
@@ -36,3 +36,24 @@ val app_spine : sub -> expr list -> expr list
 val extract : sequent -> int -> (sequent * expr) option
 
 val pp_print_sub : E_fmt.ctx -> Format.formatter -> sub -> unit
+
+class map : object
+    method expr     : sub -> expr -> expr
+    method exprs    : sub -> expr list -> expr list
+    method pform    : sub -> pform -> pform
+    method sels     : sub -> sel list -> sel list
+    method sel      : sub -> sel -> sel
+    method sequent  : sub -> sequent -> sub * sequent
+    method defn     : sub -> defn -> sub * defn
+    method defns    : sub -> defn list -> sub * defn list
+    method bounds   : sub -> bound list -> sub * bound list
+    (* TODO: method bound    : sub -> bound -> sub * bound *)
+    method bound    : sub -> bound -> bound
+    method exspec   : sub -> exspec -> exspec
+    method instance : sub -> instance -> instance
+    method hyp      : sub -> hyp -> sub * hyp
+    method hyps     : sub -> hyp Deque.dq -> sub * hyp Deque.dq
+    method normalize : ?cx:hyp Deque.dq -> expr -> expr list -> expr_
+end
+
+class map_visible_hyp : map

--- a/src/expr/e_substitutive.ml
+++ b/src/expr/e_substitutive.ml
@@ -1,0 +1,261 @@
+(*
+    expr/e_substitutive.ml --- compute substitutivity information
+*)
+open Ext
+open Property
+
+open E_t
+
+
+type substitutive_args = bool array
+
+let substitutive_arg: substitutive_args pfuncs =
+    Property.make "Expr.Substitutive.substitutive_arg"
+let has_substitutive x = Property.has x substitutive_arg
+let get_substitutive x = Property.get x substitutive_arg
+let get_substitutive_arg x n =
+    assert (has_substitutive x);
+    let arr = get_substitutive x in
+    Array.get arr n
+
+
+let make_lambda_hyps params =
+    let hyps = List.map
+        (fun (v, shp) ->
+            Fresh (v, shp, Unknown, Unbounded) @@ v)
+        params in
+    hyps
+
+
+class compute_substitutivity_array = object (self: 'self)
+    inherit [bool * int * bool ref] E_visit.iter as super
+
+    method compute cx e =
+        match e.core with
+            | Lambda (params, expr) ->
+                let hyps = make_lambda_hyps params in
+                let cx = Deque.append_list cx hyps in
+                let n = List.length params in
+                let f i =
+                    let r = ref true in
+                    let s = (true, i + 1, r) in
+                    self#expr (s, cx) expr;
+                    !r in
+                assert (n > 0);
+                Array.init n f
+            | _ ->
+                Array.make 0 true
+
+    method expr (((scope, index, r), cx) as scx) e =
+        match e.core with
+        | Ix n when (n = index) && (scope = false) ->
+            r := false
+        | Lambda (params, expr) ->
+            let hyps = make_lambda_hyps params in
+            let cx = Deque.append_list cx hyps in
+            let index = index + List.length params in
+            let s = (scope, index, r) in
+            self#expr (s, cx) expr
+        | Apply ({core=Internal (Builtin.Prime | StrongPrime
+                | Box _ | Diamond | ENABLED | UNCHANGED)},
+                [expr]) ->
+            let scope = false in
+            let s = (scope, index, r) in
+            self#expr (s, cx) expr
+        | Sub (_, e1, e2)
+        | Apply ({core=Internal (Builtin.Leadsto | Actplus | Cdot)},
+                [e1; e2]) ->
+            let scope = false in
+            let s = (scope, index, r) in
+            self#expr (s, cx) e1;
+            self#expr (s, cx) e2
+        | Apply ({core=Ix n}, args) ->
+            let hyp = E_t.get_val_from_id cx n in
+            begin match hyp.core with
+            | Defn ({core = Operator _} as op, _, _, _) ->
+                List.iteri
+                    (fun i arg ->
+                        let scope = get_substitutive_arg op i in
+                        let s = (scope, index, r) in
+                        self#expr (s, cx) arg)
+                    args
+            | _ -> super#expr scx e
+            end
+        | Tquant (_, ls, _) ->
+            let index = index + (List.length ls) in
+            let s = (scope, index, r) in
+            super#expr (s, cx) e
+        | Choose (v, optdom, expr) ->
+            let bound = match optdom with
+                | None -> Unbounded
+                | Some dom ->
+                    self#expr scx dom ;
+                    Bounded (dom, Visible)
+                in
+            let hyp = Fresh (v, Shape_expr, Constant, bound) @@ v in
+            let index = index + 1 in
+            let cx = Deque.snoc cx hyp in
+            let s = (scope, index, r) in
+            let scx = (s, cx) in
+            self#expr scx expr
+        | SetSt (v, dom, expr) ->
+            self#expr scx dom;
+            let bound = Bounded (dom, Visible) in
+            let hyp = Fresh (v, Shape_expr, Constant, bound) @@ v in
+            let cx = Deque.snoc cx hyp in
+            let index = index + 1 in
+            let s = (scope, index, r) in
+            let scx = (s, cx) in
+            self#expr scx expr
+        | _ -> super#expr scx e
+
+    method defn scx df =
+        let ((scope, index, r), cx) = super#defn scx df in
+        let index = index + 1 in
+        let scx = ((scope, index, r), cx) in
+        scx
+
+    method bounds scx bs =
+        let ((scope, index, r), cx) = super#bounds scx bs in
+        let index = index + (List.length bs) in
+        let scx = ((scope, index, r), cx) in
+        scx
+
+    method instance scx inst =
+        assert false  (* `INSTANCE` statements have been expanded *)
+
+    method bound scx b =
+        assert false  (* unused method *)
+
+    method hyp scx h =
+        assert false  (* sequents do not occur in expressions *)
+
+    method hyps scx hs =
+        assert false  (* sequents do not occur in expressions *)
+end
+
+
+let make_array cx e =
+    let visitor = new compute_substitutivity_array in
+    visitor#compute cx e
+
+
+let shape_to_arity shp =
+    match shp with
+    | Shape_expr -> assert false
+    | Shape_op n -> assert (n >= 1); n
+
+
+class substitutive_op_visitor = object (self: 'self)
+    inherit [unit] E_visit.map_visible_hyp as super
+
+    method expr ((s, cx) as scx) e =
+        if has_substitutive e then
+            e
+        else begin
+        match e.core with
+        | Apply ({core=Internal
+                (Mem | Notmem | Subseteq | Setminus | Cap | Cup)} as op,
+                args) ->
+            let n = List.length args in
+            assert (n = 2);
+            let args = List.map (self#expr scx) args in
+            let expr = Apply (op, args) @@ e in
+            let e_ = E_levels.compute_level cx e in
+            let level = E_levels.get_level e_ in
+            let ar = if level = 0 then
+                    Array.make n true
+                else
+                    Array.make n false in
+            assign expr substitutive_arg ar
+        | Apply ({core=Internal
+                (Prime | StrongPrime | ENABLED | Cdot | UNCHANGED
+                    | Box _ | Diamond | Leadsto | Actplus)} as op, args) ->
+            let n = List.length args in
+            assert (n >= 1);
+            let args = List.map (self#expr scx) args in
+            let expr = Apply (op, args) @@ e in
+            let ar = Array.make n false in
+            assign expr substitutive_arg ar
+        | Sub (modal_op, action, subscript) ->
+            let action = self#expr scx action in
+            let subscript = self#expr scx subscript in
+            let expr = Sub (modal_op, action, subscript) @@ e in
+            let ar = Array.make 2 false in
+            assign expr substitutive_arg ar
+        | Apply ({core=Ix n} as op_index, args) ->
+            let n_args = List.length args in
+            assert (n_args > 0);
+            let hyp = E_t.get_val_from_id cx n in
+            begin match hyp.core with
+            | Fresh (name, shp, kind, _) ->
+                begin
+                let arity = shape_to_arity shp in
+                assert (arity = n_args);
+                let is_constant_op = match kind with
+                    | Constant -> true
+                    | _ -> false in
+                let args = List.map (self#expr scx) args in
+                let ar = Array.make n_args is_constant_op in
+                let op = assign op_index substitutive_arg ar in
+                let expr = Apply (op, args) @@ e in
+                let ar = Array.make n_args is_constant_op in
+                assign expr substitutive_arg ar
+                end
+            | Defn ({core=Operator (_, expr)}, _, _, _) ->
+                begin match expr.core with
+                | Lambda (params, _) ->
+                    let args = List.map (self#expr scx) args in
+                    let is_subst = not (List.exists
+                        (fun (_, shp) -> match shp with
+                            | Shape_op _ -> true
+                            | _ -> false)
+                        params) in
+                    let ar = Array.make n_args is_subst in
+                    let op = assign op_index substitutive_arg ar in
+                    let expr = Apply (op, args) @@ e in
+                    let ar = Array.make n_args is_subst in
+                    assign expr substitutive_arg ar
+                | _ ->
+                    let e = super#expr scx e in
+                    let ar = Array.make n_args true in
+                    assign e substitutive_arg ar
+                end
+            | _ ->
+                (* TODO: logic in support of this pattern case *)
+                let args = List.map (self#expr scx) args in
+                let ar = Array.make n_args true in
+                let op = assign op_index substitutive_arg ar in
+                let expr = Apply (op, args) @@ e in
+                let ar = Array.make n_args true in
+                assign expr substitutive_arg ar
+            end
+        | _ -> super#expr scx e
+        end
+
+    method hyp scx h =
+        if has_substitutive h then
+            (scx, h)
+        else begin
+        match h.core with
+        | Defn ({core=Operator (name, expr)} as op, wd, visibility, e) ->
+            let expr = self#expr scx expr in
+            let ar = make_array (snd scx) expr in
+            let op = Operator (name, expr) @@ op in
+            let op = assign op substitutive_arg ar in
+            let h = Defn (op, wd, visibility, e) @@ h in
+            (E_visit.adj scx h, h)
+        | _ -> super#hyp scx h
+        end
+
+    method pform scx p =
+        if has_substitutive p then p else super#pform scx p
+
+    method defn scx p =
+        if has_substitutive p then p else super#defn scx p
+end
+
+
+let compute_subst cx e =
+    let visitor = new substitutive_op_visitor in
+    visitor#expr ((), cx) e

--- a/src/expr/e_substitutive.mli
+++ b/src/expr/e_substitutive.mli
@@ -1,0 +1,17 @@
+(*
+    expr/e_substitutive.mli --- compute substitutivity information
+*)
+open Property
+
+open E_t
+
+
+type substitutive_args = bool array
+
+
+val substitutive_arg: substitutive_args pfuncs
+val has_substitutive: 'a Property.wrapped -> bool
+val get_substitutive: 'a Property.wrapped -> substitutive_args
+val get_substitutive_arg: 'a Property.wrapped -> int -> bool
+
+val compute_subst: ctx -> expr -> expr

--- a/src/expr/e_t.ml
+++ b/src/expr/e_t.ml
@@ -2,11 +2,12 @@
  * expressions
  *
  *
- * Copyright (C) 2008-2010  INRIA and Microsoft Corporation
+ * Copyright (C) 2008-2019  INRIA and Microsoft Corporation
  *)
 
 Revision.f "$Rev$";;
 
+open Ext
 open Property
 open Util
 
@@ -36,38 +37,65 @@ type shape =
 type expr = expr_ wrapped
 and expr_ =
     (* operators *)
+    (* de Bruijn index *)
   | Ix of int
+    (* identifier name *)
   | Opaque of string
+    (* builtin operator *)
   | Internal of Builtin.builtin
+    (* `LAMBDA` and
+    signatures of operator definitions *)
   | Lambda of (hint * shape) list * expr
-    (* sequents *)
+    (* sequents (`ASSUME`/`PROVE` with definitions from
+    module scope) *)
   | Sequent of sequent
-    (* unified module and subexpression references *)
+    (* unified module and subexpression references (Foo!Op) *)
   | Bang of expr * sel list
     (* ordinary TLA+ expressions *)
+    (* operator application `Op(arg1, arg2)` *)
   | Apply of expr * expr list
+    (* Expression annotated with prover directive. *)
   | With of expr * Method.t
+    (* Ternary conditional `IF P THEN A ELSE B` *)
   | If of expr * expr * expr
+    (* Conjunction and disjunction lists *)
   | List of bullet * expr list
+    (* `LET` *)
   | Let of defn list * expr
+    (* rigid quantification `\E` or `\A` *)
   | Quant of quantifier * bounds * expr
+    (* temporal quantification `\EE` or `\AA` *)
   | Tquant of quantifier * hint list * expr
+    (* `CHOOSE` *)
   | Choose of hint * expr option * expr
+    (* `{x \in S:  P(x)}` *)
   | SetSt of hint * expr * expr
+    (* `{f(x):  x \in S}` *)
   | SetOf of expr * bounds
+    (* `{1, 2}` *)
   | SetEnum of expr list
+    (* Cartesian product *)
   | Product of expr list
+    (* `<<1, 2>>` *)
   | Tuple of expr list
+    (* Function constructor `[x \in S |-> e]` *)
   | Fcn of bounds * expr
+    (* `f[x]` *)
   | FcnApp of expr * expr list
   | Arrow of expr * expr
+  (* [h: S, ...] *)
   | Rect of (string * expr) list
+  (* [h |-> v, ...] *)
   | Record of (string * expr) list
   | Except of expr * exspec list
   | Dot of expr * string
+    (* Subscripted (action) expressions:  `[A]_v` and `<< A >>_v` *)
   | Sub of modal_op * expr * expr
+    (* Temporal subscripted expressions:  `[][A]_v` and `<><< A >>_v` *)
   | Tsub of modal_op * expr * expr
+    (* `WF_` and `SF_` *)
   | Fair of fairness_op * expr * expr
+    (* `CASE` *)
   | Case of (expr * expr) list * expr option
   | String of string
   | Num of string * string
@@ -107,30 +135,72 @@ and bound_domain =
   | Domain of expr
   | Ditto
 
-(** Definitions *)
+(** Definitions
+
+- Used in LET scope.
+- Used within Defn when in antecedents.
+*)
 and defn = defn_ wrapped
 and defn_ =
+    (* recursive operator definition
+    Results by expanding in the function `hyps_of_modunit`
+    a `RECURSIVE` section represented by `Module.T.Recursives`.
+    *)
   | Recursive of hint * shape
+    (*
+    operator definition:
+    - name `hint`
+    - body `expr`:
+      - if arity is <_, ... >, then a `Lambda (args, expr)`, with:
+        - `args`: the signature of the operator definition
+        - `expr`: the expression of the body of the operator definition.
+      - if arity is _, then the expression of the definition body.
+    *)
   | Operator of hint * expr
+    (* parameter substitution for instantiation *)
   | Instance of hint * instance
   | Bpragma of hint * expr * ((hint * backend_args) list list)
 
 (** Instance *)
 and instance = {
-  (** arguments of the instance *)
+  (** arguments of the statement `INSTANCE`, for example:
+
+    let wrap (x: string): hint = noprops x in
+    List.map wrap ["x"; "y"]
+  *)
   inst_args : hint list ;
 
-  (** the instanced module *)
+  (** name of the instantiated module *)
   inst_mod  : string ;
 
-  (** substitution *)
+  (** substitution defined by the statement `INSTANCE`, for example:
+
+    let wrap (x: string): hint = noprops x in
+    let expr1 = noprops (Opaque "p")
+    let expr2 =
+        let op = noprops (Internal Builtin.Plus) in
+        let arg1 = noprops (Opaque "q") in
+        let arg2 = noprops (Opaque "r") in
+        noprops (op [arg1; arg2])
+    in
+
+    [ (wrap("x"), expr1);
+      (wrap("y"), expr2) ]
+  *)
   inst_sub  : (hint * expr) list ;
 }
 
 (** The [sequent] type represents (a generalisation of) TLA+
     ASSUME/PROVE forms *)
 and sequent = {
-  (** antecedents *)
+  (** antecedents:
+  These include all definitions from module scope.
+  The definitions are annotated as `Visible` or `Hidden` (see the component
+  `visibility` of the constructor `Defn` of the type `hyp_` below).
+  Proof obligations are sequents. Visible definitions in a proof obligation are
+  expanded in `backends/prep.ml`. Hidden definitions remain in the
+  sequent's context.
+  *)
   context : hyp Deque.dq ;
 
   (** succeedent (always a TLA+ expression) *)
@@ -152,11 +222,21 @@ and backend_action =
   | All | Once
 
 (** Antecedents of a sequent *)
+and ctx = hyp Deque.dq
 and hyp = hyp_ wrapped
 and hyp_ =
+    (* declared identifier with:
+      - name `hint.core`
+      - arity `shape`
+      - level `kind` (unspecified level if `kind` is `Unknown`)
+      - domain bound `hdom`
+    *)
   | Fresh of hint * shape * kind * hdom
+    (* declared variable named `hint.core` *)
   | Flex of hint
+    (* operator definition in module or `LET` scope *)
   | Defn of defn * wheredef * visibility * export
+    (* theorem when it appears as hypothesis *)
   | Fact of expr * visibility * time
 
 and hdom = Unbounded | Bounded of expr * visibility
@@ -185,7 +265,202 @@ let hyp_name h = match h.core with
   -> nm.core
   | Fact (_, _,_) -> "_"
 
+
+let visibility_to_string = function
+    | Visible -> "visible"
+    | Hidden -> "hidden"
+
+
+let print_cx cx =
+    (* Print the hypotheses of context `cx`. *)
+    print_string "\nContext of sequent (hypotheses):\n";
+    let print_hyp i hyp =
+        let idx = string_of_int i in
+        print_string ("\nHypothesis with index " ^ idx ^ " :\n");
+        let msg = match hyp.core with
+            | Flex name ->
+                "Variable `" ^ name.core ^ "`\n"
+            | Fresh (name, arity, kind, dom) ->
+                "Constant operator `" ^ name.core ^ "`\n"
+            | Defn (df, _, visibility, _) ->
+                let name = match df.core with
+                    | Operator (name, expr) -> name
+                    | Bpragma (name, expr, backend_args) -> name
+                    | Instance (name, instance) -> name
+                    | Recursive (name, arity) -> name
+                    in
+                let visible = visibility_to_string visibility in
+                "Defined operator `" ^ name.core ^ "` (" ^ visible ^ ")\n"
+            | Fact (expr, visibility, _) ->
+                let visible = visibility_to_string visibility in
+                "Fact (" ^ visible ^ ")\n"
+            in
+        print_string msg
+        in
+    Deque.iter print_hyp cx
+
+
+let cx_front cx n =
+    (* front of queue `cx` omitting the `n` last elements. *)
+    let k = (Deque.size cx) - n in
+    let new_cx = Deque.first_n cx k in
+    new_cx
+
+
+let scx_front scx n =
+    (* `scx` with `n` last elements omitted from `snd scx`. *)
+    let cx = snd scx in
+    let new_cx = cx_front cx n in
+    let new_scx = (fst scx, new_cx) in
+    new_scx
+
+
+let find_hyp_named
+        (cx: hyp Deque.dq)
+        (name: string): (int * hyp) =
+    (* Return the depth in the context `cx` of
+    the hypothesis with `name`, and
+    the hypothesis expression.
+    *)
+    let name_test hyp = (name = (hyp_name hyp)) in
+    let pair = Deque.find ~backwards:true cx name_test in
+    let pair = Option.get pair in
+    let (depth, expr) = pair in
+    (depth, expr)
+
+
+let expr_locus expr = match Util.query_locus expr with
+    | None -> None
+    | Some loc ->
+        let loc_str = Loc.string_of_locus ~cap:true loc in
+        Some loc_str
+
+
+let format_locus expr = match (expr_locus expr) with
+    | None -> "<unknown location>"
+    | Some loc_str -> loc_str
+
+
 let exprify_sequent sq =
   if Deque.null sq.context
   then sq.active.core
   else Sequent sq
+
+
+let shape_to_arity (shape: shape): int =
+    (* Return operator arity that corresponds to `shape`. *)
+    let arity = match shape with
+        | Shape_expr -> 0
+        | Shape_op arity -> assert (arity >= 1); arity
+        in
+    assert (arity >= 0);
+    arity
+
+
+type hyp_numbers = {
+    n_variables: int;
+    n_constants: int;
+    n_visible_defs: int;
+    n_hidden_defs: int;
+    n_visible_facts: int;
+    n_hidden_facts: int;
+    visible_definition_names: string list;
+    hidden_definition_names: string list;
+    visible_fact_names: expr list;
+    hidden_fact_names: expr list}
+
+
+let rec number_of_hyp (hyps: ctx) =
+    let n_variables = ref 0 in
+    let n_constants = ref 0 in
+    let n_visible_defs = ref 0 in
+    let n_hidden_defs = ref 0 in
+    let n_visible_facts = ref 0 in
+    let n_hidden_facts = ref 0 in
+    let visible_definition_names = ref [] in
+    let hidden_definition_names = ref [] in
+    let visible_fact_names = ref [] in
+    let hidden_fact_names = ref [] in
+    let rec recurse hyps =
+        begin match Deque.front hyps with
+        | None -> ()
+        | Some (h, hs) -> begin match h.core with
+            | Fresh _ -> incr n_constants
+            | Flex _ -> incr n_variables
+            | Defn ({core=Operator (name, _)}, _, Visible, _)
+            | Defn ({core=Bpragma (name, _, _)}, _, Visible, _) ->
+                incr n_visible_defs;
+                visible_definition_names :=
+                    name.core :: !visible_definition_names
+            | Defn ({core=Operator (name, _)}, _, Hidden, _)
+            | Defn ({core=Bpragma (name, _, _)}, _, Hidden, _) ->
+                incr n_hidden_defs;
+                hidden_definition_names :=
+                    name.core :: !hidden_definition_names
+            | Fact (expr, Hidden, _) ->
+                incr n_hidden_facts;
+                visible_fact_names :=
+                    expr :: !visible_fact_names
+            | Fact (expr, Visible, _) ->
+                incr n_visible_facts;
+                hidden_fact_names :=
+                    expr :: !hidden_fact_names
+            | _ -> assert false
+            end;
+            recurse hs
+        end in
+    recurse hyps;
+    let r = {
+        n_variables=(!n_variables);
+        n_constants=(!n_constants);
+        n_visible_defs=(!n_visible_defs);
+        n_hidden_defs=(!n_hidden_defs);
+        n_visible_facts=(!n_visible_facts);
+        n_hidden_facts=(!n_hidden_facts);
+        visible_definition_names=(!visible_definition_names);
+        hidden_definition_names=(!hidden_definition_names);
+        visible_fact_names=(!visible_fact_names);
+        hidden_fact_names=(!hidden_fact_names)}
+    in
+    r
+
+
+let sequent_stats (sq: sequent) =
+    (* Count and print number of each kind of hypothesis. *)
+    let n_hyp = Deque.size sq.context in
+    let nums = number_of_hyp sq.context in
+    let msg = (
+        "\nNumber of sequent hypotheses: " ^ (string_of_int n_hyp) ^
+        "\nNumber of constants: " ^ (string_of_int nums.n_constants) ^
+        "\nNumber of variables: " ^ (string_of_int nums.n_variables) ^
+        "\nNumber of visible definitions: " ^
+            (string_of_int nums.n_visible_defs) ^
+        "\nNumber of hidden definitions: " ^
+            (string_of_int nums.n_hidden_defs) ^
+        "\nNumber of visible facts: " ^
+            (string_of_int nums.n_visible_facts) ^
+        "\nNumber of hidden facts: " ^ (string_of_int nums.n_hidden_facts) ^
+        "\n\n" ^
+        "\nVisible definition names:\n" ^
+        (String.concat "\n" nums.visible_definition_names) ^
+        "\nHidden definition names:\n" ^
+        (String.concat "\n" nums.hidden_definition_names) ^
+        "\nVisible fact names:\n")
+        in
+    Util.printf ~prefix:"[INFO]: " "%s" msg;
+    (*
+    let print_fact e =
+        let print = Expr.Fmt.pp_print_expr in
+        let cx = (Deque.empty, Ctx.dot) in
+        let fmt = Format.std_formatter in
+        print cx fmt e
+        in
+    List.iter print_fact nums.visible_fact_names;
+    print_string "Hidden fact names:\n";
+    List.iter print_fact nums.hidden_fact_names; *)
+    n_hyp
+
+let enabledaxioms : bool pfuncs =
+  Property.make "Module.Elab.enabledaxioms"
+let has_enabledaxioms x = Property.has x enabledaxioms
+let get_enabledaxioms x = Property.get x enabledaxioms

--- a/src/expr/e_t.mli
+++ b/src/expr/e_t.mli
@@ -147,6 +147,7 @@ and backend_action =
   | All | Once
 
 (** Antecedents of a sequent *)
+and ctx = hyp Deque.dq
 and hyp = hyp_ wrapped
 and hyp_ =
   | Fresh of hint * shape * kind * hdom
@@ -170,5 +171,19 @@ val get_val_from_id : 'hyp Deque.dq -> int -> 'hyp;;
 (* fmt.ml *)
 val hyp_name : hyp_ Property.wrapped -> string;;
 
+val print_cx: ctx -> unit
+
+val find_hyp_named : ctx -> string -> int * hyp
+val cx_front : ctx -> int -> ctx
+val scx_front : 'a * ctx -> int -> 'a * ctx
+val format_locus : 'a wrapped -> string
+val shape_to_arity : shape -> int
+
 (* anon.ml *)
 val exprify_sequent : sequent -> expr_;;
+
+val sequent_stats : sequent -> int
+
+val enabledaxioms : bool pfuncs
+val has_enabledaxioms : 'a Property.wrapped -> bool
+val get_enabledaxioms : 'a Property.wrapped -> bool

--- a/src/expr/e_tla_norm.mli
+++ b/src/expr/e_tla_norm.mli
@@ -6,6 +6,7 @@
  * Copyright (C) 2013  INRIA and Microsoft Corporation
  *)
 
+val rewrite_unch : E_t.expr -> E_t.expr
 val expand_unchanged : unit E_visit.scx -> E_t.expr -> E_t.expr
 val expand_action : unit E_visit.scx -> E_t.expr -> E_t.expr
 val expand_leadsto : unit E_visit.scx -> E_t.expr -> E_t.expr

--- a/src/expr/e_visit.ml
+++ b/src/expr/e_visit.ml
@@ -435,7 +435,7 @@ class virtual ['s] map_visible_hyp = object (self : 'self)
       | Defn (df, wd, Visible, ex) ->
           let h = Defn (self#defn scx df, wd, Visible, ex) @@ h in
           (adj scx h, h)
-      | Fact (e, vis, tm) ->
+      | Fact (e, Visible, tm) ->
           let h = Fact (self#expr scx e, Visible, tm) @@ h in
           (adj scx h, h)
 end
@@ -482,16 +482,13 @@ let collect_unprimed_vars cx e =
             | Apply ({core=Internal Prime}, _) ->
                 assert (not prime_scope)
             | Ix n ->
-                begin
                 assert (n >= 1);
                 assert (not prime_scope);
                 let hyp = E_t.get_val_from_id cx n in
-                match hyp.core with
+                begin match hyp.core with
                     | Flex name ->
                         let var_name = name.core in
-                        if (not (Hashtbl.mem
-                                unprimed_vars var_name)) then
-                            Hashtbl.add unprimed_vars var_name ()
+                        Hashtbl.replace unprimed_vars var_name ()
                     | _ -> ()
                 end
             | Apply ({core=Internal ENABLED}, _) ->

--- a/src/expr/e_visit.ml
+++ b/src/expr/e_visit.ml
@@ -54,7 +54,10 @@ class virtual ['s] map = object (self : 'self)
     | Bang (e, sels) ->
         Bang (self#expr scx e, List.map (self#sel scx) sels) @@ oe
     | Lambda (vs, e) ->
-        let scx = adjs scx (List.map (fun (v, shp) -> Fresh (v, shp, Unknown, Unbounded) @@ v) vs) in
+        let scx = self#adjs scx
+            (List.map
+                (fun (v, shp) -> Fresh (v, shp, Unknown, Unbounded) @@ v)
+                vs) in
         Lambda (vs, self#expr scx e) @@ oe
     | String s ->
         String s @@ oe
@@ -78,7 +81,7 @@ class virtual ['s] map = object (self : 'self)
         let (scx, bs) = self#bounds scx bs in
         Quant (q, bs, self#expr scx e) @@ oe
     | Tquant (q, vs, e) ->
-        let scx = adjs scx (List.map (fun v -> Flex v @@ v) vs) in
+        let scx = self#adjs scx (List.map (fun v -> Flex v @@ v) vs) in
         Tquant (q, vs, self#expr scx e) @@ oe
     | Choose (v, optdom, e) ->
         let optdom = Option.map (self#expr scx) optdom in
@@ -86,12 +89,12 @@ class virtual ['s] map = object (self : 'self)
           | None -> Fresh (v, Shape_expr, Constant, Unbounded) @@ v
           | Some dom -> Fresh (v, Shape_expr, Constant, Bounded (dom, Visible)) @@ v
         in
-        let scx = adj scx h in
+        let scx = self#adj scx h in
         let e = self#expr scx e in
         Choose (v, optdom, e) @@ oe
     | SetSt (v, dom, e) ->
         let dom = self#expr scx dom in
-        let scx = adj scx (Fresh (v, Shape_expr, Constant, Bounded (dom, Visible)) @@ v) in
+        let scx = self#adj scx (Fresh (v, Shape_expr, Constant, Bounded (dom, Visible)) @@ v) in
         let e = self#expr scx e in
         SetSt (v, dom, e) @@ oe
     | SetOf (e, bs) ->
@@ -161,7 +164,7 @@ class virtual ['s] map = object (self : 'self)
     | [] -> (scx, [])
     | df :: dfs ->
         let df = self#defn scx df in
-        let scx = adj scx (Defn (df, User, Visible, Local) @@ df) in
+        let scx = self#adj scx (Defn (df, User, Visible, Local) @@ df) in
         let (scx, dfs) = self#defns scx dfs in
         (scx, df :: dfs)
 
@@ -174,7 +177,7 @@ class virtual ['s] map = object (self : 'self)
     let hs = List.map begin
       fun (v, k, _) -> Fresh (v, Shape_expr, k, Unbounded) @@ v
     end bs in
-    let scx = adjs scx hs in
+    let scx = self#adjs scx hs in
     (scx, bs)
 
   method bound scx b =
@@ -192,7 +195,7 @@ class virtual ['s] map = object (self : 'self)
   method instance scx i =
     let scx = List.fold_left begin
       fun scx v ->
-        adj scx (Fresh (v, Shape_expr, Unknown, Unbounded) @@ v)
+        self#adj scx (Fresh (v, Shape_expr, Unknown, Unbounded) @@ v)
     end scx i.inst_args in
     { i with inst_sub = List.map (fun (v, e) -> (v, self#expr scx e)) i.inst_sub }
 
@@ -203,17 +206,17 @@ class virtual ['s] map = object (self : 'self)
           | Bounded (r, rvis) -> Bounded (self#expr scx r, rvis)
         in
         let h = Fresh (nm, shp, lc, dom) @@ h in
-        (adj scx h, h)
+        (self#adj scx h, h)
     | Flex s ->
         let h = Flex s @@ h in
-        (adj scx h, h)
+        (self#adj scx h, h)
     | Defn (df, wd, vis, ex) ->
         let df = self#defn scx df in
         let h = Defn (df, wd, vis, ex) @@ h in
-        (adj scx h, h)
+        (self#adj scx h, h)
     | Fact (e, vis, tm) ->
         let h = Fact (self#expr scx e, vis, tm) @@ h in
-        (adj scx h, h)
+        (self#adj scx h, h)
 
   method hyps scx hs = match Dq.front hs with
     | None -> (scx, Dq.empty)
@@ -221,6 +224,14 @@ class virtual ['s] map = object (self : 'self)
         let (scx, h) = self#hyp scx h in
         let (scx, hs) = self#hyps scx hs in
         (scx, Dq.cons h hs)
+
+  method adj (s, cx) h =
+    (s, Dq.snoc cx h)
+
+  method adjs scx = function
+    | [] -> scx
+    | h :: hs ->
+        self#adjs (self#adj scx h) hs
 
 end
 
@@ -238,7 +249,8 @@ class virtual ['s] iter = object (self : 'self)
         self#expr scx e ;
         List.iter (self#sel scx) sels
     | Lambda (vs, e) ->
-        let scx = adjs scx (List.map (fun (v, shp) -> Fresh (v, shp, Unknown, Unbounded) @@ v) vs) in
+        let scx = adjs scx (List.map (fun (v, shp) ->
+            Fresh (v, shp, Unknown, Unbounded) @@ v) vs) in
         self#expr scx e
     | Apply (op, es) ->
         self#expr scx op ;
@@ -398,5 +410,286 @@ class virtual ['s] iter = object (self : 'self)
         let scx = self#hyp scx h in
         let scx = self#hyps scx hs in
         scx
+
+end
+
+class virtual ['s] map_visible_hyp = object (self : 'self)
+    (* Map expressions, visiting only visible hypotheses. *)
+    inherit ['s] map as super
+
+    method hyp scx h = match h.core with
+      | Fresh (nm, shp, lc, dom) ->
+          let dom = match dom with
+            | Unbounded -> Unbounded
+            | Bounded (r, rvis) -> Bounded (self#expr scx r, rvis)
+          in
+          let h = Fresh (nm, shp, lc, dom) @@ h in
+          (adj scx h, h)
+      | Flex s ->
+          let h = Flex s @@ h in
+          (adj scx h, h)
+      | Defn (_, _, Hidden, _)
+      | Fact (_, Hidden, _) ->
+        (* TODO: what about mutable properties of `h` ? *)
+        (adj scx h, h)
+      | Defn (df, wd, Visible, ex) ->
+          let h = Defn (self#defn scx df, wd, Visible, ex) @@ h in
+          (adj scx h, h)
+      | Fact (e, vis, tm) ->
+          let h = Fact (self#expr scx e, Visible, tm) @@ h in
+          (adj scx h, h)
+end
+
+class virtual ['s] iter_visible_hyp = object (self : 'self)
+    (* Iterate on expressions, visiting only visible hypotheses. *)
+    inherit ['s] iter as super
+
+    method hyp scx h =
+      begin
+        match h.core with
+          | Fresh (nm, _, lc, e) -> begin
+              match e with
+                | Bounded (dom, _) -> self#expr scx dom
+                | Unbounded -> ()
+            end
+          | Flex s ->
+              ()
+          | Defn (_, _, Hidden, _)
+          | Fact (_, Hidden, _) ->
+              ()
+          | Defn (df, _, Visible, _) ->
+              ignore (self#defn scx df)
+          | Fact (e, Visible, _) ->
+              self#expr scx e
+      end ; adj scx h
+end
+
+
+let set_to_list table =
+        (* `Hashtbl` keys to `List`. *)
+    let seq = Hashtbl.to_seq_keys table in
+    Stdlib.List.of_seq seq
+
+
+let collect_unprimed_vars cx e =
+    let unprimed_vars = Hashtbl.create 16 in
+    let visitor =
+        object (self: 'self)
+        inherit [bool] iter_visible_hyp as super
+
+        method expr (((prime_scope: bool), cx) as scx) e =
+            match e.core with
+            | Apply ({core=Internal Prime}, _) ->
+                assert (not prime_scope)
+            | Ix n ->
+                begin
+                assert (n >= 1);
+                assert (not prime_scope);
+                let hyp = E_t.get_val_from_id cx n in
+                match hyp.core with
+                    | Flex name ->
+                        let var_name = name.core in
+                        if (not (Hashtbl.mem
+                                unprimed_vars var_name)) then
+                            Hashtbl.add unprimed_vars var_name ()
+                    | _ -> ()
+                end
+            | Apply ({core=Internal ENABLED}, _) ->
+                if (not prime_scope) then
+                    self#expr scx e
+            | Apply ({core=Internal Cdot}, [arg1; _]) ->
+                assert (not prime_scope);
+                self#expr scx arg1
+            | Apply ({core=Internal UNCHANGED}, [arg]) ->
+                assert (not prime_scope);
+                self#expr scx arg
+            | Sub (_, action, subscript) ->
+                assert (not prime_scope);
+                self#expr scx action;
+                self#expr scx subscript
+            | _ -> super#expr scx e
+    end
+    in
+    let prime_scope = false in
+    let scx = (prime_scope, cx) in
+    visitor#expr scx e;
+    set_to_list unprimed_vars
+
+
+let collect_primed_vars cx e =
+    let primed_vars = Hashtbl.create 16 in
+    let visitor =
+        object (self: 'self)
+        inherit [bool] iter_visible_hyp as super
+
+        method expr (((prime_scope: bool), cx) as scx) e =
+            match e.core with
+            | Apply ({core=Internal Prime}, [arg]) ->
+                assert (not prime_scope);
+                self#expr (true, cx) arg
+            | Ix n ->
+                begin
+                assert (n >= 1);
+                let hyp = E_t.get_val_from_id cx n in
+                match hyp.core with
+                    | Flex name ->
+                        let var_name = name.core in
+                        if (prime_scope &&
+                                not (Hashtbl.mem primed_vars var_name)) then
+                            Hashtbl.add primed_vars var_name ()
+                    | _ -> ()
+                end
+            | Apply ({core=Internal ENABLED}, _) ->
+                assert (not prime_scope)
+            | Apply ({core=Internal Cdot}, [_; arg2]) ->
+                assert (not prime_scope);
+                self#expr scx arg2
+            | Apply ({core=Internal UNCHANGED}, [arg]) ->
+                assert (not prime_scope);
+                let prime_scope_ = true in
+                let scx_ = (prime_scope_, cx) in
+                self#expr scx_ arg
+            | Sub (_, action, subscript) ->
+                assert (not prime_scope);
+                self#expr scx action;
+                let prime_scope_ = true in
+                let scx_ = (prime_scope_, cx) in
+                self#expr scx_ subscript
+            | _ -> super#expr scx e
+    end
+    in
+    let prime_scope = false in
+    let scx = (prime_scope, cx) in
+    visitor#expr scx e;
+    set_to_list primed_vars
+
+
+class virtual ['s] map_rename = object (self : 'self)
+  (* Rename hypotheses. The renaming of identifiers is implemented in the
+  method `rename`.
+  *)
+  inherit ['s] map as super
+
+  method expr (scx : 's scx) oe =
+    let cx = snd scx in
+    match oe.core with
+    | Lambda (signature, e) ->
+        let hyps = (List.map
+            (fun (v, shp) -> Fresh (v, shp, Unknown, Unbounded) @@ v)
+            signature) in
+        let names = List.map (fun (v, _) -> v) signature in
+        let (hyps, names) = self#renames cx hyps names in
+        let signature = List.map2
+            (fun (_, shp) name -> (name, shp))
+            signature names in
+        let scx = self#adjs scx hyps in
+        Lambda (signature, self#expr scx e) @@ oe
+    | Tquant (q, names, e) ->
+        let hyps = List.map (fun v -> Flex v @@ v) names in
+        let (hyps, names) = self#renames cx hyps names in
+        let scx = self#adjs scx hyps in
+        Tquant (q, names, self#expr scx e) @@ oe
+    | Choose (v, optdom, e) ->
+        let optdom = Option.map (self#expr scx) optdom in
+        let h = match optdom with
+          | None -> Fresh (v, Shape_expr, Constant, Unbounded) @@ v
+          | Some dom -> Fresh (v, Shape_expr, Constant, Bounded (dom, Visible)) @@ v
+        in
+        let (h, v) = self#rename cx h v in
+        let scx = self#adj scx h in
+        let e = self#expr scx e in
+        Choose (v, optdom, e) @@ oe
+    | SetSt (v, dom, e) ->
+        let dom = self#expr scx dom in
+        let hyp = Fresh (v, Shape_expr, Constant, Bounded (dom, Visible)) @@ v in
+        let (hyp, v) = self#rename cx hyp v in
+        let scx = self#adj scx hyp in
+        let e = self#expr scx e in
+        SetSt (v, dom, e) @@ oe
+    | _ -> super#expr scx oe
+
+  method defn scx df =
+    let df = match df.core with
+      | Recursive (nm, shp) -> df
+      | Operator (nm, e) ->
+          { df with core = Operator (nm, self#expr scx e) }
+      | Instance (nm, i) ->
+          { df with core = Instance (nm, self#instance scx i) }
+      | Bpragma(nm,e,l) ->
+          { df with core = Bpragma (nm, self#expr scx e, l) }
+    in
+    df
+
+  method defns scx = function
+    | [] -> (scx, [])
+    | df :: dfs ->
+        let df = self#defn scx df in
+        let hyp = Defn (df, User, Visible, Local) @@ df in
+        let (hyp, _) = self#rename (snd scx) hyp (noprops "") in
+        let df = match hyp.core with
+            | Defn (df, _, _, _) -> df
+            | _ -> assert false in
+        let scx = self#adj scx hyp in
+        let (scx, dfs) = self#defns scx dfs in
+        (scx, df :: dfs)
+
+  method bounds scx bs =
+    let cx = snd scx in
+    let bs = List.map begin
+      fun (v, k, dom) -> match dom with
+        | Domain d -> (v, k, Domain (self#expr scx d))
+        | _ -> (v, k, dom)
+    end bs in
+    let hs = List.map begin
+      fun (v, k, _) -> Fresh (v, Shape_expr, k, Unbounded) @@ v
+    end bs in
+    let names = List.map (fun (v, _, _) -> v) bs in
+    let (hs, names) = self#renames cx hs names in
+    let bs = List.map2 (fun (v, k, dom) name -> (name, k, dom))
+        bs names in
+    let scx = self#adjs scx hs in
+    (scx, bs)
+
+  method instance scx i =
+    assert false  (* `INSTANCE` statements assumed to have been expanded *)
+    (* TODO: call `self#rename` *)
+    (*
+    let scx = List.fold_left begin
+      fun scx v ->
+        self#adj scx (Fresh (v, Shape_expr, Unknown, Unbounded) @@ v)
+    end scx i.inst_args in
+    { i with inst_sub = List.map (fun (v, e) -> (v, self#expr scx e)) i.inst_sub }
+    *)
+
+  method hyp scx h =
+    let cx = snd scx in
+    match h.core with
+    | Fresh (nm, shp, lc, dom) ->
+        let dom = match dom with
+          | Unbounded -> Unbounded
+          | Bounded (r, rvis) -> Bounded (self#expr scx r, rvis)
+        in
+        let h = Fresh (nm, shp, lc, dom) @@ h in
+        let (h, _) = self#rename cx h nm in
+        (self#adj scx h, h)
+    | Flex s ->
+        let h = Flex s @@ h in
+        let (h, _) = self#rename cx h s in
+        (self#adj scx h, h)
+    | Defn (df, wd, vis, ex) ->
+            (* call `self#defns` to ensure calling `self#rename` *)
+        let (_, dfs) = self#defns scx [df] in
+        assert ((List.length dfs) = 1);
+        let df = List.hd dfs in
+        let h = Defn (df, wd, vis, ex) @@ h in
+        (self#adj scx h, h)
+    | Fact (e, vis, tm) ->
+        let h = Fact (self#expr scx e, vis, tm) @@ h in
+        (self#adj scx h, h)
+
+  method renames cx hyps names =
+    List.split (List.map2 (self#rename cx) hyps names)
+
+  method rename cx hyp name = (hyp, name)
 
 end

--- a/src/expr/e_visit.mli
+++ b/src/expr/e_visit.mli
@@ -27,6 +27,8 @@ class virtual ['s] map : object
   method instance : 's scx -> instance -> instance
   method hyp      : 's scx -> hyp -> 's scx * hyp
   method hyps     : 's scx -> hyp Deque.dq -> 's scx * hyp Deque.dq
+  method adj      : 's scx -> hyp -> 's scx
+  method adjs     : 's scx -> hyp list -> 's scx
 end
 
 class virtual ['s] iter : object
@@ -43,3 +45,29 @@ class virtual ['s] iter : object
   method hyp      : 's scx -> hyp -> 's scx
   method hyps     : 's scx -> hyp Deque.dq -> 's scx
 end
+
+class virtual ['s] map_visible_hyp : ['s] map
+class virtual ['s] iter_visible_hyp : ['s] iter
+
+class virtual ['s] map_rename : object
+  method expr     : 's scx -> expr -> expr
+  method pform    : 's scx -> pform -> pform
+  method sel      : 's scx -> sel -> sel
+  method sequent  : 's scx -> sequent -> 's scx * sequent
+  method defn     : 's scx -> defn -> defn
+  method defns    : 's scx -> defn list -> 's scx * defn list
+  method bounds   : 's scx -> bound list -> 's scx * bound list
+  method bound    : 's scx -> bound -> 's scx * bound
+  method exspec   : 's scx -> exspec -> exspec
+  method instance : 's scx -> instance -> instance
+  method hyp      : 's scx -> hyp -> 's scx * hyp
+  method hyps     : 's scx -> hyp Deque.dq -> 's scx * hyp Deque.dq
+  method adj      : 's scx -> hyp -> 's scx
+  method adjs     : 's scx -> hyp list -> 's scx
+  method rename : ctx -> hyp -> Util.hint -> hyp * Util.hint
+  method renames : ctx -> hyp list -> Util.hint list -> hyp list * Util.hint list
+end
+
+val set_to_list: ('a, 'b) Hashtbl.t -> 'a list
+val collect_unprimed_vars: ctx -> expr -> string list
+val collect_primed_vars: ctx -> expr -> string list

--- a/src/frontend/coalesce.ml
+++ b/src/frontend/coalesce.ml
@@ -1,5 +1,8 @@
 (*
- * Copyright (C) 2013  INRIA and Microsoft Corporation
+ * frontend/coalesce.ml
+ *
+ *
+ * Copyright (C) 2013-2019  INRIA and Microsoft Corporation
  *)
 
 Revision.f "$Rev$";;
@@ -14,16 +17,27 @@ open Expr.Subst
 
 let dot = Ctx.dot
 
+
+let string_to_hex s =
+    (* Return hexadecimal digest of string `s`. *)
+    Digest.to_hex (Digest.string s)
+
+
+let shorter_string_to_hex s =
+    (* Return 5-character hexadecimal digest of string `s`. *)
+    String.sub (string_to_hex s) 0 5
+
+
 (* to fix it to use Ix instead of variable names *)
 let crypthash scx cx e =
-  let s =
-    let b = Buffer.create 10 in
-    let fmt = Format.formatter_of_buffer b in
-    Expr.Fmt.pp_print_expr (scx, cx) fmt e ;
-    Format.pp_print_flush fmt () ;
-    Buffer.contents b
-  in
-  "h" ^ String.sub (Digest.to_hex (Digest.string s)) 0 30
+    let s =
+        let b = Buffer.create 10 in
+        let fmt = Format.formatter_of_buffer b in
+        Expr.Fmt.pp_print_expr (scx, cx) fmt e ;
+        Format.pp_print_flush fmt () ;
+        Buffer.contents b
+    in
+    "h" ^ String.sub (string_to_hex s) 0 5
 
 (* for using it with PLTL it is enough to have a trivial coalescing returning a
  * unique constant depending on all symbols in it, TODO make a smarter (according
@@ -31,93 +45,336 @@ let crypthash scx cx e =
 let coalesce cx e =
   Opaque (crypthash cx dot e) @@ e
 
+
 let rec int_compr ls = function
+  (* Return the list of numbers `[m; m-1; ..; 1]`. *)
   | 0 -> ls
-  | m -> m :: (int_compr ls (m-1))
+  | m -> m :: (int_compr ls (m - 1))
+
+
+let indexed_args args =
+    (* Combine each item in `args` with an index to form the list
+    `[(n, args[0]); (n - 1, args[1]); ..; (1, args[n - 1])]`
+    *)
+    let n = List.length args in
+    List.combine (int_compr [] n) args
+
 
 let coalesce_operator cx op args =
-  let nm = match op.core with
-    | Operator (nm, _) -> nm
-    | _ -> failwith "expected operator" in
-  let star e = Opaque "*" @@ e in
-  let args =
-    let map_fun (id, arg) =
-      if (Expr.Constness.is_const arg || Expr.Leibniz.is_leibniz op (id-1)) then star arg
-      else arg in
-    List.map map_fun (List.combine (int_compr [] (List.length args)) args) in
-  coalesce cx (Apply (Opaque nm.core @@ nm, args) @@ op)
+    let nm = match op.core with
+        | Operator (nm, _) -> nm
+        | _ -> failwith "expected operator" in
+    let star e = Opaque "*" @@ e in
+    let args =
+        let map_fun (id, arg) =
+        if (
+                ((Expr.Levels.get_level arg) = 0)
+                || Expr.SubstOp.get_substitutive_arg op (id - 1)) then
+            star arg
+        else
+            arg in
+        List.map map_fun (indexed_args args) in
+    let op_ = Opaque nm.core @@ nm in
+    let expr_ = Apply (op_, args) @@ op in
+    coalesce cx expr_
+
+
+let coalesce_apply cx expr =
+    (* Return string that uniquely describes operator application.
+
+    Uniquely here means up to hash equality.
+    *)
+    match expr.core with
+    | Apply (op, args) ->
+        let op = Expr.SubstOp.compute_subst cx op in
+        let op_name = Expr.Fmt.string_of_expr cx op in
+        let op_e = (Internal TRUE) @@ expr in
+        let defn = Operator (op_name @@ expr, op_e) @@ expr in
+        (* print_string (Expr.Fmt.string_of_expr cx expr); *)
+        assert (
+            (Expr.Levels.has_level expr)
+            && (Expr.SubstOp.has_substitutive expr));
+        coalesce_operator cx defn args
+    | _ -> assert false
+
 
 (* Coalescing of modal operators follows the paper. A main difference is that we
  * do not compute a set of bound rigid variables since all variables are
  * considered bound in TLA
  *)
 module IxSet = Set.Make (
-  struct type t = expr
-  let compare e1 e2 = match (e1.core,e2.core) with
-  | (Ix n, Ix m) -> compare n m
-  | _ -> failwith "illegal type"
+    struct type t = expr
+    let compare e1 e2 = match (e1.core, e2.core) with
+        | (Ix n, Ix m) -> compare n m
+        | _ -> failwith "illegal type"
 end)
 
-let coalesce_modal e =
-  let coalesce_prime_var cx m =
-    Printf.sprintf "%s#prime" (
-      match (get_val_from_id cx m).core with
-      | Fresh (s, _, _, _) | Flex (s) -> s.core
-      | _ -> failwith "expecting only variables but got a Fact or Def"
-    ) in
-  let compute_vars cx e =
-    let vars = ref IxSet.empty in
-    let vars_visitor = object (self)
-      (* a visitor for accumulating free variables indices
-       * in tlapm if m is an id of a bound variable, then n < m are also bound
-       * variables. therefore, we only keep track of the biggest id at each
-       * point*)
-      inherit [int] Expr.Visit.iter as isuper
-      method expr ((max_bound_id, cx) as scx) e = match e.core with
-      | Ix n -> begin
-        match (get_val_from_id cx n).core with
-        | Fresh _
-        | Flex _ ->
-            if (n > max_bound_id) then vars := IxSet.add (Ix (n -
-            max_bound_id) @@ e) !vars
-        | _ -> isuper#expr scx e
-      end
-      | Lambda (ls, _) ->
-          isuper#expr (max_bound_id + (List.length ls), cx) e
-      | Quant (_, ls, _) ->
-          let (_, cx) = self#bounds scx ls in
-          isuper#expr (max_bound_id + (List.length ls), cx) e
-      | Tquant (_, ls, _) ->
-          isuper#expr (max_bound_id + (List.length ls), cx) e
-      | _ -> isuper#expr scx e
+
+let level_to_kind level =
+    match level with
+    | 0 -> "CONSTANT"
+    | 1 -> "STATE"
+    | 2 -> "ACTION"
+    | 3 -> "TEMPORAL"
+    | _ -> assert false
+
+
+let with_unique_identifiers: bool = false
+
+
+let rename_with_loc cx e =
+    (* Rename declared operators to include location information. *)
+    let visitor = object (self)
+        inherit [unit] Expr.Visit.map_rename as super
+
+        method rename cx hyp name =
+            let locus = shorter_string_to_hex (format_locus hyp) in
+            let locus = if with_unique_identifiers then locus else "" in
+            match hyp.core with
+            | Fresh (nm, shp, kind, dom) ->
+                let kind_str = match kind with
+                    | Constant -> "CONSTANT"
+                    | State -> "STATE"
+                    | Action -> "ACTION"
+                    | Temporal -> "TEMPORAL"
+                    | Unknown -> "Unknown"
+                    in
+                let name = kind_str ^ "_" ^ nm.core ^ "_" ^ locus in
+                let nm = name @@ nm in
+                let h = Fresh (nm, shp, kind, dom) @@ hyp in
+                (h, nm)
+            | Flex var_name ->
+                let str = "VARIABLE" ^ "_" ^ var_name.core ^ "_" ^ locus in
+                let var_name = str @@ var_name in
+                let h = Flex var_name @@ hyp in
+                (h, name)
+            | Defn (df, wd, vis, ex) ->
+                let (core, name) = begin match df.core with
+                    | Recursive (name, _) -> (df.core, name)
+                    | Operator (nm, expr) ->
+                        let expr = Expr.Levels.compute_level cx expr in
+                        let level = Expr.Levels.get_level expr in
+                        let kind_str = level_to_kind level in
+                        let name = kind_str ^ "_" ^ nm.core ^ "_" ^ locus in
+                        let nm = name @@ nm in
+                        (Operator (nm, expr), nm)
+                    | Instance (name, _) -> (df.core, name)
+                    | Bpragma (name, _, _) -> (df.core, name)
+                    end in
+                let df = core @@ df in
+                (* Same name for defined operators because `LET` definitions
+                have been expanded. Definitions from only module scope remain.
+                These definitions do not include multiple operators with the
+                same identifier.
+                *)
+                let h = Defn (df, wd, vis, ex) @@ hyp in
+                (h, name)
+            | Fact (e, vis, tm) ->
+                assert false
     end in
-    let () = vars_visitor#expr (0, cx) e in
-    IxSet.elements !vars in
-  let visitor = object (self)
-    inherit [unit] Expr.Visit.map as super
-    method expr scx e = match e.core with
-    (* modal expressions *)
-    | Apply ({core = Internal (Builtin.Prime | Builtin.Box _  | Builtin.Diamond
-    | Builtin.Leadsto | Builtin.ENABLED) as sym}, args) -> begin
-      match (sym, compute_vars (snd scx) e, args) with
-      | (_,[],_) -> coalesce (snd scx) e
-      | (Internal Builtin.Prime, [{core = Ix m}], [{core = Ix n}]) when n = m ->
-        Opaque (coalesce_prime_var (snd scx) m) @@ e
-      | (_,vars,_) ->
-        (Apply (coalesce (snd scx) e, vars)) @@ e
-    end
-    | Apply ({core = Ix n}, args) -> begin match (get_val_from_id (snd scx) n).core with
-      (* user defined operators *)
-      | Defn ({core = Operator (_, _)} as op, _,_,_) ->
-        let not_to_coalesce =
-          let funn (id, arg) =
-            if (Expr.Constness.is_const arg || Expr.Leibniz.is_leibniz op (id-1)) then true
-            else false in
-          List.for_all funn (List.combine (int_compr [] (List.length args)) args) in
-        if (not_to_coalesce) then super#expr scx e
-        else Apply (coalesce_operator (snd scx) op args, List.map (self#expr scx) args) @@ e
-      | _ -> super#expr scx e
-    end
-    | _ -> super#expr scx e
-  end in
-  visitor#expr ((), Deque.empty) e
+    visitor#expr ((), cx) e
+
+
+let coalesce_primed_var cx index =
+    (* Append `"#prime"` to the identifier name. *)
+    let name =
+        let hyp = get_val_from_id cx index in
+        match hyp.core with
+        | Fresh (name, _, _, _) -> name.core
+        | Flex name -> name.core
+        | _ -> failwith "Expecting variable or constant but got a Fact or Def"
+        in
+    Printf.sprintf "%s" (name ^ "#prime")
+
+
+let vars_visitor = object (self: 'self)
+    (* A visitor for accumulating free variables and free constants. *)
+    inherit [int] Expr.Visit.iter_visible_hyp as super
+
+    val mutable vars = ref IxSet.empty
+
+    method compute cx e =
+        let vars = ref IxSet.empty in
+        let max_bound_idx = 0 in
+        self#expr (max_bound_idx, cx) e;
+        IxSet.elements !vars
+
+    method expr ((max_bound_idx, cx) as scx) e =
+        match e.core with
+        | Ix n -> begin
+            let hyp = get_val_from_id cx n in
+            match hyp.core with
+            | Fresh _
+            | Flex _ ->
+                if (n > max_bound_idx) then
+                    begin
+                    let m = n - max_bound_idx in
+                    vars := IxSet.add (Ix m @@ e) !vars
+                    end
+            | Defn ({core = Operator (_, expr)}, _, Visible, _)
+                when
+                not ((Expr.Levels.get_level expr) = 0) ->
+                (* TODO: what about considering hidden nonconstant
+                operators as variables ?
+                Different operator applications could be to different variables
+                so there occurrences would need to be represented as different
+                variables.
+                *)
+                (* visit both `Hidden` and `Visible` definitions
+                The function `Backend.Prep.expand_defs` removes from the
+                sequent context visible definitions and pragma definitions
+                (both visible and hidden pragma definitions).)
+                *)
+                let scx = Expr.T.scx_front scx n in
+                super#expr scx expr
+            | _ -> super#expr scx e
+            end
+        | Lambda (ls, _) ->
+            let max_bound_idx = max_bound_idx + (List.length ls) in
+            super#expr (max_bound_idx, cx) e
+        | Let (defs, expr) ->
+            let scx = self#defns scx defs in
+            self#expr scx expr
+        | Quant (_, ls, expr) ->
+            let scx_ = self#bounds scx ls in
+            self#expr scx_ expr
+        | Tquant (_, ls, _) ->
+            let max_bound_idx = max_bound_idx + (List.length ls) in
+            super#expr (max_bound_idx, cx) e
+        | Choose (v, optdom, expr) ->
+            let bound = match optdom with
+                | None -> Unbounded
+                | Some dom ->
+                    self#expr scx dom ;
+                    Bounded (dom, Visible)
+                in
+            let hyp = Fresh (v, Shape_expr, Constant, bound) @@ v in
+            let max_bound_idx = max_bound_idx + 1 in
+            let cx_ = Deque.snoc cx hyp in
+            let scx_ = (max_bound_idx, cx_) in
+            self#expr scx_ expr
+        | SetSt (v, dom, expr) ->
+            self#expr scx dom;
+            let bound = Bounded (dom, Visible) in
+            let hyp = Fresh (v, Shape_expr, Constant, bound) @@ v in
+            let cx_ = Deque.snoc cx hyp in
+            let max_bound_idx = max_bound_idx + 1 in
+            let scx_ = (max_bound_idx, cx_) in
+            self#expr scx_ expr
+        | SetOf (expr, bs) ->
+            let scx_ = self#bounds scx bs in
+            self#expr scx_ expr
+        | Fcn (bs, expr) ->
+            let scx_ = self#bounds scx bs in
+            self#expr scx_ expr
+        | _ -> super#expr scx e
+
+    method defn scx df =
+        let (max_bound_idx, cx) = super#defn scx df in
+        let max_bound_idx = max_bound_idx + 1 in
+        let scx = (max_bound_idx, cx) in
+        scx
+
+    method bounds scx bs =
+        let (max_bound_idx, cx) = super#bounds scx bs in
+        let max_bound_idx = max_bound_idx + (List.length bs) in
+        let scx = (max_bound_idx, cx) in
+        scx
+
+    method instance scx inst =
+        assert false  (* `INSTANCE` statements have been expanded *)
+
+    method bound scx b =
+        assert false  (* unused method *)
+
+    method hyp scx h =
+        assert false  (* sequents do not occur in expressions *)
+
+    method hyps scx hs =
+        assert false  (* sequents do not occur in expressions *)
+end
+
+
+let compute_vars cx e =
+    vars_visitor#compute cx e
+
+
+let coalesce_modal_visitor = object (self)
+    inherit [unit] Expr.Visit.map_visible_hyp as super
+
+    method expr ((_, cx) as scx) e =
+        match e.core with
+        (* modal expressions *)
+        | Apply ({core=Internal (Builtin.Prime | Builtin.StrongPrime)},
+                [{core=Ix n}]) when
+                (let hyp = get_val_from_id cx n
+                in match hyp.core with
+                | Fresh _ -> true
+                | Flex _ -> true
+                | _ -> false)
+                ->
+            Opaque (coalesce_primed_var cx n) @@ e
+        | Apply ({core = Internal (
+                Builtin.Prime | Builtin.StrongPrime
+                | Builtin.Box _ | Builtin.Diamond
+                | Builtin.Leadsto | Builtin.ENABLED | Builtin.Cdot
+                | Builtin.UNCHANGED)}, args) ->
+            begin
+            let vars = compute_vars cx e in
+            let op = coalesce cx e in
+            match vars with
+            | [] -> op
+            | _ -> Apply (op, vars) @@ e
+            end
+        | Apply ({core = Ix n} as index, args) ->
+            let hyp = get_val_from_id cx n in
+            begin match hyp.core with
+            (* user defined operators *)
+            | Defn ({core = Operator _} as op, _, _, _) ->
+                let not_to_coalesce =
+                    let f (id, arg) =
+                        let arg = Expr.Levels.compute_level cx arg in
+                        if (
+                                ((Expr.Levels.get_level arg) = 0)
+                                || Expr.SubstOp.get_substitutive_arg
+                                        op (id - 1)) then
+                            true
+                        else false
+                        in
+                    List.for_all f (indexed_args args) in
+                if not_to_coalesce then
+                    super#expr scx e
+                else begin
+                    Apply (coalesce_operator cx op args,
+                        List.map (self#expr scx) args) @@ e end
+            | Flex _ -> super#expr scx e
+            | Fresh (op_name, _, kind, _) ->
+                begin
+                let coalesced_op = op_name in
+                match kind with
+                | Constant ->
+                    (* let op = Opaque (coalesced_op.core) @@ index in *)
+                    let op = index in
+                    let args_ = List.map (self#expr scx) args in
+                    Apply (op, args_) @@ e
+                | _ ->
+                    let expr = noprops (Internal TRUE) in
+                    let op_ = (Operator (coalesced_op, expr)) @@ index in
+                    coalesce_operator cx op_ args
+                end
+            | Fact _ -> (* unexpected `Fact` *)  assert false
+            | Defn ({core=Recursive _}, _, _, _) ->
+                (* not implemented case *)  assert false
+            | Defn ({core=Instance _}, _, _, _) ->
+                (* `INSTANCE` statements have been expanded *)  assert false
+            | Defn ({core=Bpragma _}, _, _, _) ->
+                (* unexpected back-end proof directive *)  assert false
+            end
+        | _ -> super#expr scx e
+end
+
+
+let coalesce_modal cx e =
+    let e = rename_with_loc cx e in
+    let scx = ((), cx) in
+    coalesce_modal_visitor#expr scx e

--- a/src/frontend/coalesce.ml
+++ b/src/frontend/coalesce.ml
@@ -37,7 +37,7 @@ let crypthash scx cx e =
         Format.pp_print_flush fmt () ;
         Buffer.contents b
     in
-    "h" ^ String.sub (string_to_hex s) 0 5
+    "h" ^ shorter_string_to_hex s
 
 (* for using it with PLTL it is enough to have a trivial coalescing returning a
  * unique constant depending on all symbols in it, TODO make a smarter (according
@@ -57,7 +57,7 @@ let indexed_args args =
     `[(n, args[0]); (n - 1, args[1]); ..; (1, args[n - 1])]`
     *)
     let n = List.length args in
-    List.combine (int_compr [] n) args
+    List.mapi (fun i x -> (n - i, x))
 
 
 let coalesce_operator cx op args =

--- a/src/frontend/coalesce.ml
+++ b/src/frontend/coalesce.ml
@@ -57,7 +57,7 @@ let indexed_args args =
     `[(n, args[0]); (n - 1, args[1]); ..; (1, args[n - 1])]`
     *)
     let n = List.length args in
-    List.mapi (fun i x -> (n - i, x))
+    List.mapi (fun i x -> (n - i, x)) args
 
 
 let coalesce_operator cx op args =

--- a/src/frontend/coalesce.ml
+++ b/src/frontend/coalesce.ml
@@ -119,6 +119,10 @@ let level_to_kind level =
     | _ -> assert false
 
 
+(* If the constant `with_unique_identifiers` is `true`,
+then include in the coalesced identifiers the location
+of their definition in source code.
+*)
 let with_unique_identifiers: bool = false
 
 

--- a/src/frontend/coalesce.mli
+++ b/src/frontend/coalesce.mli
@@ -1,11 +1,15 @@
 
 (*
- * Coalescing transforms a formula to a satisfying-equiavelnt formula.
-   *  coalsecing non-leibzniz formulas into leibniz formulas. The resuled
+ * Coalescing transforms a formula to a satisfying-equivalent formula.
+   *  coalsecing non-leibzniz formulas into leibniz formulas. The resulting
    * formulas can then be used in first-order theorem provers.
  *
  * Copyright (C) 2013  INRIA and Microsoft Corporation
  *)
+open Expr.T
 
-val coalesce : Expr.T.hyp Deque.dq -> Expr.T.expr -> Expr.T.expr
-val coalesce_modal : Expr.T.expr -> Expr.T.expr
+
+val coalesce : ctx -> expr -> expr
+val coalesce_modal : ctx -> expr -> expr
+val coalesce_apply: ctx -> expr -> expr
+val rename_with_loc: ctx -> expr -> expr

--- a/src/frontend/pltl.mli
+++ b/src/frontend/pltl.mli
@@ -1,6 +1,4 @@
 (*
- * The action frontend is responsible on transforming obligations containing
- * actions to purely first-order obligations
  * Copyright (C) 2013  INRIA and Microsoft Corporation
  *)
 

--- a/src/loc.mli
+++ b/src/loc.mli
@@ -8,9 +8,10 @@
 (** Source locations *)
 
 (** A location represents a col in a source file *)
-type pt_ = { line : int ;
-              bol : int ;
-              col : int ;
+type pt_ = { line : int ;  (* line number *)
+              bol : int ;  (* beginning of line *)
+              col : int ;  (* column number relative to beginning of line,
+                see the implementation of the function `locus_of_position`. *)
             }
 
 type pt = Actual of pt_ | Dummy

--- a/src/method.ml
+++ b/src/method.ml
@@ -1,5 +1,5 @@
 (*
- * Copyright (C) 2008-2012  INRIA and Microsoft Corporation
+ * Copyright (C) 2008-2019  INRIA and Microsoft Corporation
  *)
 
 Revision.f "$Rev$";;
@@ -35,6 +35,13 @@ type t =
   | Verit of float
   | Spass of float
   | Tptp of float
+  | ExpandENABLED
+  | ExpandCdot
+  | AutoUSE
+  | Lambdify
+  | ENABLEDaxioms
+  | LevelComparison
+  | Trivial
 ;;
 
 let timeout m =
@@ -56,6 +63,13 @@ let timeout m =
   | Verit f -> f
   | Spass f -> f
   | Tptp f -> f
+  | ExpandENABLED -> infinity
+  | ExpandCdot -> infinity
+  | AutoUSE -> infinity
+  | Lambdify -> infinity
+  | ENABLEDaxioms -> infinity
+  | LevelComparison -> infinity
+  | Trivial -> infinity
 
 let is_temporal m =
   match m with
@@ -82,6 +96,13 @@ let scale_time m s =
   | Verit f -> Verit (f *. s)
   | Spass f -> Spass (f *. s)
   | Tptp f -> Tptp (f *. s)
+  | ExpandENABLED -> ExpandENABLED
+  | ExpandCdot -> ExpandCdot
+  | AutoUSE -> AutoUSE
+  | Lambdify -> Lambdify
+  | ENABLEDaxioms -> ENABLEDaxioms
+  | LevelComparison -> LevelComparison
+  | Trivial -> Trivial
 ;;
 
 open Format
@@ -108,6 +129,13 @@ let pp_print_tactic ff m =
   | Tptp f -> fprintf ff "(tptp %g s)" f
   | Cooper -> fprintf ff "(cooper)"
   | Fail -> fprintf ff "(fail)"
+  | ExpandENABLED -> fprintf ff "(expandenabled)"
+  | ExpandCdot -> fprintf ff "(expandcdot)"
+  | AutoUSE -> fprintf ff "(autouse)"
+  | Lambdify -> fprintf ff "(lambdify)"
+  | ENABLEDaxioms -> fprintf ff "(enabledaxioms)"
+  | LevelComparison -> fprintf ff "(levelcomparison)"
+  | Trivial -> fprintf ff "(trivial)"
 ;;
 
 let pp_print_method ff meth =
@@ -134,6 +162,13 @@ let prover_meth_of_tac tac =
     | Tptp f -> (Some "tptp", None)
     | Cooper -> (Some "cooper", None)
     | Fail -> (Some "fail", None)
+    | ExpandENABLED -> (Some "expandenabled", None)
+    | ExpandCdot -> (Some "expandcdot", None)
+    | AutoUSE -> (Some "autouse", None)
+    | Lambdify -> (Some "lambdify", None)
+    | ENABLEDaxioms -> (Some "enabledaxioms", None)
+    | LevelComparison -> (Some "levelcomparison", None)
+    | Trivial -> (Some "trivial", None)
 
 type result =
   | Proved of string

--- a/src/method.mli
+++ b/src/method.mli
@@ -1,5 +1,5 @@
 (*
- * Copyright (C) 2011  INRIA and Microsoft Corporation
+ * Copyright (C) 2011-2019  INRIA and Microsoft Corporation
  *)
 
 (* params.ml *)
@@ -22,6 +22,13 @@ type t =
   | Verit of float
   | Spass of float
   | Tptp of float
+  | ExpandENABLED
+  | ExpandCdot
+  | AutoUSE
+  | Lambdify
+  | ENABLEDaxioms
+  | LevelComparison
+  | Trivial
 ;;
 
 (* expr/fmt.ml *)

--- a/src/method_prs.ml
+++ b/src/method_prs.ml
@@ -1,7 +1,7 @@
 (* method_prs.ml --- parse method pragmas
  *
  *
- * Copyright (C) 2008-2010  INRIA and Microsoft Corporation
+ * Copyright (C) 2008-2019  INRIA and Microsoft Corporation
  *)
 
 Revision.f "$Rev$";;
@@ -44,6 +44,13 @@ and isa_method = lazy begin
              isa_spass;
              isa_tptp;
              isa_ls4;
+             isa_enabled;
+             isa_cdot;
+             isa_autouse;
+             isa_lambdify;
+             isa_enabledaxioms;
+             isa_levelcomparison;
+             isa_trivial;
            ]
   <<< punct ")"
 end
@@ -106,3 +113,17 @@ and isa_verit = ident "verit" <!> Verit default_smt2_timeout
 and isa_spass = ident "spass" <!> Spass default_spass_timeout
 
 and isa_tptp = ident "tptp" <!> Tptp default_tptp_timeout
+
+and isa_enabled = ident "expandenabled" <!> ExpandENABLED
+
+and isa_cdot = ident "expandcdot" <!> ExpandCdot
+
+and isa_autouse = ident "autouse" <!> AutoUSE
+
+and isa_lambdify = ident "lambdify" <!> Lambdify
+
+and isa_enabledaxioms = ident "enabledaxioms" <!> ENABLEDaxioms
+
+and isa_levelcomparison = ident "levelcomparison" <!> LevelComparison
+
+and isa_trivial = ident "trivial" <!> Trivial

--- a/src/module.ml
+++ b/src/module.ml
@@ -14,3 +14,5 @@ module Dep = M_dep;;
 module Parser = M_parser;;
 module Save = M_save;;
 module Globalness = M_globalness;;
+module Subst = M_subst;;
+module Visit = M_visit;;

--- a/src/module.mli
+++ b/src/module.mli
@@ -1,5 +1,5 @@
 (*
- * Copyright (C) 2011  INRIA and Microsoft Corporation
+ * Copyright (C) 2011-2019  INRIA and Microsoft Corporation
  *)
 
 module T : sig
@@ -94,15 +94,21 @@ module Flatten : sig
 end;;
 
 module Elab : sig
-  open Proof.T
+  open Deque
+  open Expr.T
+
   open T
+
   val normalize :
     modctx -> Expr.T.hyp Deque.dq -> mule -> modctx * mule * summary
   ;;
 end;;
 
 module Dep : sig
-  val external_deps : T.mule_ Property.wrapped -> Util.Coll.Hs.t;;
+  open Util.Coll
+
+  val external_deps : T.mule_ Property.wrapped ->
+    Hs.t * Hs.t * T.mule Sm.t;;
   val schedule : T.modctx -> T.modctx * T.mule list;;
 end;;
 
@@ -123,4 +129,48 @@ module Globalness : sig
   open T
   val is_global : 'a Property.wrapped -> bool
   val globalness : mule -> mule
+end;;
+
+module Subst : sig
+    open Expr.Subst
+
+    open T
+
+    val app_modunits: sub -> modunit list -> sub * modunit list
+    val app_modunit: sub -> modunit -> sub * modunit
+    val app_mule: sub -> mule -> mule
+end;;
+
+module Visit : sig
+    open Expr.T
+    open Proof.T
+    open Util
+
+    open T
+
+    class map : object
+        method module_units: Expr.T.ctx -> M_t.modunit list ->
+            ctx * M_t.modunit list
+        method module_unit: ctx -> M_t.modunit ->
+            ctx * modunit
+        method constants: ctx -> (hint * shape) list ->
+            ctx * modunit_
+        method variables: ctx -> hint list ->
+            ctx * modunit_
+        method recursives: ctx -> (hint * shape) list ->
+            ctx * modunit_
+        method definition: ctx -> defn -> wheredef -> visibility -> export ->
+            ctx * modunit_
+        method axiom: ctx -> hint option -> expr ->
+            ctx * modunit_
+        method theorem:
+            ctx -> hint option -> sequent -> int -> proof -> proof -> summary ->
+            ctx * modunit_
+        method submod: ctx -> mule ->
+            ctx * modunit_
+        method mutate: ctx -> [`Use of bool | `Hide] -> usable ->
+            ctx * modunit_
+        method anoninst: ctx -> Expr.T.instance -> export ->
+            ctx * modunit_
+    end
 end;;

--- a/src/module/m_dep.mli
+++ b/src/module/m_dep.mli
@@ -1,11 +1,13 @@
 (*
  * Copyright (C) 2011  INRIA and Microsoft Corporation
  *)
+open Util.Coll
 
 open M_t;;
 
 (* module/save.ml *)
-val external_deps : mule_ Property.wrapped -> Util.Coll.Hs.t;;
+val external_deps : mule_ Property.wrapped ->
+    Hs.t * Hs.t * mule Sm.t;;
 
 (* tlapm.ml *)
 val schedule : modctx -> modctx * mule list;;

--- a/src/module/m_dep.mlt
+++ b/src/module/m_dep.mlt
@@ -83,8 +83,11 @@ let t3 =
 	Test.make_simple_test
 		~title:(title_external_deps ^ t3_str)
     ( fun () ->
-      Assert.is_true (Hs.exists (fun x -> x.core = "TLC") (external_deps
-      (Sm.find "a" test_case)))
+      Assert.is_true (
+        Hs.exists (fun x -> x.core = "TLC")
+        (let (e, _, _) = (external_deps (Sm.find "a" test_case))
+        in e)
+      )
     )
 
 (* determines the kind of output for kaputt *)

--- a/src/module/m_elab.ml
+++ b/src/module/m_elab.ml
@@ -8,8 +8,12 @@
 Revision.f "$Rev$";;
 
 open Ext
+open Format
+open Fmtutil
+open Tla_parser
 open Property
 open Util.Coll
+open Util
 
 open Expr.T
 open Expr.Subst
@@ -18,56 +22,6 @@ open Proof.T
 open M_t
 
 (*let debug = Printf.eprintf;;*)
-
-(******************************************************************************)
-
-(* [FIXME] move to module/subst.ml *)
-
-let rec app_modunits s = function
-  | [] -> (s, [])
-  | mu :: mus ->
-      let (s, mu) = app_modunit s mu in
-      let (s, mus) = app_modunits s mus in
-      (s, mu :: mus)
-
-and app_modunit s mu =
-  match mu.core with
-  | Constants cs ->
-      (bumpn (List.length cs) s, mu)
-  | Recursives cs ->
-      (bumpn (List.length cs) s, mu)
-  | Variables vs ->
-      (bumpn (List.length vs) s, mu)
-  | Definition (df, wd, vis, ex) ->
-      let df = app_defn s df in
-      (bump s, Definition (df, wd, vis, ex) @@ mu)
-  | Axiom (nm, e) ->
-      let e = app_expr s e in
-      let s = bumpn (if nm = None then 1 else 2) s in
-      (s, Axiom (nm, e) @@ mu)
-  | Theorem (nm, sq, naxs, prf, prf_orig,summ) ->
-      let sq = app_sequent s sq in
-      let s = bump s in
-      let prf =
-        let s = bumpn (Deque.size sq.context) s in
-        Proof.Subst.app_proof s prf
-      in
-      let s = if nm = None then s else bump s in
-      (s, Theorem (nm, sq, naxs, prf, prf_orig, summ) @@ mu)
-  | Submod m ->
-      let m = app_mule s m in
-      (s, Submod m @@ mu)
-  | Mutate (uh, us) ->
-      let us = Proof.Subst.app_usable s us in
-      let s = if uh = `Hide then s else bumpn (List.length us.facts) s in
-      (s, Mutate (uh, us) @@ mu)
-  | Anoninst (inst, loc) ->
-      let isub = List.map (fun (v, e) -> (v, app_expr s e)) inst.inst_sub in
-      (s, Anoninst ({inst with inst_sub = isub}, loc) @@ mu)
-
-and app_mule s m =
-  let (_, bod) = app_modunits s m.core.body in
-  { m.core with body = bod } @@ m
 
 (******************************************************************************)
 
@@ -84,7 +38,8 @@ let localize_axioms body =
               | None ->
                   (prefix, app_expr (shift 1) e)
               | Some nm ->
-                  ((Definition (Operator (nm, e) @@ mu, Proof Always, Visible, Export)
+                  ((Definition
+                      (Operator (nm, e) @@ mu, Proof Always, Visible, Export)
                     @@ mu)
                    :: prefix,
                    Ix 2 @@ mu)
@@ -109,7 +64,7 @@ let localize_axioms body =
                 end
             in
             let mus = insert_ax [] 0 mus in
-            let (_, mus) = app_modunits (shift (-1)) mus in
+            let (_, mus) = M_subst.app_modunits (shift (-1)) mus in
             spin prefix mus
         | _ ->
             spin (mu :: prefix) mus
@@ -124,129 +79,261 @@ let salt oname =
   incr salt_counter;
   (oname.core ^ "$" ^ string_of_int !salt_counter) @@ oname
 
-(* The following function appears complex, but is actually pretty
- * straightforward. Do not be awed by its length, but instead try to
- * understand it piece by piece. *)
 
-let instantiate anon (mcx : modctx) cx (inst : instance wrapped) ~local ~iname =
-  let not_complained = ref true in
-  if not (Sm.mem inst.core.inst_mod mcx) then begin
-    Errors.err ~at:inst "Module %S not found" inst.core.inst_mod;
-    failwith "Module.Elab.instantiate"
-  end;
-  let mule = Sm.find inst.core.inst_mod mcx in
+module StringMap = Util.Coll.Sm  (* Map.Make(String) *)
+module StringSet = Util.Coll.Ss  (* Set.Make(String) *)
 
-  (* Find all the necessary parameters *)
-  let mule_params =
-    let rec scan ps = function
-      | [] -> ps
-      | mu :: mus ->
-          begin match mu.core with
-          | Constants cs ->
-              let ps =
-                List.fold_left (fun ps (nm, _) -> Ss.add nm.core ps) ps cs
-              in
-              scan ps mus
-          | Variables vs ->
-              let ps = List.fold_left (fun ps nm -> Ss.add nm.core ps) ps vs in
-              scan ps mus
-          | _ ->
-              scan ps mus
+open Util
+
+module HC = struct
+  type t = hint
+  let compare x y = Stdlib.compare x.core y.core
+end
+
+module HintMap = Util.Coll.Hm  (* Map.Make(HC) *)
+module HintSet = Util.Coll.Hs  (* Set.Make(HC) *)
+
+
+let module_parameters (tla_module: M_t.mule):
+        StringSet.t =
+    (* Return a `StringSet` containing the `VARIABLE` and `CONSTANT`
+    identifiers declared in module scope in the module `tla_module`.
+    *)
+    let rec scan params = function
+        | [] -> params
+        | module_unit :: module_units ->
+            let params = begin match module_unit.core with
+                | Constants constants ->
+                    let f = fun params (name, _) ->
+                                StringSet.add name.core params in
+                    List.fold_left f params constants
+                | Variables variables ->
+                    let f = fun params name ->
+                                StringSet.add name.core params in
+                    List.fold_left f params variables
+                | _ -> params
+            end in
+            scan params module_units in
+      scan StringSet.empty tla_module.core.body
+
+
+let find_instantiated_module
+        (instance: Expr.T.instance wrapped)
+        (mcx: M_t.modctx):
+            M_t.mule =
+    let module_name = instance.core.inst_mod in
+    let found_module = StringMap.mem module_name mcx in
+    if not found_module then begin
+        Errors.err ~at:instance
+            "Module %S not found"
+            module_name;
+        failwith "Module.Elab.is_instance_of_module"
+    end else
+        let tla_module = StringMap.find module_name mcx in
+        tla_module
+
+
+let instance_substitution_to_map
+        (instance: Expr.T.instance wrapped) =
+    (* Roll given substitution into a map for efficient lookup *)
+    let (instance_substitution: (hint * Expr.T.expr) list) =
+        instance.core.inst_sub in
+    let f = fun subst (var, expr) -> HintMap.add var expr subst in
+    let substitution_map =
+        List.fold_left f HintMap.empty instance_substitution in
+    substitution_map
+
+
+let assert_instance_substitutes_declared_identifiers
+        substitution_map
+        module_parameters
+        (module_name: string):
+            unit =
+    (* Raise error if any instantiated parameter is not declared in the
+    instantiated module.
+    *)
+    let check (op: hint) _ =
+        if not (StringSet.mem op.core module_parameters) then begin
+            Errors.err ~at:op "%s" (
+                "Parameter " ^ op.core ^ " occurs in the statement " ^
+                "`INSTANCE " ^ module_name ^ " WITH`, " ^
+                "and is not declared in the module " ^ module_name ^ "\n");
+            failwith "Module.Elab.instance_substitutes_declared_identifiers"
         end
-    in scan Ss.empty mule.core.body
-  in
+        in
+    HintMap.iter check substitution_map
 
-  (* Roll given substitution into a map for efficient lookup *)
-  let subst =
-    List.fold_left (fun subst (v, e) -> Hm.add v e subst) Hm.empty
-                   inst.core.inst_sub
-  in
 
-  (* complain if there are any extra parameters *)
-  let complain v _ =
-    if not (Ss.mem v.core mule_params) then begin
-      Errors.err ~at:v
-                 "Parameter %s in substitution not declared in module %S"
-                 v.core inst.core.inst_mod;
-      failwith "Module.Elab.instantiate"
-    end
-  in
-  Hm.iter complain subst;
+let extend_context
+        (cx: Expr.T.ctx)
+        (instance_args: hint list):
+            Expr.T.ctx =
+    (* Extend the context `cx` with the parameters that occur in the
+    `WITH` of the statement `INSTANCE ModuleName WITH ...`.
 
-  (* Extend the cx *)
-  let extend cx v =
-    Deque.snoc cx (Fresh (v, Shape_expr, Unknown, Unbounded) @@ v)
-  in
-  let cx = List.fold_left extend cx inst.core.inst_args in
+    The parameters are declared as `CONSTANTS` of arity _ ,
+    in module scope.
+    *)
+    let extend cx v =
+        let fresh_op = Fresh (v, Shape_expr, Unknown, Unbounded) in
+        let decl = fresh_op @@ v in
+        Deque.snoc cx decl  (* append to module context *)
+    in
+    List.fold_left extend cx instance_args
 
-  (* Complete the substitution with the missing parameters *)
-  let f s subst =
-    if Hm.mem (s @@ inst) subst then subst
-    else match Deque.find cx (Expr.Anon.hyp_is_named s) with
-      | None ->
-          Errors.err ~at:inst
-            "Required parameter %S for module %S could not be inferred.\n"
-            s inst.core.inst_mod;
-          failwith "Module.Elab.normalize"
-      | Some _ ->
-          Hm.add (s @@ inst) (Opaque s @@ inst) subst
-  in
-  let subst = Ss.fold f mule_params subst in
 
-  (* anonymize the subst *)
-  let subst = Hm.map (anon#expr ([], cx)) subst in
+let complete_with_statement_params
+        inst
+        substitution_map
+        (module_parameters: StringSet.t)
+        cx
+            =
+    (* Complete the substitution with the missing parameters *)
+    let f s subst =
+        if HintMap.mem (s @@ inst) subst then
+            subst
+        else
+            match Deque.find cx (Expr.Anon.hyp_is_named s) with
+            | None ->
+                Errors.err ~at:inst "%s" (
+                    "Required parameter " ^ s ^ " for module " ^
+                    inst.core.inst_mod ^ " could not be inferred.\n");
+                failwith "Module.Elab.complete_with_statement_params"
+            | Some _ ->
+            HintMap.add (s @@ inst) (Opaque s @@ inst) subst
+    in
+    StringSet.fold f module_parameters substitution_map
 
-  (* erases proof *)
-  let remove_pf mu =
+
+let anonymize_substitution anon cx subst =
+    HintMap.map (anon#expr ([], cx)) subst
+
+
+let remove_pf mu =
+    (* Erase proofs from module `mu`. *)
     match mu.core with
     | Theorem (nm, sq, naxs, prf, prf_orig, summ) ->
         Theorem (nm, sq, naxs, (Omitted Implicit @@ prf), prf_orig, summ) @@ mu
     | _ -> mu
-  in
 
-  (* bring mule body to here *)
-  assert (Deque.size cx >= mule.core.defdepth);
-  let (_, body) =
-    app_modunits (shift (Deque.size cx - mule.core.defdepth))
-                 (List.map remove_pf mule.core.body)
-  in
 
-  (* perform the substitution *)
-  let rec apply_subst body body_len = function
+let lambdify_expr cx expr =
+    (* Both `ENABLED` and `\cdot` need to be lambdified for
+    soundly performing module instantiation.
+    So pass `true` for those options.
+    *)
+    let lambdify_enabled = true in
+    let lambdify_cdot = true in
+    let autouse = true in
+    let expr = Expr.Action.lambdify cx expr
+            ~lambdify_enabled:lambdify_enabled
+            ~lambdify_cdot:lambdify_cdot
+            ~autouse:autouse in
+        expr
+
+
+let lambdify_definition cx df =
+    let expr = match df.core with
+        | Operator (_, expr) -> expr
+        | Bpragma (_, expr, _) -> expr
+        | _ -> assert false in
+    let expr = match expr.core with
+        | Lambda _ -> expr  (* arity < _, ... > *)
+        | _ ->  lambdify_expr cx expr (* arity _ *)
+        in
+    let core = match df.core with
+        | Operator (name, _) -> Operator (name, expr)
+        | Bpragma (name, _, backend_args) -> Bpragma (name, expr, backend_args)
+        | _ -> assert false in
+    let df = core @@ df in
+    df
+
+
+let get_sequent expr = match expr.core with
+    | Sequent sq -> sq
+    | _ -> assert false
+
+
+let lambdify_sequent cx (sq: Expr.T.sequent) =
+    let sq_expr = noprops (Sequent sq) in
+    let expr = lambdify_expr cx sq_expr in
+    (* let expr = sq in *)
+    get_sequent expr
+
+
+let lambdify_enabled_cdot cx mus =
+    (* Lambdify `ENABLED` and `\cdot` in theorems and definitions. *)
+    let visitor = object (self: 'self)
+        inherit M_visit.map as super
+
+        method definition cx df wd visibility e =
+            let df = lambdify_definition cx df in
+            super#definition cx df wd visibility e
+
+        method theorem cx name sq naxs prf prf_orig summ =
+            (* Lambdify `ENABLED` and `\cdot` to ensure
+            soundness of instantiation, and of wrapping within
+            defined operators.
+            *)
+            let sq = begin
+                try
+                    lambdify_sequent cx sq
+                with Failure msg ->
+                    let msg = (msg ^
+                        "\nCould not instantiate the theorem " ^ (
+                        match name with
+                        | Some s ->
+                            "named: " ^ s.core ^ ", "
+                        | None -> ""
+                        ) ^ "at: " ^ (Expr.T.format_locus sq.active)) in
+                    Util.printf ~at:sq.active ~prefix:"[ERROR]" "%s" msg;
+                    Backend.Toolbox.print_message msg;
+                    {context=Deque.empty; active=(Internal TRUE) @@ sq.active}
+                end in
+            (* Proofs are not instantiated, so mappings relevant to
+            `ENABLED` and `\cdot` are not applied within proofs.
+            *)
+            super#theorem cx name sq naxs prf prf_orig summ
+    end
+    in
+    let (cx, mus) = visitor#module_units cx mus in
+    mus
+
+
+let rec apply_subst body body_len subst = function
+    (* Perform the substitution. *)
     | [] -> List.rev body
-    | mu :: mus ->
-        begin match mu.core with
+    | mu :: mus -> begin match mu.core with
         | Constants [nm, _]
         | Variables [nm] ->
-            let e = Hm.find nm subst in
+            let e = HintMap.find nm subst in
             let e = app_expr (shift body_len) e in
-            let (_, mus) = app_modunits (scons e (shift 0)) mus in
-            apply_subst body body_len mus
+            let (_, mus) = M_subst.app_modunits (scons e (shift 0)) mus in
+            apply_subst body body_len subst mus
         | Constants (c :: cs) ->
-            apply_subst body body_len ((Constants [c] @@ mu)
-                                       :: (Constants cs @@ mu)
-                                       :: mus)
+            apply_subst body body_len subst (
+                (Constants [c] @@ mu)
+                    :: (Constants cs @@ mu)
+                    :: mus)
         | Variables (v :: vs) ->
-            apply_subst body body_len ((Variables [v] @@ mu)
-                                       :: (Variables vs @@ mu)
-                                       :: mus)
+            apply_subst body body_len subst (
+                (Variables [v] @@ mu)
+                    :: (Variables vs @@ mu)
+                    :: mus)
         | _ ->
-            apply_subst (mu :: body) (body_len + hyp_size mu) mus
-      end
-  in
-  let body = apply_subst [] 0 body in
+            apply_subst (mu :: body) (body_len + hyp_size mu) subst mus
+        end
 
-  (* name tweaking *)
-  let tweak nm =
+
+let tweak iname nm =
+    (* Name tweaking. *)
     match iname.core with
     | "" -> nm
     | _ -> (iname.core ^ "!" ^ nm.core) @@ nm
-  in
 
-  (* tweaking substitution *)
-  let niargs = List.length inst.core.inst_args in
-  let iargs = List.init niargs (fun k -> Ix (niargs - k) @@ inst) in
-  let resub_for n =
+
+let resub_for n niargs iargs inst =
+    (* Tweaking substitution. *)
     (* This function is inefficient because it builds intermediate lists
      * and then iterates over them. It has a conceptual simplicity,
      * but if/when performance becomes an issue, this should be revisited.
@@ -264,124 +351,198 @@ let instantiate anon (mcx : modctx) cx (inst : instance wrapped) ~local ~iname =
      *         (indexes in range n + 1 .. n + niargs) are moved to 1 .. niargs.
      *)
     let sub =
-      List.fold_right scons (List.init niargs (fun k -> Ix (k + 1) @@ inst)) sub
-    in
+        List.fold_right
+            scons
+            (List.init niargs (fun k -> Ix (k + 1) @@ inst))
+            sub
+        in
     (* Step 3. original parameters are now shifted up by niargs to account
      *         for the now localized instance parameters.
      *)
     let sub =
-      let l =
-        List.init n (fun k -> Apply (Ix (k + niargs + 1) @@ inst, iargs) @@inst)
-      in
-      List.fold_right scons l sub
-   in
+        let l =
+            let init k =
+                let op = Ix (k + niargs + 1) @@ inst in
+                (if (List.length iargs) >= 1 then begin
+                    assert ((List.length iargs) >= 1);
+                    Apply (op, iargs) @@ inst end
+                else begin
+                    assert ((List.length iargs) = 0);
+                    op end)
+                in
+            List.init n init
+        in
+        List.fold_right scons l sub
+    in
     sub
-  in
 
-  (* add additional lambdas if needed *)
-  let lambdify e =
+
+let lambdify e inst niargs =
+    (* Add additional lambdas if needed. *)
     match e.core with
     | Lambda (vs, le) ->
-        let ivs = List.map (fun v -> (v, Shape_expr)) inst.core.inst_args in
+        let ivs = List.map
+                    (fun v -> (v, Shape_expr))
+                    inst.core.inst_args in
         Lambda (ivs @ vs, le) @@ e
     | _ ->
-        if niargs = 0
-        then e
+        if niargs = 0 then
+            e
         else begin
-          let ivs = List.map (fun v -> (v, Shape_expr)) inst.core.inst_args in
-          Lambda (ivs, e) @@ e
+            let ivs = List.map
+                        (fun v -> (v, Shape_expr))
+                        inst.core.inst_args in
+            Lambda (ivs, e) @@ e
         end
-  in
 
-  (* for each definition and fact, resub and lambdify *)
-  let rec localize body body_len = function
-    | [] -> List.rev body
-    | mu :: mus ->
-        begin match mu.core with
-        | Definition ({core = Operator (nm, e)} as df, wd, vis, ex) ->
-            let nm = if ex = Local then salt nm else nm in
-            let nm = tweak nm in
-            let e = app_expr (resub_for body_len) e in
-            let e = lambdify e in
-            let wd = if ex = Local then Builtin else wd in
-            let ex = if ex = Local then Local else local in
-            let mu = Definition (Operator (nm, e) @@ df, wd, vis, ex) @@ mu in
-            localize (mu :: body) (body_len + 1) mus
-        | Definition ({core = Bpragma (nm, e, meth)} as df, wd, vis, ex) ->
-            (* This case is almost excaclty a duplicate of the previous one *)
-            let nm = if ex = Local then salt nm else nm in
-            let nm = tweak nm in
-            let e = app_expr (resub_for body_len) e in
-            let e = lambdify e in
-            let wd = if ex = Local then Builtin else wd in
-            let ex = if ex = Local then Local else local in
-            let mu =
-              Definition (Bpragma (nm, e, meth) @@ df, wd, vis, ex) @@ mu
-            in
-            localize (mu :: body) (body_len + 1) mus
-        | Axiom (nm, e) ->
-            let nm = Option.map tweak nm in
-            let e = app_expr (resub_for body_len) e in
-            if niargs > 0 && !not_complained then begin
-              Errors.warn ~at:inst
-                "%s\n%s@\n(%s)"
-                "Instancing produces parametric axioms."
-                "Such axioms will be forcibly hidden and cannot be cited."
-                "This warning appears at-most once per INSTANCE declaration.";
-              not_complained := false;
-            end;
-            let e = lambdify e in
-            let mu = Axiom (nm, e) @@ mu in
-            localize (mu :: body) (body_len + hyp_size mu) mus
-        | Theorem (nm, sq, naxs, prf, prf_orig, summ) ->
-            let nm = Option.map tweak nm in
-            let e = exprify_sequent sq @@ mu in
-            let e = app_expr (resub_for body_len) e in
-            if niargs > 0 && !not_complained then begin
-              Util.eprintf ~at:inst ~prefix:"Warning: "
-                "%s@\n%s@\n(%s)"
-                "Instancing produces parametric theorems."
-                "Such theorems will be forcibly hidden and cannot be cited."
-                "This warning appears at-most once per INSTANCE declaration.";
-              not_complained := false;
-            end;
-            let e = lambdify e in
-            let sq =
-              match e.core with
-              | Sequent sq -> sq
-              | _ -> {context = Deque.empty ; active = e}
-            in
-            let prf = Omitted (Elsewhere (Util.get_locus mu)) @@ mu in
-            let mu = Theorem (nm, sq, naxs, prf, prf_orig, summ) @@ mu in
-            localize (mu :: body) (body_len + 1) mus
-        | Mutate (`Hide, _) ->
-            localize body body_len mus
-        | Mutate (`Use _, us) ->
-            let (_, mus) =
-              app_modunits (shift (- (List.length us.Proof.T.facts))) mus
-            in
-            localize body body_len mus
-        | Submod _ ->
-            localize body body_len mus
-        | Constants _
-        | Recursives _
-        | Variables _
-        | Definition _
-        | Anoninst _ ->
-            (* the instancee has been normalized before, so there
-             * should not be any parameters or (unnamed) instances. *)
-            Errors.bug ~at:inst "Module.Elab.localize"
-      end
-  in
-  let body = localize [] 0 body in
-  localize_axioms body
+
+let rec localize body body_len iname niargs iargs not_complained inst local =
+    function
+    (* For each definition and fact, resub and lambdify. *)
+  | [] -> List.rev body
+  | mu :: mus ->
+      begin match mu.core with
+      | Definition ({core = Operator (nm, e)} as df, wd, vis, ex) ->
+          let nm = if ex = Local then salt nm else nm in
+          let nm = tweak iname nm in
+          let e = app_expr (resub_for body_len niargs iargs inst) e in
+          let e = lambdify e inst niargs in
+          let wd = if ex = Local then Builtin else wd in
+          let ex = if ex = Local then Local else local in
+          let mu = Definition (Operator (nm, e) @@ df, wd, vis, ex) @@ mu in
+          localize (mu :: body) (body_len + 1) iname niargs iargs
+            not_complained inst local mus
+      | Definition ({core = Bpragma (nm, e, meth)} as df, wd, vis, ex) ->
+          (* This case is almost excaclty a duplicate of the previous one *)
+          let nm = if ex = Local then salt nm else nm in
+          let nm = tweak iname nm in
+          let e = app_expr (resub_for body_len niargs iargs inst) e in
+          let e = lambdify e inst niargs in
+          let wd = if ex = Local then Builtin else wd in
+          let ex = if ex = Local then Local else local in
+          let mu =
+            Definition (Bpragma (nm, e, meth) @@ df, wd, vis, ex) @@ mu
+          in
+          localize (mu :: body) (body_len + 1) iname niargs iargs
+            not_complained inst local mus
+      | Axiom (nm, e) ->
+          let nm = Option.map (tweak iname) nm in
+          let e = app_expr (resub_for body_len niargs iargs inst) e in
+          if niargs > 0 && !not_complained then begin
+            Errors.warn ~at:inst
+              "%s\n%s@\n(%s)"
+              "Instancing produces parametric axioms."
+              "Such axioms will be forcibly hidden and cannot be cited."
+              "This warning appears at-most once per INSTANCE declaration.";
+            not_complained := false;
+          end;
+          let e = lambdify e inst niargs in
+          let mu = Axiom (nm, e) @@ mu in
+          localize (mu :: body) (body_len + hyp_size mu) iname niargs iargs
+            not_complained inst local mus
+      | Theorem (nm, sq, naxs, prf, prf_orig, summ) ->
+          let nm = Option.map (tweak iname) nm in
+          let e = exprify_sequent sq @@ mu in
+          let e = app_expr (resub_for body_len niargs iargs inst) e in
+          if niargs > 0 && !not_complained then begin
+            Util.eprintf ~at:inst ~prefix:"Warning: "
+              "%s@\n%s@\n(%s)"
+              "Instancing produces parametric theorems."
+              "Such theorems will be forcibly hidden and cannot be cited."
+              "This warning appears at-most once per INSTANCE declaration.";
+            not_complained := false;
+          end;
+          let e = lambdify e inst niargs in
+          let sq =
+            match e.core with
+            | Sequent sq -> sq
+            | _ -> {context = Deque.empty ; active = e}
+          in
+          let prf = Omitted (Elsewhere (Util.get_locus mu)) @@ mu in
+          let mu = Theorem (nm, sq, naxs, prf, prf_orig, summ) @@ mu in
+          localize (mu :: body) (body_len + 1) iname niargs iargs
+            not_complained inst local mus
+      | Mutate (`Hide, _) ->
+          localize body body_len iname niargs iargs not_complained inst local
+            mus
+      | Mutate (`Use _, us) ->
+          let (_, mus) =
+            M_subst.app_modunits (shift (- (List.length us.Proof.T.facts))) mus
+          in
+          localize body body_len iname niargs iargs not_complained inst local
+            mus
+      | Submod _ ->
+          localize body body_len iname niargs iargs not_complained inst local
+            mus
+      | Constants _
+      | Recursives _
+      | Variables _
+      | Definition _
+      | Anoninst _ ->
+          (* the instancee has been normalized before, so there
+           * should not be any parameters or (unnamed) instances. *)
+          Errors.bug ~at:inst "Module.Elab.localize"
+    end
+
+
+(* The following function appears complex, but is actually pretty
+ * straightforward. Do not be awed by its length, but instead try to
+ * understand it piece by piece. *)
+
+let instantiate
+        anon
+        (mcx: M_t.modctx)
+        cx
+        (instance: Expr.T.instance wrapped)
+        ~local
+        ~iname =
+    let tla_module = find_instantiated_module instance mcx in
+        let module_name = instance.core.inst_mod in
+        (* let mule = tla_module in *)
+        let inst = instance in
+    (* compute the substitution *)
+    let module_parameters = module_parameters tla_module in
+        (* let mule_params = module_parameters in *)
+    let substitution_map = instance_substitution_to_map instance in
+        (* let subst = substitution_map in *)
+    assert_instance_substitutes_declared_identifiers
+        substitution_map
+        module_parameters
+        module_name;
+    let cx = extend_context cx inst.core.inst_args in
+    let subst = complete_with_statement_params
+                    instance substitution_map
+                    module_parameters cx in
+    let subst = anonymize_substitution anon cx subst in
+    (* bring mule body to here *)
+    let cx_shift = Deque.size cx - tla_module.core.defdepth in
+    assert (cx_shift >= 0);
+    let body = tla_module.core.body in
+
+
+    let body = List.map remove_pf body in
+    let (_, body) = M_subst.app_modunits (shift cx_shift) body in
+    (* lambdify `ENABLED` and `\cdot` *)
+    let body = lambdify_enabled_cdot cx body in
+    (* apply the substitution *)
+    let body = apply_subst [] 0 subst body in
+    let niargs = List.length inst.core.inst_args in
+    let iargs = List.init niargs (fun k -> Ix (niargs - k) @@ inst) in
+    let not_complained = ref true in
+    let body = localize [] 0 iname niargs iargs not_complained inst local body
+    in
+    localize_axioms body
+
 
 (******************************************************************************)
+(* Anonymization (replacement of named variables and constants by
+de Bruijn indices).
+*)
 
 let anon = object (self : 'self)
   inherit Proof.Anon.anon as super
 
-  val mutable __mcx : modctx = Sm.empty
+  val mutable __mcx : modctx = StringMap.empty
 
   method mexpr mcx scx e =
     __mcx <- mcx ;
@@ -406,7 +567,7 @@ let anon = object (self : 'self)
   method defns scx dfs =
     match dfs with
     | {core = Instance (nm, inst)} as df :: dfs ->
-        if not (Sm.mem inst.inst_mod __mcx) then begin
+        if not (StringMap.mem inst.inst_mod __mcx) then begin
           Errors.err ~at:df "Module %S unknown\n%!" inst.inst_mod;
           failwith "Module.Elab.anon#defns"
         end;
@@ -419,7 +580,7 @@ let anon = object (self : 'self)
               begin match mu.core with
               | Definition (df, _, _, _) -> make_defs (df :: sofar) mus
               | _ ->
-                  let (_, mus) = app_modunits (shift (-1)) mus in
+                  let (_, mus) = M_subst.app_modunits (shift (-1)) mus in
                   make_defs sofar mus
               end
         in
@@ -430,69 +591,587 @@ end
 
 (******************************************************************************)
 
+(* from `Proof.Gen` *)
+let set_defn vis l df =
+  let rec doit n l = match n with
+    | 0 -> begin
+        match Deque.front l with
+          | Some ({core = Defn (d, wd, _, ex)} as h, l) -> Deque.cons (Defn (d, wd, vis, ex) @@ h) l
+          | Some (e, _) ->
+              if !Params.verbose then
+                Util.eprintf ~at:df "Indicated point is not a definition, but %t!\n%!"
+                  (fun ff -> ignore (Expr.Fmt.pp_print_hyp (l, Ctx.dot) ff e)) ;
+              failwith "Proof.Gen.set_defn/doit" ;
+          | None -> l
+      end
+    | n -> begin match Deque.front l with
+        | Some (h, l) -> Deque.cons h (doit (n - 1) l)
+        | _ -> Errors.bug ~at:df "set_defn for empty context"
+      end
+  in
+    doit
+      (match df.core with
+            | Dx n -> Deque.size l - n
+            | Dvar v ->
+                if !Params.verbose then
+                  Util.eprintf ~at:df "Unknown definition %S\n" v ;
+                failwith "Proof.Gen.set_defn")
+      l
+
+(* from `Proof.Gen` *)
+let domain_match f hran = match f.core with
+  | Apply ({core = Internal Builtin.Mem}, [{core = Ix 0} ; ran])
+      when Expr.Eq.expr hran ran ->
+      true
+  | _ -> false
+
+(* from `Proof.Gen` *)
+let set_expr vis f cx =
+  let succ = ref false in
+  let rec doit f hs = match Deque.front hs with
+    | None -> Deque.empty
+    | Some (h, hs) ->
+        let f = app_expr (shift (-1)) f in
+        let h = begin match h.core with
+          | Fact (hf, hv, tm) when Expr.Eq.expr hf f ->
+              succ := true ;
+              Fact (hf, vis, tm)
+          | Fresh (hx, shp, hk, Bounded (hran, hv)) when domain_match f hran ->
+              succ := true ;
+              Fresh (hx, shp, hk, Bounded (hran, vis))
+          | h -> h
+        end @@ h
+        in Deque.cons h (doit f hs)
+  in
+  let cx = Deque.rev (doit f (Deque.rev cx)) in
+    if !succ then cx else begin
+      Util.eprintf ~at:f "This expression does not appear in the context and cannot be hidden.\n" ;
+      failwith "proof.Gen.set_expr"
+    end
+
+
+let check_enabled_axioms_map = object (self: 'self)
+    inherit [int ref * (Proof.T.step * hyp Deque.dq * int) StringMap.t]
+        Proof.Visit.map as super
+
+    method proof scx pf = let pf = match pf.core with
+      | Omitted _ | Error _ -> pf
+      | Obvious ->
+          self#check_usable pf scx {facts=[]; defs=[]} false
+      | By (usable, onl) ->
+          let pf = By (self#usable scx usable, onl) @@ pf in
+          self#check_usable pf scx usable onl
+      | Steps (inits, qed) ->
+          let (scx, inits) = self#steps scx inits in
+          let qed_prf = self#proof scx (get_qed_proof qed) in
+          Steps (inits, {qed with core = Qed qed_prf}) @@ pf
+      in
+      pf
+
+    method step (((level, sm), cx) as scx) st =
+        (*
+        let step_str = Proof.Fmt.string_of_step cx st in
+        print_string step_str;
+        print_string "\n";
+        *)
+        let stepnm = string_of_stepno (Property.get st Props.step) in
+        (* print_string stepnm; *)
+        assert ((not (StringMap.mem stepnm sm)) ||
+            (* unlabeled step *)
+            ((String.get stepnm ((String.length stepnm) - 1)) = '>'));
+        let sm = if (StringMap.mem stepnm sm) then
+            StringMap.remove stepnm sm else sm in
+        let adj_step scx =
+          Expr.Visit.adj scx (Defn (Operator (
+                stepnm @@ st,
+                At false @@ nowhere) @@ st, Proof
+          Always, Visible, Local) @@ st) in
+        (* sequent's context level *)
+        let rec hyps_level hs =
+            match Deque.front hs with
+            | None -> 0
+            | Some (h, hs) ->
+                let h_level = Expr.Levels.get_level h in
+                let hs_level = hyps_level hs in
+                max h_level hs_level
+            in
+        match st.core with
+        | Forget m ->
+            let nfacts = Deque.size cx in
+            let cx = Deque.map begin
+                         fun n h -> match h.core with
+                           | Fact (e, Visible, tm) when m + n < nfacts ->
+                               Fact (e, Hidden, tm) @@ h
+                           | _ -> h
+                       end cx in
+            (((level, sm), cx),
+                Forget m @@ st)
+        | Hide usables ->
+            let cx = List.fold_left (set_defn Hidden) cx usables.defs in
+            let cx = List.fold_right (set_expr Hidden) usables.facts cx in
+            (((level, sm), cx),
+                Hide usables @@ st)
+        | Use ({defs = []; facts = [f]}, only) ->
+            let tm = Always in
+            let cx = Deque.snoc cx (Fact (f, Visible, tm) @@ f) in
+            (((level, sm), cx),
+                Use ({defs = []; facts = [f]}, only) @@ st)
+        | Assert (sq, prf) ->
+            (* ignore (self#sequent scx sq) ; *)
+            let sq_expr = Expr.Levels.compute_level cx (noprops (Sequent sq)) in
+            let sq = match sq_expr.core with
+                | Sequent sq -> sq
+                | _ -> assert false
+                in
+            let proof_level = ref 0 in
+            let prf =
+                let level_hyps = hyps_level sq.context in
+                (* store (assumption) level of sequent context *)
+                let sm = StringMap.add stepnm (st, cx, level_hyps) sm in
+                let scx = ((proof_level, sm), cx) in
+                (* context changes *)
+                let scx = Expr.Visit.adjs scx (Deque.to_list sq.context) in
+                let scx = Proof.Visit.bump scx 1 in
+                let scx = adj_step scx in
+                let scx = Proof.Visit.bump scx 1 in
+                self#proof scx prf in
+            let scx = adj_step scx in
+            let scx = Proof.Visit.bump scx 1 in
+            let ((_, sm), cx) = scx in
+            (* level computation *)
+            let sq_level = Expr.Levels.get_level sq_expr in
+            (*
+            print_int sq_level;
+            print_string "\n";
+            print_int !proof_level;
+            print_string "\n";
+            *)
+            level := if !proof_level < 2 then
+                !proof_level
+            else
+                min sq_level !proof_level;
+            (*
+            print_int !level;
+            print_string "\n";
+            *)
+            (* store (assumption) level of sequent and its proof *)
+            let sm = StringMap.add stepnm (st, cx, !level) sm in
+            (((level, sm), cx),
+                Assert (sq, prf) @@ st)
+        | Suffices (sq, prf) ->
+            (* ignore (self#sequent scx sq) ; *)
+            let sq_expr = Expr.Levels.compute_level cx (noprops (Sequent sq)) in
+            let sq = match sq_expr.core with
+                | Sequent sq -> sq
+                | _ -> assert false
+                in
+            let proof_level = ref 0 in
+            let prf =
+              let scx = adj_step scx in
+              let scx = Proof.Visit.bump scx 1 in
+              let ((_, sm), cx) = scx in
+              let sq_level = Expr.Levels.get_level sq_expr in
+              level := sq_level;
+              let sm = StringMap.add stepnm (st, cx, !level) sm in
+              let scx = ((proof_level, sm), cx) in
+              self#proof scx prf
+            in
+            let level_hyps = hyps_level sq.context in
+            (* store (assumption) level of sequent context *)
+            let sm = StringMap.add stepnm (st, cx, level_hyps) sm in
+            let scx = ((proof_level, sm), cx) in
+            (* context changes *)
+            let scx = Expr.Visit.adjs scx (Deque.to_list sq.context) in
+            let scx = Proof.Visit.bump scx 1 in
+            let scx = adj_step scx in
+            let scx = Proof.Visit.bump scx 1 in
+            (scx,
+                Suffices (sq, prf) @@ st)
+        | Pcase _
+        | Have _
+        | Take _
+        | Witness _
+        | Pick _ ->
+            assert false  (* after `Proof.Simplify.simplify` *)
+        | _ ->
+            let sm = StringMap.add stepnm (st, cx, 1) sm in
+            let scx = ((level, sm), cx) in
+            super#step scx st
+
+    method check_usable pf ((level, sm), cx) usables only =
+        (* computation of proof's assumption expression level *)
+        let check_fact cx fact =
+            begin match fact.core with
+            | Ix n -> begin
+            let hyp = E_t.get_val_from_id cx n in
+            let cx_ = Expr.T.cx_front cx n in
+                match hyp.core with
+                | Fact (expr, Visible, _) ->
+                    print_string (Expr.Fmt.string_of_expr cx_ expr);
+                    assert false
+                (* checking referenced steps *)
+                | Defn ({core=Operator (name, _)}, _, Visible, _) ->
+                    (*
+                    print_string "Step number:\n";
+                    print_string name.core;
+                    *)
+                    let nm = name.core in
+                    if (String.contains_from nm 0 '<') then begin
+                        if (StringMap.mem nm sm) then begin
+                            let (step, cx, step_level) = StringMap.find nm sm in
+                            level := max step_level !level
+                        end end
+                | _ -> ()
+                end
+            (* checking of expressions in the BY statement *)
+            | _ ->
+                let fact = Expr.Levels.compute_level cx fact in
+                let expr_level = Expr.Levels.get_level fact in
+                level := max expr_level !level
+            end
+            in
+        (* checking assumptions in the step's context *)
+        if not only then begin
+        let check_assumptions n hyp =
+            match hyp.core with
+            | Fact ({core=At _}, _, _) -> ()  (* dummy steps *)
+            | Fact (expr, Visible, _) ->
+                let cx_ = Expr.T.cx_front cx ((Deque.size cx) - n) in
+                (*
+                print_string "Fact:\n";
+                print_string (Expr.Fmt.string_of_expr cx_ expr);
+                *)
+                check_fact cx_ expr
+            | _ -> ()
+            in
+        Deque.iter check_assumptions cx
+        end;
+
+        let max_level = ref 0 in
+        let check_step cx fact =
+            begin match fact.core with
+            | Ix n -> begin
+                let hyp = E_t.get_val_from_id cx n in
+                match hyp.core with
+                | Defn ({core=Operator (name, _)}, _, Visible, _) ->
+                    let nm = name.core in
+                    (* is this a step number ? *)
+                    if (String.contains_from nm 0 '<') then begin
+                        if (StringMap.mem nm sm) then begin
+                            (* print_string ("Found stored step " ^ nm ^ "\n"); *)
+                            let (step, cx, step_level) = StringMap.find nm sm in
+                            max_level := max step_level !max_level
+                        end end
+                | _ -> ()
+                end
+            | _ ->
+                let fact = Expr.Levels.compute_level cx fact in
+                let expr_level = Expr.Levels.get_level fact in
+                max_level := max expr_level !max_level
+            end
+            in
+        let check_steps n hyp =
+            match hyp.core with
+            (*
+            | Defn ({core=Operator (name, _)}, _, Visible, _) ->
+                let nm = name.core in
+                (* is this a step number ? *)
+                if (String.contains_from nm 0 '<') then begin
+                    if (StringMap.mem nm sm) then begin
+                        (* print_string ("Found stored step " ^ nm ^ "\n"); *)
+                        let (step, cx, step_level) = StringMap.find nm sm in
+                        (*
+                        if (step_level > 1) && (!max_level <= 1) then
+                            print_string nm;
+                        *)
+                        max_level := max step_level !max_level;
+                    end end
+            *)
+            | Fact ({core=At _}, _, _) -> ()  (* dummy steps *)
+            | Fact (expr, Visible, _) ->
+                let cx_ = Expr.T.cx_front cx ((Deque.size cx) - n) in
+                (*
+                print_string (Expr.Fmt.string_of_expr cx_ expr);
+                print_string "\n";
+                *)
+                check_step cx_ expr
+            | _ -> ()
+            in
+        (* find proof directive in the context *)
+        let found = ref false in
+        let find_proof_directive n hyp =
+            match hyp.core with
+            | Fact (expr, Visible, _) ->
+                let cx_ = Expr.T.cx_front cx ((Deque.size cx) - n) in
+                begin match expr.core with
+                | Ix n -> begin
+                    let hyp = E_t.get_val_from_id cx_ n in
+                    match hyp.core with
+                    | Defn ({core=Bpragma (name, _, _)}, _, _, _) ->
+                        found := !found || (name.core = "ENABLEDaxioms")
+                    | _ -> ()
+                    end
+                | _ -> ()
+                end
+            | _ -> ()
+            in
+        Deque.iter find_proof_directive cx;
+
+        if !found then begin
+            (* print_string "Found ENABLEDaxioms\n"; *)
+            Deque.iter check_steps cx;
+            if (!max_level > 1) then
+                begin
+                Util.eprintf ~at:pf "%s"
+                    ("ENABLEDaxioms depends on assumption of expression " ^
+                    "level > 1");
+                (*
+                Util.eprintf "%a@" (Proof.Fmt.pp_print_proof (cx, Ctx.dot)) pf
+                *)
+                assign pf enabledaxioms false
+                end
+            else
+                assign pf enabledaxioms true
+            end
+        else
+            assign pf enabledaxioms true
+end
+
+
+let check_enabled_axioms_usage = object (self: 'self)
+    inherit [unit]
+        Proof.Visit.iter as super
+
+    val mutable found_enabled_axioms: bool = false
+
+    method find_enabled_axioms cx pf =
+        found_enabled_axioms <- false;
+        let scx = ((), cx) in
+        self#proof scx pf;
+        found_enabled_axioms
+
+    method proof ((_, cx) as scx) pf = match pf.core with
+        | Omitted _ | Error _ -> ()
+        | Obvious ->
+            self#check_usable pf scx {facts=[]; defs=[]} false
+        | By (usable, onl) ->
+            self#check_usable pf scx usable onl
+        | Steps (inits, qed) ->
+            let scx = self#steps scx inits in
+            self#proof scx (get_qed_proof qed);
+
+    method step ((_, cx) as scx) st =
+        let stepnm = string_of_stepno (Property.get st Props.step) in
+        let adj_step scx =
+          Expr.Visit.adj scx (Defn (Operator (
+                stepnm @@ st,
+                At false @@ nowhere) @@ st, Proof
+          Always, Visible, Local) @@ st) in
+        match st.core with
+        | Forget m ->
+            let nfacts = Deque.size cx in
+            let cx = Deque.map begin
+                         fun n h -> match h.core with
+                           | Fact (e, Visible, tm) when m + n < nfacts ->
+                               Fact (e, Hidden, tm) @@ h
+                           | _ -> h
+                       end cx in
+            ((), cx)
+        | Hide usables ->
+            let cx = List.fold_left (set_defn Hidden) cx usables.defs in
+            let cx = List.fold_right (set_expr Hidden) usables.facts cx in
+            ((), cx)
+        | Use ({defs = []; facts = [f]}, only) ->
+            let tm = Always in
+            let cx = Deque.snoc cx (Fact (f, Visible, tm) @@ f) in
+            ((), cx)
+        | Assert (sq, prf) ->
+            let () =
+                (* context changes *)
+                let scx = Expr.Visit.adjs ((), cx) (Deque.to_list sq.context) in
+                let scx = Proof.Visit.bump scx 1 in
+                let scx = adj_step scx in
+                let scx = Proof.Visit.bump scx 1 in
+                self#proof scx prf in
+            let scx = adj_step scx in
+            let scx = Proof.Visit.bump scx 1 in
+            let (_, cx) = scx in
+            ((), cx)
+        | Suffices (sq, prf) ->
+            let () =
+              let scx = adj_step scx in
+              let scx = Proof.Visit.bump scx 1 in
+              let (_, cx) = scx in
+              self#proof ((), cx) prf
+            in
+            let scx = ((), cx) in
+            let scx = Expr.Visit.adjs scx (Deque.to_list sq.context) in
+            let scx = Proof.Visit.bump scx 1 in
+            let scx = adj_step scx in
+            let scx = Proof.Visit.bump scx 1 in
+            scx
+        | Pcase _
+        | Have _
+        | Take _
+        | Witness _
+        | Pick _ ->
+            assert false  (* after `Proof.Simplify.simplify` *)
+        | _ ->
+            let scx = ((), cx) in
+            super#step scx st
+
+    method check_usable pf (_, cx) usables only =
+        let found = ref false in
+        (* find proof directive in the context *)
+        let cx_iter n hyp =
+            match hyp.core with
+            | Fact (expr, _, _) ->
+                let cx_ = Expr.T.cx_front cx ((Deque.size cx) - n) in
+                begin match expr.core with
+                | Ix n -> begin
+                    let hyp = E_t.get_val_from_id cx_ n in
+                    match hyp.core with
+                    | Defn ({core=Bpragma (name, _, _)}, _, _, _) ->
+                        found := !found || (name.core = "ENABLEDaxioms")
+                    | _ -> ()
+                    end
+                | _ -> ()
+                end
+            | _ -> ()
+            in
+        Deque.iter cx_iter cx;
+        if !found then begin
+            found_enabled_axioms <- true;
+            end
+end
+
+(******************************************************************************)
+
+let assert_module_exists name mcx mu =
+    if not (StringMap.mem name mcx) then begin
+      Errors.err ~at:mu "Module %S unknown\n%!" name;
+      failwith "Module.Elab.normalize";
+    end
+
+
 (* is_anon = false => not yet anonymised *)
 let rec normalize mcx cx m =
   let origbody = m.core.body in
   let prefix = ref Deque.empty in
   let emit mu = prefix := Deque.snoc !prefix mu in
+  let gencx = cx in
+  (* let submod_obs: Proof.T.obligation list ref = ref [] in *)
   let rec spin mcx cx = function
     | [] -> cx
     | (mu, is_anon) :: mus ->
       begin
+        let print cx mu s =
+            let hs = hyps_of_modunit mu in
+            let pr_mu ff =
+                ignore (M_fmt.pp_print_modunit (cx, Ctx.dot) ff mu) in
+            let pr_seq ff =
+                ignore (Expr.Fmt.pp_print_sequent (cx, Ctx.dot) ff
+                               {context = Deque.of_list hs;
+                                active = (At false) @@ mu}) in
+            Util.eprintf ~debug:"inst" ~at:mu
+                         "((%s)) modunit = %thyps = %t@." s
+                         pr_mu pr_seq
+            in
         let continue mcx cx mu s =
-          emit mu;
-          let hs = hyps_of_modunit mu in
-          let pr_mu ff =
-            ignore (M_fmt.pp_print_modunit (cx, Ctx.dot) ff mu)
-          in
-          let pr_seq ff =
-            ignore (Expr.Fmt.pp_print_sequent (cx, Ctx.dot) ff
-                             {context = Deque.of_list hs;
-                              active = (At false) @@ mu})
-          in
-          Util.eprintf ~debug:"inst" ~at:mu
-                       "((%s)) modunit = %thyps = %t@." s
-                       pr_mu pr_seq;
-          let cx = Deque.append_list cx (hyps_of_modunit mu) in
-          spin mcx cx mus
+            emit mu;
+            print cx mu s;
+            let cx = Deque.append_list cx (hyps_of_modunit mu) in
+            spin mcx cx mus
         in
+        let const_visitor =
+            object inherit Expr.Constness.const_visitor end in
+        let redundant nm = match nm with
+            | None -> false
+            | Some nm ->
+                let what = Expr.Anon.hyp_is_named nm.core in
+                Deque.find cx what != None
+        in
+        let map_proof cx nm sq pf mu m = begin
+        (* add a definition for the theorem if it is named,
+        to the context `cx` within the theorem's proof
+        *)
+            let (cx, sq) =
+                match nm with
+                    | Some nm ->
+                        let op_sq = exprify_sequent sq @@ nm in
+                        let op = Operator (nm, op_sq) @@ mu in
+                        (Deque.snoc
+                            cx
+                            (Defn (op, Proof Always, Visible, Export) @@ mu),
+                            app_sequent (shift 1) sq)
+                    | None ->
+                        (cx, sq)
+                    in
+            (* add the theorem's hypotheses to the context `cx` within
+            the theorem's proof
+            *)
+            let cx = Deque.append cx sq.context in
+            let time_flag = Expr.Temporal_props.check_time_change
+                sq.context Always in
+            Util.eprintf ~debug:"simplify" ~at:mu
+                "@[<v0>Simplifying:@,  THEOREM %a@,  %a@]"
+                    (Expr.Fmt.pp_print_expr (Deque.empty, Ctx.dot))
+                    (exprify_sequent sq @@ mu)
+                    (Proof.Fmt.pp_print_proof (cx, Ctx.dot))
+                    pf;
+            (*let pf =
+            let visitor1 = object
+            inherit [unit] Proof.Visit.map as proofer
+            inherit Expr.Constness.const_visitor
+            method proof scx pf = proofer#proof scx pf
+            end
+            in
+            visitor1#proof ((),cx) pf in*)
+            let pf = anon#mproof mcx ([], cx) pf in
+            (* comment this condition check to generate proofs for
+            all modules, including submodules, even when the parser
+            marks submodules as not important.
+            *)
+            if m.core.important then begin
+                let pf = Proof.Simplify.simplify cx sq.active pf time_flag in
+                    (* ((ref 0, StringMap.empty), cx) pf; *)
+                let has = check_enabled_axioms_usage#find_enabled_axioms
+                    cx pf in
+                let pf = if has then check_enabled_axioms_map#proof
+                    ((ref 0, StringMap.empty), cx) pf else pf in
+                pf
+                end
+            else
+                pf
+            end
+            in
+        let create_instance inst mcx cx mu ~local ~iname =
+            assert_module_exists inst.inst_mod mcx mu;
+            Util.eprintf ~debug:"inst" ~at:mu
+                "Instantiating: %t@."
+                (fun ff -> ignore (M_fmt.pp_print_modunit (cx, Ctx.dot) ff mu));
+            let submus =
+                instantiate anon mcx cx (inst @@ mu)
+                    ~local:local ~iname:iname in
+            (* iterate over the list of statements introduced by `INSTANCE`,
+            concatenated with the remaining module units (the list `mus`).
+            *)
+            let is_anon = true in
+            let same x = (x, is_anon) in
+            let submus = List.map same submus in
+            spin mcx cx (submus @ mus)
+            in
         match mu.core with
         | Anoninst (inst, loc) ->
-          begin
-            if not (Sm.mem inst.inst_mod mcx) then begin
-              Errors.err ~at:mu "Module %S unknown\n%!" inst.inst_mod;
-              failwith "Module.Elab.normalize";
-            end;
-            let submus =
-              instantiate anon mcx cx (inst @@ mu) ~local:loc ~iname:("" @@ mu)
-            in
-            spin mcx cx ((List.map (fun x -> x,true) submus) @ mus)
-          end
+            create_instance inst mcx cx mu ~local:loc ~iname:("" @@ mu)
         | Definition ({core = Instance (nm, inst)}, _, _, ex) ->
-          begin
-            if not (Sm.mem inst.inst_mod mcx) then begin
-              Errors.err ~at:mu "Module %S unknown\n%!" inst.inst_mod;
-              failwith "Module.Elab.normalize";
-            end;
-            Util.eprintf ~debug:"inst" ~at:mu
-              "Instantiating: %t@."
-              (fun ff -> ignore (M_fmt.pp_print_modunit (cx, Ctx.dot) ff mu));
-            let submus =
-              instantiate anon mcx cx (inst @@ mu) ~local:ex ~iname:nm
-            in
-            spin mcx cx ((List.map (fun x -> x,true) submus) @ mus)
-          end
+            create_instance inst mcx cx mu ~local:ex ~iname:nm
         | Definition ({core = Operator (nm, _)} as df, wd, vis, ex)
             (* treat pragma definitions as usual operator definitions *)
         | Definition ({core = Bpragma (nm, _, _)} as df, wd, vis, ex) ->
           begin
             let df = if is_anon then df else anon#defn ([], cx) df in
-            let df =
-                let visitor = object
-                  inherit Expr.Constness.const_visitor
-                end
-                in
-                visitor#defn ((),cx) df in
+            let df = const_visitor#defn ((), cx) df in
             let mu = Definition (df, wd, vis, ex) @@ mu in
             (* merge identical operator definitions *)
             let h = Defn (df, wd, vis, ex) @@ mu in
@@ -508,7 +1187,7 @@ let rec normalize mcx cx m =
                 if eq then begin
                   let mus,flags = List.split mus in
                   let (_, mus) =
-                    app_modunits (scons (Ix (x + 1) @@ h) (shift 0)) (mus) in
+                    M_subst.app_modunits (scons (Ix (x + 1) @@ h) (shift 0)) (mus) in
                   let mus = List.combine mus flags in
                     spin mcx cx mus
                 end else begin
@@ -523,34 +1202,17 @@ let rec normalize mcx cx m =
         | Constants _
         | Variables _ -> continue mcx cx mu "Variables"
         | Axiom (nm, e) ->
-            let redundant =
-              match nm with
-              | None -> false
-              | Some nm ->
-                  Deque.find cx (Expr.Anon.hyp_is_named nm.core) != None
-            in
-            if redundant then begin
+            if redundant nm then begin
               spin mcx cx mus
             end else begin
               let e = anon#mexpr mcx ([], cx) e in
-              let e =
-                let visitor = object
-                  inherit Expr.Constness.const_visitor
-                end
-                in
-                visitor#expr ((),cx) e in
+              let e = const_visitor#expr ((), cx) e in
               let mu = Axiom (nm, e) @@ mu in
               continue mcx cx mu "Axiom"
             end
         | Theorem (nm, sq, naxs, pf, pf_orig, summ) ->
-            let redundant =
-              match nm with
-              | None -> false
-              | Some nm ->
-                  Deque.find cx (Expr.Anon.hyp_is_named nm.core) != None
-            in
             let (nm, pf, pf_orig) =
-              if redundant then begin
+              if redundant nm then begin
                 let name =
                   match nm with
                   | Some n -> ("(redundant)" ^ n.core) @@ n
@@ -561,45 +1223,12 @@ let rec normalize mcx cx m =
             in
             begin
               let (_, sq) = anon#msequent mcx ([], cx) sq in
-              let (_, sq) =
-                let visitor = object
-                  inherit Expr.Constness.const_visitor
-                end
-                in
-                visitor#sequent ((),cx) sq in
-              let pf =
-                let (cx, sq) =
-                  match nm with
-                  | Some nm ->
-                      let op = Operator (nm, exprify_sequent sq @@ nm) @@ mu in
-                      (Deque.snoc cx (Defn (op, Proof Always, Visible, Export) @@ mu),
-                       app_sequent (shift 1) sq)
-                  | None ->
-                      (cx, sq)
-                in
-                let cx = Deque.append cx sq.context in
-                let time_flag = Expr.Temporal_props.check_time_change sq.context Always in
-                Util.eprintf ~debug:"simplify" ~at:mu
-                  "@[<v0>Simplifying:@,  THEOREM %a@,  %a@]"
-                  (Expr.Fmt.pp_print_expr (Deque.empty, Ctx.dot))
-                  (exprify_sequent sq @@ mu)
-                  (Proof.Fmt.pp_print_proof (cx, Ctx.dot)) pf;
-                (*let pf =
-                  let visitor1 = object
-                    inherit [unit] Proof.Visit.map as proofer
-                    inherit Expr.Constness.const_visitor
-                    method proof scx pf = proofer#proof scx pf
-                  end
-                  in
-                  visitor1#proof ((),cx) pf in*)
-                let pf = anon#mproof mcx ([], cx) pf in
-                if m.core.important then
-                  Proof.Simplify.simplify cx sq.active pf time_flag
-                else pf
-              in
+              let (_, sq) = const_visitor#sequent ((),cx) sq in
+              let pf = map_proof cx nm sq pf mu m in
               (* we apply it later to obligations so we can skip the proofs
                * themselves *)
-(*              let pf =
+              (*
+                let pf =
                 let visitor = object
                   inherit [unit] Proof.Visit.map as proofer
                   inherit Expr.Constness.const_visitor
@@ -624,13 +1253,17 @@ let rec normalize mcx cx m =
             continue mcx cx mu "Mutate"
         | Submod m ->
             let (mcx, m, _) = normalize mcx cx m in
+            (* let (m, obs, summ) = M_gen.generate gencx m in
+            submod_obs := List.append !submod_obs obs; *)
             let mu = Submod m @@ mu in
             continue mcx cx mu "Submod"
         end
   in
-  let gencx = cx in
-  let _cx = spin mcx cx (List.map (fun x -> x,false) m.core.body) in
-    Util.eprintf ~debug:"foo" "%a" (fun fmt cx -> ignore (Expr.Fmt.pp_print_sequent (Deque.empty, Ctx.dot) fmt cx))  ({context = _cx ; active = Ix(1) @@ m});
+  let _cx = spin mcx cx (List.map (fun x -> x, false) m.core.body) in
+    Util.eprintf ~debug:"noprinting" "%a"
+        (fun fmt cx -> ignore (
+            Expr.Fmt.pp_print_sequent (Deque.empty, Ctx.dot) fmt cx))
+        ({context = _cx ; active = Ix(1) @@ m});
   let prefix = Deque.to_list !prefix in
   let maybe_salt mu =
     if has mu salt_prop then begin
@@ -655,10 +1288,12 @@ let rec normalize mcx cx m =
             sum_suppressed = 0, []
           })
   in
+  (* let all_obs = List.append obs !submod_obs in *)
   let m = match m.core.stage with
     | Special -> m
     | Flat ->
         let stage = Final { final_named  = origbody
+                          (* ; final_obs    = Array.of_list all_obs *)
                           ; final_obs    = Array.of_list obs
                           ; final_status = (Unchecked, summ)
                           }
@@ -669,5 +1304,5 @@ let rec normalize mcx cx m =
         Errors.bug ~at:m "Elaborating a final module"
   in
   let m = { m.core with defdepth = Deque.size gencx } @@ m in
-  let mcx = Sm.add m.core.name.core m mcx in
+  let mcx = StringMap.add m.core.name.core m mcx in
   (mcx, m, summ)

--- a/src/module/m_elab.mli
+++ b/src/module/m_elab.mli
@@ -7,7 +7,13 @@
 
 (** Elaborate modules *)
 
-open Proof.T
+open Deque
+open Expr.T
+open Expr.Visit
+
 open M_t
 
-val normalize : modctx -> Expr.T.hyp Deque.dq -> mule -> modctx * mule * summary
+
+val normalize :
+    modctx -> Expr.T.ctx -> mule ->
+    modctx * mule * summary

--- a/src/module/m_parser.ml
+++ b/src/module/m_parser.ml
@@ -92,6 +92,7 @@ and parse = lazy begin
   locate (use parse_)
 end
 
+(* submodules --- See above *)
 and parse_ = lazy begin
   (punct "----" >*> kwd "MODULE" >*> locate anyname <<< punct "----")
   <*> optional (kwd "EXTENDS" >>> sep1 (punct ",") (locate anyident))
@@ -102,7 +103,7 @@ and parse_ = lazy begin
     ; extendees = extends
     ; instancees = []
     ; defdepth = 0
-    ; important = false
+    ; important = (* false *) true  (* to simplify proofs of submodules *)
     ; body = List.concat mus
     ; stage = Parsed }
   end

--- a/src/module/m_standard.ml
+++ b/src/module/m_standard.ml
@@ -25,16 +25,20 @@ let stm x = Util.locate x stloc
 let st = stm ()
 
 let nullary what op =
-  Definition (Operator (what @@ st, Apply (Internal op @@ st, []) @@ st) @@ st, Builtin, Visible, Export) @@ st
+    let name = what @@ st in
+    let op = Internal op @@ st in
+    let df = Operator (name, op) @@ st in
+    Definition (df, Builtin, Visible, Export) @@ st
 
 let lambda arity name fn =
+  assert (arity >= 1);
   let vars = List.init arity (fun n -> ("x" ^ string_of_int (n + 1)) @@ st, Shape_expr) in
   let lambda = Lambda (vars, fn vars) @@ st in
   Definition (Operator (name @@ st, lambda) @@ st, Builtin, Visible, Export) @@ st
 
 let operator arity name op =
   lambda arity name begin
-    fun _ ->
+    fun _ -> assert (arity >= 1);
       Apply (Internal op @@ st,
              List.init arity (fun n -> Ix (arity - n) @@ st)) @@ st
   end
@@ -218,7 +222,7 @@ let tlapm =
         (* sequences *)
         unary   "Builtins!Seq"           B.Seq ;
         unary   "Builtins!Len"           B.Len ;
-        unary   "Builtins!Bounded"       B.BSeq ;
+        binary  "Builtins!Bounded"       B.BSeq ;
         binary  "Builtins!Cat"           B.Cat ;
         binary  "Builtins!Append"        B.Append ;
         unary   "Builtins!Head"          B.Head ;

--- a/src/module/m_subst.ml
+++ b/src/module/m_subst.ml
@@ -1,0 +1,57 @@
+(* Utilities for performing substitutions in module syntax graphs. *)
+open Property
+
+open Expr.T
+open Expr.Subst
+
+open M_t
+
+
+let rec app_modunits (s: sub) (mus: modunit list):  (sub * modunit list) =
+    match mus with
+  | [] -> (s, [])
+  | (mu: modunit) :: mus ->
+      let (s, (mu: modunit)) = app_modunit s mu in
+      let (s, mus) = app_modunits s mus in
+      (s, mu :: mus)
+
+
+and app_modunit (s: sub) (mu: modunit):  (sub * modunit) =
+  match mu.core with
+  | Constants cs ->
+      (bumpn (List.length cs) s, mu)
+  | Recursives cs ->
+      (bumpn (List.length cs) s, mu)
+  | Variables vs ->
+      (bumpn (List.length vs) s, mu)
+  | Definition (df, wd, vis, ex) ->
+      let df = app_defn s df in
+      (bump s, Definition (df, wd, vis, ex) @@ mu)
+  | Axiom (nm, e) ->
+      let e = app_expr s e in
+      let s = bumpn (if nm = None then 1 else 2) s in
+      (s, Axiom (nm, e) @@ mu)
+  | Theorem (nm, sq, naxs, prf, prf_orig,summ) ->
+      let sq = app_sequent s sq in
+      let s = bump s in
+      let prf =
+        let s = bumpn (Deque.size sq.context) s in
+        Proof.Subst.app_proof s prf
+      in
+      let s = if nm = None then s else bump s in
+      (s, Theorem (nm, sq, naxs, prf, prf_orig, summ) @@ mu)
+  | Submod m ->
+      let m = app_mule s m in
+      (s, Submod m @@ mu)
+  | Mutate (uh, us) ->
+      let us = Proof.Subst.app_usable s us in
+      let s = if uh = `Hide then s else bumpn (List.length us.facts) s in
+      (s, Mutate (uh, us) @@ mu)
+  | Anoninst (inst, loc) ->
+      let isub = List.map (fun (v, e) -> (v, app_expr s e)) inst.inst_sub in
+      (s, Anoninst ({inst with inst_sub = isub}, loc) @@ mu)
+
+
+and app_mule (s: sub) (m: mule) =
+  let (_, bod) = app_modunits s m.core.body in
+  { m.core with body = bod } @@ m

--- a/src/module/m_subst.mli
+++ b/src/module/m_subst.mli
@@ -1,0 +1,9 @@
+(* Utilities for performing substitutions in module syntax graphs. *)
+open Expr.Subst
+
+open M_t
+
+
+val app_modunits: sub -> modunit list -> sub * modunit list
+val app_modunit: sub -> modunit -> sub * modunit
+val app_mule: sub -> mule -> mule

--- a/src/module/m_t.ml
+++ b/src/module/m_t.ml
@@ -41,7 +41,7 @@ and modunit_ =
   | Theorem    of hint option * sequent * int * proof * proof * summary
   | Submod     of mule
   | Mutate     of [`Use of bool | `Hide] * usable
-  | Anoninst   of instance * export
+  | Anoninst   of Expr.T.instance * export
 
 and named = Named | Anonymous
 
@@ -96,6 +96,7 @@ let hyps_of_modunit (mu : modunit) = match mu.core with
   | Variables vs ->
       List.map (fun nm -> Flex nm @@ mu) vs
   | Definition (df, wd, vis, ex) ->
+      (* defined instances are assumed to have been expanded *)
       [ Defn (df, wd, vis, ex) @@ mu ]
   | Axiom (None, e) ->
       [ Fact (e, Hidden, Always) @@ mu ]

--- a/src/module/m_t.mli
+++ b/src/module/m_t.mli
@@ -12,11 +12,12 @@ open Proof.T;;
 type mule = mule_ wrapped
 and mule_ = {
   name              : hint ;
-  extendees         : hint list ;
-  instancees        : hint list ;
-    (* only external instancees *)
+  extendees         : hint list ;  (* module names from `EXTENDS` statements *)
+  instancees        : hint list ;  (* module names from `INSTANCE` statements,
+                                      only external instancees *)
   body              : modunit list ;
-  defdepth          : int ;
+  defdepth          : int ;  (* context depth:
+      number of declarations and definitions (TODO: confirm) *)
   mutable stage     : stage ;
   mutable important : bool
 }

--- a/src/module/m_visit.ml
+++ b/src/module/m_visit.ml
@@ -1,0 +1,114 @@
+(* Visitor class for module syntax graphs.
+
+Based on the modules:
+    - `Expr.Visit`
+    - `Module.Elab`
+    - `Module.T`
+
+*)
+open Expr.T
+open Property
+
+open M_t
+
+
+module Dq = Deque
+
+
+let update_cx (cx: ctx) mu =
+    let hyps = M_t.hyps_of_modunit (noprops mu) in
+    Dq.append_list cx hyps
+
+
+class map =
+    object (self : 'self)
+
+    method module_units cx tla_module =
+        (* The context `cx` would be relevant for modules that extend modules
+        or for submodules.
+        *)
+        let new_module = [] in
+        let init = (cx, new_module) in
+        let f (cx, new_module) mu =
+            let (cx, mu) = self#module_unit cx mu in
+            let new_module = List.append new_module [mu] in
+            (cx, new_module) in
+        let (cx, new_module) = List.fold_left
+            f init tla_module in
+        (cx, new_module)
+
+    method module_unit (cx: ctx) (mu: M_t.modunit) =
+        let (cx, core) = match mu.core with
+        (* Declarations *)
+        | Constants decls -> self#constants cx decls
+        | Variables names -> self#variables cx names
+        | Recursives decls -> self#recursives cx decls
+        (* Definitions *)
+        | Definition (df, wd, vsbl, local) ->
+            self#definition cx df wd vsbl local
+        (* Theorems and proofs *)
+        | Axiom (name, expr) -> self#axiom cx name expr
+        | Theorem (name, sq, naxs, pf, orig_pf, summ) ->
+            self#theorem cx name sq naxs pf orig_pf summ
+        | Mutate (change, usable) -> self#mutate cx change usable
+        (* Modules and instances *)
+        | Submod tla_module -> self#submod cx tla_module
+        | Anoninst (inst, local) -> self#anoninst cx inst local
+        in
+        (cx, core @@ mu)
+
+    method constants cx decls =
+        let mu = Constants decls in
+        let cx = update_cx cx mu in
+        (cx, mu)
+
+    method variables cx names =
+        let mu = Variables names in
+        let cx = update_cx cx mu in
+        (cx, mu)
+
+    method recursives cx decls =
+        let mu = Recursives decls in
+        let cx = update_cx cx mu in
+        (cx, mu)
+
+    method definition cx df wd vsbl local =
+        (* TODO: assumes that `INSTANCE` statements have been expanded *)
+        let mu = Definition (df, wd, vsbl, local) in
+        let cx = update_cx cx mu in
+        (cx, mu)
+
+    method axiom cx name expr =
+        let mu = Axiom (name, expr) in
+        (* add a fact for the axiom, and, if named, then also a definition,
+        to the context `cx`
+        *)
+        let cx = update_cx cx mu in
+        (cx, mu)
+
+    method theorem cx name sq naxs pf orig_pf summ =
+        (* add the hypotheses of the theorem to the context `cx` *)
+        let mu = Theorem (name, sq, naxs, pf, orig_pf, summ) in
+        (* add a fact for the theorem, and, if named, then also a definition,
+        to the context `cx`
+        *)
+        let cx = update_cx cx mu in
+        (cx, mu)
+
+    method mutate cx change usable =
+        let mu = Mutate (change, usable) in
+        (* TODO: change the visibility of facts in `cx` based on the
+        `Mutate` statement.
+        *)
+        (cx, mu)
+
+    method submod cx tla_module =
+        let mu = Submod tla_module in
+        (cx, mu)
+
+    method anoninst cx inst local =
+        (* TODO: expand statements from `INSTANCE` *)
+        let mu = Anoninst (inst, local) in
+        (cx, mu)
+
+end

--- a/src/module/m_visit.mli
+++ b/src/module/m_visit.mli
@@ -1,0 +1,32 @@
+open Expr.T
+open Proof.T
+open Util
+
+open M_t
+
+
+class map : object
+    method module_units: Expr.T.ctx -> M_t.modunit list ->
+        ctx * M_t.modunit list
+    method module_unit: ctx -> M_t.modunit ->
+        ctx * modunit
+    method constants: ctx -> (hint * shape) list ->
+        ctx * modunit_
+    method variables: ctx -> hint list ->
+        ctx * modunit_
+    method recursives: ctx -> (hint * shape) list ->
+        ctx * modunit_
+    method definition: ctx -> defn -> wheredef -> visibility -> export ->
+        ctx * modunit_
+    method axiom: ctx -> hint option -> expr ->
+        ctx * modunit_
+    method theorem:
+        ctx -> hint option -> sequent -> int -> proof -> proof -> summary ->
+        ctx * modunit_
+    method submod: ctx -> mule ->
+        ctx * modunit_
+    method mutate: ctx -> [`Use of bool | `Hide] -> usable ->
+        ctx * modunit_
+    method anoninst: ctx -> Expr.T.instance -> export ->
+        ctx * modunit_
+end

--- a/src/params.ml
+++ b/src/params.ml
@@ -86,7 +86,7 @@ let get_exec e =
     let r = 10000 + (Random.int 10000) in
      let stat = sprintf "echo path prefix: \"%s\" ; %s stat `which %s` >/tmp/stat-%d-%d.txt"
                 path_prefix path_prefix exec tod r in
-     
+
      ignore (Sys.command stat);
      let check = sprintf "%s type %s >/tmp/check-%d-%d.txt" path_prefix exec tod r in
        *)
@@ -204,6 +204,8 @@ let eprover = make_exec "eprover" "eprover --auto --tstp-format --silent \"$file
 
 let ls4 = make_exec "ls4" "ptl_to_trp -i $file | ls4" "echo unknown";;
 
+let smt_logic = ref "UFNIA"
+
 (* The default SMT solver is now Z3. The user can override it with:
    - environment variable TLAPM_SMT_SOLVER
    - command-line option --solver
@@ -218,6 +220,9 @@ let smt =
     (* Yices does not handle SMTLIB version 2 yet *)
 
 let set_smt_solver slv = smt := User slv;;
+
+let set_smt_logic logic = smt_logic := logic
+
 
 let max_threads = ref nprocs
 

--- a/src/params.mli
+++ b/src/params.mli
@@ -47,6 +47,9 @@ val noproving : bool ref;;
 val max_threads : int ref;;
 val path_prefix : string;;
 
+(* backend/smt.ml *)
+val smt_logic : string ref
+
 (* backend/fingerprints.ml *)
 val rawversion : unit -> string;;
 val get_zenon_verfp : unit -> string;;
@@ -82,6 +85,7 @@ val stats : bool ref;;
 val add_search_dir : string -> unit;;
 val keep_going : bool ref;;   (* FIXME check still used ? *)
 val suppress_all : bool ref;;
+val set_smt_logic : string -> unit;;
 val set_smt_solver : string -> unit;;
 val printconfig : bool -> string;;
 val print_config_toolbox : bool -> string;;

--- a/src/pars/intf.ml
+++ b/src/pars/intf.ml
@@ -12,7 +12,7 @@ module type Tok = sig
   type token
     (** Type of tokens *)
 
-  val bof : Loc.locus -> token
+  val bof : Loc.locus -> token  (* beginning of file *)
     (** token representing start of file *)
 
   val rep : token -> string

--- a/src/system.ml
+++ b/src/system.ml
@@ -109,13 +109,13 @@ let make_line_buffer fd = {desc = fd; buf = Buffer.create 100};;
 let rawbuf = Bytes.create 1000;;
 
 let read_lines buf =
-  let n = Unix.read buf.desc rawbuf 0 (String.length rawbuf) in
+  let n = Unix.read buf.desc rawbuf 0 (String.length (Bytes.to_string rawbuf)) in
   if n = 0 then begin
     let last = Buffer.contents buf.buf in
     Buffer.reset buf.buf;
     if last = "" then [Leof] else [Line last; Leof]
   end else begin
-    Buffer.add_substring buf.buf rawbuf 0 n;
+    Buffer.add_substring buf.buf (Bytes.to_string rawbuf) 0 n;
     let data = Buffer.contents buf.buf in
     let lines = Ext.split data '\n' in
     match List.rev lines with

--- a/src/system.ml
+++ b/src/system.ml
@@ -109,13 +109,13 @@ let make_line_buffer fd = {desc = fd; buf = Buffer.create 100};;
 let rawbuf = Bytes.create 1000;;
 
 let read_lines buf =
-  let n = Unix.read buf.desc rawbuf 0 (String.length (Bytes.to_string rawbuf)) in
+  let n = Unix.read buf.desc rawbuf 0 (Bytes.length rawbuf) in
   if n = 0 then begin
     let last = Buffer.contents buf.buf in
     Buffer.reset buf.buf;
     if last = "" then [Leof] else [Line last; Leof]
   end else begin
-    Buffer.add_substring buf.buf (Bytes.to_string rawbuf) 0 n;
+    Buffer.add_subbytes buf.buf rawbuf 0 n;
     let data = Buffer.contents buf.buf in
     let lines = Ext.split data '\n' in
     match List.rev lines with

--- a/src/tlapm.ml
+++ b/src/tlapm.ml
@@ -57,245 +57,400 @@ module Clocks = struct
 
 end
 
+
+let mkdir_tlaps t =
+    let cachedir = "__tlacache__" in
+    let tlapsdir = cachedir ^ "/" ^ t.core.name.core ^ ".tlaps" in
+    if not (Sys.file_exists cachedir) then Unix.mkdir cachedir 0o777;
+    if not (Sys.file_exists tlapsdir) then Unix.mkdir tlapsdir 0o777;
+    (cachedir, tlapsdir)
+
+
 let handle_abort _ =
   if !Params.verbose then
     Util.eprintf ~prefix:"FATAL: " ">>> Interrupted -- aborting <<<" ;
   if !Params.stats then
     Clocks.report () ;
-  Pervasives.exit 255
+  Stdlib.exit 255
 
 
 module IntSet = Set.Make (struct type t = int let compare = (-) end);;
 
 let modules_list : string list ref = ref []
 
-(* Note that when process_obs is called, all obligations have id fields *)
-let process_obs t obs modname thyf fpf =
-  Clocks.start Clocks.backend ;
-  let fpout = Fpfile.fp_init fpf !modules_list in
-  let thyout = Isabelle.thy_init modname thyf in
-  let treated = ref IntSet.empty in
-  let proved = ref IntSet.empty in
-  let record success ob =
-    treated := IntSet.add (Option.get ob.id) !treated;
-    if success then proved := IntSet.add (Option.get ob.id) !proved;
-  in
-  let _ = Errors.get_warnings () in
-  let tasks =
-    try Array.map (Prep.make_task fpout thyout record) obs
-    with Exit -> [| |]
-  in
-  Schedule.run !Params.max_threads (Array.to_list tasks);
-  Isabelle.thy_close thyf thyout;
-  Fpfile.fp_close_and_consolidate fpf fpout;
-  Clocks.stop ();
 
-  if not !Params.noproving && not (Toolbox.is_stopped ()) then begin
-    if !Params.toolbox then begin
-      let untreated = ref [] in
-      let f ob =
-        if not (IntSet.mem (Option.get ob.id) !treated) then
-          untreated := ob :: !untreated;
-      in
-      Array.iter f obs;
-      let res =
-        Types.NTriv (Types.RFail (Some (Types.Cantwork "unexpected error")),
-                     Method.Fail)
-      in
-      let f ob =
-        Toolbox.print_new_res ob res "" None
-      in
-      List.iter f !untreated;
+let print_proved_obligation (ob: Proof.T.obligation) =
+    if !Params.verbose then
+        Util.printf
+            ~at:ob.Proof.T.obl
+            ~prefix:"[INFO]: "
+            "@[<v2>Attempted to prove or check:@,%a@]@."
+            Proof.Fmt.pp_print_obligation ob
+
+
+let print_proved_obligations
+        (proved: Proof.T.obligation list ref)
+        (obs: Proof.T.obligation array)
+        (tla_module: Module.T.mule): unit =
+    List.iter print_proved_obligation !proved
+
+
+let print_unproved_obligation (ob: Proof.T.obligation) =
+    Util.eprintf
+        ~at:ob.Proof.T.obl
+        ~prefix:"[ERROR]: "
+        "@[<v2>Could not prove or check:@,%a@]@."
+        Proof.Fmt.pp_print_obligation ob
+
+
+let print_unproved_obligations
+        (unproved: Proof.T.obligation list ref)
+        (obs: Proof.T.obligation array)
+        (tla_module: Module.T.mule): unit =
+    List.iter print_unproved_obligation !unproved;
+    let n_unproved = List.length !unproved in
+    let n_obligations = Array.length obs in
+    let s = if n_obligations > 1 then "s" else "" in
+    let n_neg = string_of_int n_unproved in
+    let n_all = string_of_int n_obligations in
+    if n_unproved <> 0 then begin
+        Util.eprintf
+            ~at:tla_module "%s"
+            ~prefix:"[ERROR]: "
+            (n_neg ^ "/" ^ n_all ^ " obligation" ^ s ^ " failed.");
+        Util.eprintf
+            "There were backend errors processing module `%S`."
+            tla_module.core.name.core;
+        if not !Params.toolbox then
+            failwith "backend errors: there are unproved obligations"
     end else begin
-      let badobs = ref [] in
-      let f ob =
-        if not (IntSet.mem (Option.get ob.id) !proved) then
-          badobs := ob :: !badobs;
-      in
-      Array.iter f obs;
-      if !badobs <> [] then begin
-        let f ob =
-          Util.eprintf ~at:ob.Proof.T.obl
-                       "@[<v2>Could not prove or check:@,%a@]@."
-                       Proof.Fmt.pp_print_obligation ob;
-        in
-        List.iter f !badobs;
-        if !Params.verbose then begin
-          Util.eprintf ~at:t "%d/%d obligation(s) failed" (List.length !badobs)
-                       (Array.length obs);
-          Util.eprintf "FATAL: there were backend errors processing module %S"
-                       t.core.name.core;
-        end;
-        failwith "backend errors"
-      end
+        Util.eprintf
+            ~at:tla_module "%s"
+            ~prefix:"[INFO]: "
+            ("All " ^ n_all ^ " obligation" ^ s ^ " proved.")
     end
-  end
-;;
 
+
+(* Note that when process_obs is called, all obligations have id fields *)
+let process_obs
+        (t: Module.T.mule)
+        (obs: Proof.T.obligation array)
+        (modname: string)
+        (thyf: string)
+        (fpf: string):
+            unit =
+    (* initialize table of treated obligations *)
+    let treated = ref IntSet.empty in
+    (* initialize table of proved obligations *)
+    let proved_ids = ref IntSet.empty in
+    let record
+            (success: bool)
+            (ob: Proof.T.obligation):
+                unit =
+        (* the number `obl_id \in Nat` that identifies the obligation `ob` *)
+        let obl_id = Option.get ob.id in
+        (* store the obligation id number in the internal table `treated` *)
+        treated := IntSet.add obl_id !treated;
+        (* if the prover (frontend or backend) succeeded, *)
+        if success then (* then store the obligation id number in
+                        the internal table `proved_ids`
+                        *)
+            proved_ids := IntSet.add obl_id !proved_ids;
+        in
+    let collect_untreated_obligations
+            (untreated: Proof.T.obligation list ref):
+                unit =
+        (* Store in the `list ref` `untreated` all the obligations that
+        are not in the `IntSet` `treated`.
+        *)
+        let f ob =
+            let obl_id = Option.get ob.id in
+            if not (IntSet.mem obl_id !treated) then
+                untreated := ob :: !untreated;
+            in
+        Array.iter f obs
+        in
+    let collect_proved_obligations
+            (proved: Proof.T.obligation list ref):
+                unit =
+        let f ob = begin
+            let obl_id = Option.get ob.id in
+            if (IntSet.mem obl_id !proved_ids) then
+                proved := ob :: !proved
+            end
+            in
+        Array.iter f obs
+        in
+    let collect_unproved_obligations
+            (unproved: Proof.T.obligation list ref):
+                unit =
+        let f ob = begin
+            let obl_id = Option.get ob.id in
+            if not (IntSet.mem obl_id !proved_ids) then
+                unproved := ob :: !unproved
+            end
+            in
+        Array.iter f obs
+        in
+    Clocks.start Clocks.backend ;
+    (* initialize file for output of fingerprints
+    (saves fingerprints file history)
+    *)
+    let fpout = Fpfile.fp_init fpf !modules_list in
+    let thyout = Isabelle.thy_init modname thyf in
+    let _ = Errors.get_warnings () in
+    (* prepare proof tasks *)
+    let tasks =
+        try
+            let f = Prep.make_task fpout thyout record in
+            Array.to_list (Array.map f obs)
+        with Exit -> []
+    in
+    (* proving *)
+    Schedule.run !Params.max_threads tasks;
+    Isabelle.thy_close thyf thyout;
+    (* close fingerprints file *)
+    Fpfile.fp_close_and_consolidate fpf fpout;
+    Clocks.stop ();
+    (* `--noproving` command line option or TLA+ Toolbox has sent "stop" *)
+    if not (!Params.noproving || (Toolbox.is_stopped ())) then begin
+    (* Check proof results for each obligation, output summary *)
+    if !Params.toolbox then begin
+        let untreated = ref [] in
+        collect_untreated_obligations untreated;
+        let result =
+            let c = Types.Cantwork "unexpected error" in
+            let fail = Types.RFail (Some c) in
+            Types.NTriv (fail, Method.Fail)
+            in
+        let f ob =
+            Toolbox.print_new_res ob result "" None
+            in
+        List.iter f !untreated
+        end;
+    (* Printing of proved and unproved obligations *)
+    let proved = ref [] in
+    let unproved = ref [] in
+    collect_proved_obligations proved;
+    collect_unproved_obligations unproved;
+    print_proved_obligations proved obs t;
+    print_unproved_obligations unproved obs t
+    end
 
 
 let add_id i ob = {ob with id = Some (i+1)}
 
 
 let toolbox_consider ob =
-  let loc = Option.get (Util.query_locus ob.Proof.T.obl) in
-  !Params.tb_sl <= Loc.line loc.Loc.start
-  && Loc.line loc.Loc.stop <= !Params.tb_el
+    let loc = Option.get (Util.query_locus ob.Proof.T.obl) in
+    !Params.tb_sl <= Loc.line loc.Loc.start
+    && Loc.line loc.Loc.stop <= !Params.tb_el
 
 let toolbox_clean arr =
- if !Params.toolbox
- then List.filter toolbox_consider (Array.to_list arr)
- else Array.to_list arr
+    if !Params.toolbox
+        then List.filter toolbox_consider (Array.to_list arr)
+        else Array.to_list arr
 
 
-let process_module mcx t =
-  modules_list := t.core.name.core :: !modules_list;
-  if t.core.important then begin
-    let tlapsdir = t.core.name.core ^ ".tlaps" in
-    Params.output_dir := tlapsdir;
-    if not (Sys.file_exists tlapsdir) then Unix.mkdir tlapsdir 0o777;
-  end;
-
-  let thyf =
-    Filename.concat !Params.output_dir (t.core.name.core ^ ".thy")
-  and fpf =
-    Filename.concat !Params.output_dir "fingerprints"
-  in
-  Params.fpf_out := Some fpf;
-  let (mcx, t) = match t.core.stage with
+let process_module
+        mcx
+        (t: Module.T.mule) =
+    modules_list := t.core.name.core :: !modules_list;
+    if t.core.important then begin
+        let (_, tlapsdir) = mkdir_tlaps t in
+        Params.output_dir := tlapsdir;
+    end;
+    (* names of theory and fingerprint files *)
+    (* Theory file name *)
+    let thyf: string = Filename.concat
+                            !Params.output_dir (t.core.name.core ^ ".thy")
+    (* Fingerprints output file name *)
+    and fpf: string = Filename.concat
+                            !Params.output_dir "fingerprints"
+    in
+    (* file for output of fingerprints *)
+    (Params.fpf_out: string option ref) := Some fpf;
+    (* cases of module (stage: Module.T.stage) =
+        | Special
+        | Final _
+        | Parsed | Flat
+    *)
+    let (mcx, t) = match t.core.stage with
     | Special -> (mcx, t)
     | Final _ ->
         if Params.debugging "rep" && t.core.important then begin
-          Clocks.start Clocks.print ;
-          Module.Fmt.pp_print_module (Deque.empty, Ctx.dot) Format.std_formatter t ;
-          Format.printf "\n%!" ;
-          Clocks.stop () ;
+            Clocks.start Clocks.print ;
+            Module.Fmt.pp_print_module
+                (Deque.empty, Ctx.dot) Format.std_formatter t ;
+            Format.printf "\n%!" ;
+            Clocks.stop () ;
         end ;
         (mcx, t)
     | _ ->
-       if !Params.verbose then begin
-          Util.printf "(* processing module %S *)" t.core.name.core
+        if !Params.verbose then begin
+            Util.printf "(* processing module %S *)" t.core.name.core
         end ;
         Clocks.start Clocks.elab ;
         (* Normalize the proofs in order to get proof obligations *)
         let (mcx, t, summ) = Module.Elab.normalize mcx Deque.empty t in
+        (*
+        List.iter
+            (fun u -> Module.Fmt.pp_print_module
+                (Deque.empty, Ctx.dot) Format.std_formatter (snd u))
+            (Sm.bindings mcx);
+        *)
+        (*
+        let _ = Sm.iter
+                    (fun f u -> Printf.printf "Module: %s\n" u.core.name.core)
+                    mcx in
+        *)
         Clocks.stop () ;
         if Params.debugging "rep" && t.core.important then begin
-          Clocks.start Clocks.print ;
-          Module.Fmt.pp_print_module (Deque.empty, Ctx.dot) Format.std_formatter t ;
-          Format.printf "\n%!" ;
-          Clocks.stop () ;
+            Clocks.start Clocks.print ;
+            Module.Fmt.pp_print_module
+                (Deque.empty, Ctx.dot)
+                Format.std_formatter t ;
+            Format.printf "\n%!" ;
+            Clocks.stop () ;
         end ;
-         if !Params.stats && t.core.important then begin
-          Util.printf "(* module %S: %d total %s *)"
-            t.core.name.core
-            summ.sum_total
-            (Util.plural summ.sum_total "obligation")
+        if !Params.stats && t.core.important then begin
+            Util.printf
+                "(* module %S: %d total %s *)"
+                t.core.name.core
+                summ.sum_total
+                (Util.plural summ.sum_total "obligation")
         end ;
 
         (* managing the fingerprints (erasing or loading) *)
-         if !Params.cleanfp && t.core.important then
-           (try Sys.remove fpf; Util.printf "(* fingerprints file %S removed *)%!" fpf
-            with _ ->  if Sys.file_exists fpf then Util.printf "(* did not succeed in removing fingerprints file %S *)%!" fpf)
-         else begin
-           let fpf_in = begin
-             match !Params.fpf_in with
-               | Some f -> f
-               | None -> fpf
-           end in
-           if Sys.file_exists fpf_in && (summ.sum_total <> 0) && t.core.important then
-             begin
-               Util.printf "(* loading fingerprints in %S *)%!" fpf_in;
-               Clocks.start Clocks.fp_loading;
-               Backend.Fpfile.load_fingerprints fpf_in;
-               Params.fp_loaded := true;
-               Params.fp_original_number := Backend.Fpfile.get_length ();
-               Clocks.stop ()
+        (* `--cleanfp` command line option *)
+        if !Params.cleanfp && t.core.important then begin
+            try
+                Sys.remove fpf;
+                Util.printf "(* fingerprints file %S removed *)%!" fpf
+            with _ ->
+                if Sys.file_exists fpf then
+                    Util.printf "%s%s" (
+                        "(* did not succeed in removing " ^
+                        "fingerprints file %S *)%!") fpf
+        end
+        else begin
+            (* file for input of fingerprints *)
+            let fpf_in = begin
+                match !Params.fpf_in with
+                    | Some f -> f  (* `--usefp` command line option *)
+                    | None -> fpf  (* same as file for output of fingerprints *)
+            end in
+            if      Sys.file_exists fpf_in
+                    && (summ.sum_total <> 0)
+                    && t.core.important
+                then begin
+                Util.printf "(* loading fingerprints in %S *)%!" fpf_in;
+                Clocks.start Clocks.fp_loading;
+                (* load fingerprints from input file *)
+                Backend.Fpfile.load_fingerprints fpf_in;
+                Params.fp_loaded := true;
+                Params.fp_original_number := Backend.Fpfile.get_length ();
+                Clocks.stop ()
              end
-         end;
+        end;
 
-         flush stdout ;
+        flush stdout ;
         Clocks.start Clocks.prep ;
         let fin = match t.core.stage with
-          | Final fin -> fin
-          | _ ->
-             Errors.bug ~at:t "normalization didn't produce a finalized module"
+            | Final fin -> fin
+            | _ -> Errors.bug ~at:t
+                        "normalization didn't produce a finalized module"
         in
         let obs = Array.mapi add_id fin.final_obs in  (* add obligation ids *)
         let obs = toolbox_clean obs in (* only consider specified obligations *)
-        let fin = { fin with final_obs = Array.of_list obs ; final_status = (Incomplete, summ) } in
+        let fin = {
+                fin with final_obs = Array.of_list obs ;
+                final_status = (Incomplete, summ) } in
         t.core.stage <- Final fin ;
         Module.Save.store_module ~clock:Clocks.elab t ;
         (mcx, t)
-  in
-  if !Params.summary && t.core.important then
-    Module.Fmt.summary t ;
-  begin match t.core.stage with
-    | Final fin when t.core.important (*Array.length fin.final_obs > 0*)  ->
+    in
+    if !Params.summary && t.core.important then
+        Module.Fmt.summary t ;
+    begin match t.core.stage with
+    | Final fin when t.core.important
+        (* Array.length fin.final_obs > 0 *)
+        ->
         if !Params.verbose then
-          Util.printf "(* module %S: %d unique obligations *)"
-            t.core.name.core
-            (Array.length fin.final_obs) ;
+            Util.printf "(* module %S: %d unique obligations *)"
+                t.core.name.core
+                (Array.length fin.final_obs) ;
 
         if (!Params.toolbox) then begin
-          let f ob =
-            Backend.Toolbox.toolbox_print ob "to be proved" None None 0. None
-                                          !Params.printallobs None "" None
-          in
-          Array.iter f fin.final_obs;
-          (* prints the list of obligations which have to be proved *)
-          Backend.Toolbox.print_ob_number (Array.length fin.final_obs) ;
+            let f ob =
+                Backend.Toolbox.toolbox_print
+                    ob
+                    "to be proved"
+                    None
+                    None
+                    0.
+                    None
+                    !Params.printallobs None "" None
+            in
+            (* prints the list of obligations which have to be proved *)
+            Array.iter f fin.final_obs;
+            (* prints total number of obligations *)
+            Backend.Toolbox.print_ob_number
+                (Array.length fin.final_obs) ;
         end;
 
         let missing =
-          match fin.final_status with
-          | (Incomplete, miss) -> snd (miss.sum_absent)
-          | _ -> []
+            match fin.final_status with
+            | (Incomplete, miss) -> snd (miss.sum_absent)
+            | _ -> []
         in
 
-    begin if not !Params.suppress_all then
-      process_obs t fin.final_obs t.core.name.core thyf fpf;
+        begin
+        if not !Params.suppress_all then
+            process_obs t fin.final_obs
+            t.core.name.core thyf fpf;
 
-      (** Added by HV. It collects all facts and definitions used in the 
-          current proof tree into a one-line proof. *)
-      if Params.debugging "oneline" && t.core.important then begin
-        Util.eprintf "One-line proof:\n"; 
-        match Module.Gen.collect_usables t with
-        | None -> Util.eprintf "  OBVIOUS"
-        | Some u -> 
-            let s = Util.sprintf "@[<hov2>%a@]" 
-							(Proof.Fmt.pp_print_usable (Deque.empty,Ctx.dot)) u in
-            let s = Str.global_replace (Str.regexp "?") "" s in
-            Util.eprintf "  BY @[<hov2>%s@]@.\n" s
+        (** Added by HV. It collects all facts and definitions used in the
+        current proof tree into a one-line proof. *)
+        if Params.debugging "oneline" && t.core.important then begin
+            Util.eprintf "One-line proof:\n";
+            match Module.Gen.collect_usables t with
+                | None -> Util.eprintf "  OBVIOUS"
+                | Some u ->
+                    let s = Util.sprintf "@[<hov2>%a@]"
+                        (Proof.Fmt.pp_print_usable (Deque.empty,Ctx.dot)) u in
+                    let s = Str.global_replace (Str.regexp "?") "" s in
+                        Util.eprintf "  BY @[<hov2>%s@]@.\n" s
         end else ();
 
-      let wrap x = { core = x; props = [] } in
-      let dummy_seq = {
-        Expr.T.context = Deque.empty;
-        Expr.T.active = wrap (Expr.T.String "");
-      } in
-      let dummy_ob = {
-        id = None;
-        obl = wrap dummy_seq;
-        fingerprint = None;
-        kind = Ob_main;
-      } in
-      Array.fill fin.final_obs 0 (Array.length fin.final_obs) dummy_ob;
+        let wrap x = { core = x; props = [] } in
+        let dummy_seq = {
+            Expr.T.context = Deque.empty;
+            Expr.T.active = wrap (Expr.T.String "");
+            } in
+        let dummy_ob: Proof.T.obligation = {
+                id = None;
+                obl = wrap dummy_seq;
+                fingerprint = None;
+                kind = Ob_main;
+            } in
+        Array.fill fin.final_obs 0 (Array.length fin.final_obs) dummy_ob;
 
-      if t.core.important && not (Toolbox.is_stopped ()) then begin
-        Clocks.start Clocks.check ;
-        let modname = t.core.name.core in
-        let nmiss = List.length missing in
-        if !Params.check then
-          Std.finally Clocks.stop Isabelle.recheck (modname, nmiss, thyf)
-      end;
-      Clocks.stop ();
-      (mcx, t)
-    end
+        if t.core.important && not (Toolbox.is_stopped ()) then begin
+            Clocks.start Clocks.check ;
+            let modname = t.core.name.core in
+            let nmiss = List.length missing in
+            if !Params.check then
+                Std.finally Clocks.stop Isabelle.recheck (modname, nmiss, thyf)
+        end;
+        Clocks.stop ();
+        (mcx, t)
+        end
     | _ -> (mcx, t)
-  end
+    end
 
 let read_new_modules mcx fs =
+  (* Read the files with names in the list of strings `fs`. *)
   List.fold_left begin
     fun (mcx, mods) fn ->
       let mule =
@@ -305,6 +460,13 @@ let read_new_modules mcx fs =
       (* set a flag for each module of the new modules that it is important *)
       mule.core.important <- true ;
       let mcx = Sm.add mule.core.name.core mule mcx in
+      (* `mcx` is a mapping from names of already loaded modules and
+      modules loaded by the function `read_new_modules`, to modules
+      (values of type `mule`)
+
+      `mods` is a list of module (values of type `mule`) that are loaded by
+      the function `read_new_modules`.
+      *)
       (mcx, mule :: mods)
   end (mcx, []) fs
 
@@ -319,12 +481,17 @@ let main fs =
   let mcx = Module.Standard.initctx in
   (* reads the new modules and return both the map:name->module with the new
    * module and a list of the new modules*)
+  (* The module names (or file names) in the list `fs` are those listed on
+  the command line. Each file is read by the function `read_new_modules .
+  Submodules are read below.
+  *)
   let (mcx, mods) = read_new_modules mcx fs in
   if List.length mods = 0 then begin
     Util.eprintf ~prefix:"FATAL: " "could not read any modules successfully!" ;
     failwith "fatal error: could not read any modules";
   end else begin
-    (* load the transitive closure over extends of all modules*)
+    (* load the transitive closure over extends of all modules *)
+    (* TODO: load also modules that occur in `INSTANCE` statements from extended modules. *)
     let mcx = Module.Save.complete_load ~clock:Clocks.parsing mcx in
     (* flatten the modules *)
     let (mcx, mods) = Module.Dep.schedule mcx in
@@ -353,15 +520,15 @@ let init () =
        let backtrace = Printexc.get_backtrace () in
        Format.pp_print_flush Format.std_formatter ();
        Format.pp_print_flush Format.err_formatter ();
-       Pervasives.flush stdout;
-       Pervasives.flush stderr;
+       Stdlib.flush stdout;
+       Stdlib.flush stderr;
        let error = (Printexc.to_string e) ^ "\n" ^ backtrace in
        Util.eprintf ~prefix:"FATAL:" " tlapm ending abnormally with %s" error;
        let config = Params.print_config_toolbox false in
-       begin match !Errors.loc,!Errors.msg with
-       | Some l,Some m -> Backend.Toolbox.print_message (l ^  "\n\n" ^ m)
+       begin match !Errors.loc, !Errors.msg with
+       | Some l, Some m -> Backend.Toolbox.print_message (l ^  "\n\n" ^ m)
        | None, Some m -> Backend.Toolbox.print_message m
-       | _,_ ->
+       | _, _ ->
           let msg =
             Printf.sprintf
                "Oops, this seems to be a bug in TLAPM.\n\

--- a/src/tlapm_args.ml
+++ b/src/tlapm_args.ml
@@ -36,6 +36,16 @@ let set_target_start s =
 let set_target_end e =
   tb_el := if e = 0 then max_int else e
 
+let set_target_line s =
+    toolbox := true;
+    if s = 0 then begin
+        tb_sl := 0;
+        tb_el := max_int
+    end else begin
+        tb_sl := s;
+        tb_el := s
+    end
+
 let set_default_method meth =
   try set_default_method meth
   with Failure msg -> raise (Arg.Bad ("--method: " ^ msg))
@@ -155,6 +165,8 @@ let init () =
                 "<meth> set default method to <meth> (try --method help)" ;
     "--solver", Arg.String set_smt_solver,
                 "<solver> set SMT solver to <solver>";
+    "--smt-logic", Arg.String set_smt_logic,
+                "<logic> set SMT logic to <logic>";
     "--fast-isabelle", Arg.Unit Params.set_fast_isabelle,
                        " (Windows-only) Launch Isabelle with fast shortcut";
     "--stretch", Arg.Set_float Params.timeout_stretch,
@@ -172,6 +184,8 @@ let init () =
     blank;
     "--toolbox", (Arg.Tuple [Arg.Int set_target_start;Arg.Int set_target_end]),
                  "<int><int> toolbox mode";
+    "--line", Arg.Int set_target_line,
+              "<int> line to prove";
     "--wait", Arg.Set_int wait,
               "<time> wait for <time> before printing obligations in progress";
     "--noproving", Arg.Set noproving,

--- a/src/util/deque.ml
+++ b/src/util/deque.ml
@@ -2,7 +2,7 @@
  * deque.ml --- Persistent functional double-ended queues
  *
  *
- * Copyright (C) 2008-2010  INRIA and Microsoft Corporation
+ * Copyright (C) 2008-2019  INRIA and Microsoft Corporation
  *)
 
 Revision.f "$Rev$";;
@@ -105,9 +105,36 @@ let rec nth ?(backwards=false) q n =
         | Some (x, q) ->
             if n = 0 then Some x else git q (n - 1)
         | None ->
-            failwith "Queue.nth: internal error"
+            failwith "Deque.nth: internal error"
     in
     git q n
+
+let rec first_n q n =
+    (* Return the first `n` elements of the queue `q`. *)
+    if (n < 0) then
+        failwith ("Deque.first_n:  n = " ^
+            (string_of_int n)
+            ^ " < 0");
+    if (n > (size q)) then
+        failwith ("Deque.first_n:  n = " ^
+            (string_of_int n) ^ " > size q = " ^
+            (string_of_int (size q)) );
+    let rec f q n =
+        assert (n <= size q);
+        assert (n >= 0);
+        match n with
+        | 0 -> empty
+        | _ -> begin match front q with
+            | None -> assert false
+            | Some (x, q) ->
+                let r = f q (n - 1) in
+                cons x r
+            end
+    in
+    (* TODO: move this unit test *)
+    (* assert ((size (f empty 0)) == 0); *)
+    f q n
+
 
 let map f q =
   let rec go n q r = match front q with
@@ -171,4 +198,3 @@ let alter ?(backwards=false) q n alt_fn =
         end
   in
   spin 0 q
-

--- a/src/util/deque.ml
+++ b/src/util/deque.ml
@@ -112,13 +112,9 @@ let rec nth ?(backwards=false) q n =
 let rec first_n q n =
     (* Return the first `n` elements of the queue `q`. *)
     if (n < 0) then
-        failwith ("Deque.first_n:  n = " ^
-            (string_of_int n)
-            ^ " < 0");
+        failwith (Printf.sprintf "Deque.first_n:  n = %d < 0" n);
     if (n > (size q)) then
-        failwith ("Deque.first_n:  n = " ^
-            (string_of_int n) ^ " > size q = " ^
-            (string_of_int (size q)) );
+        failwith (Printf.sprintf "Deque.first_n:  n = %d > size q = %d" n (size q));
     let rec f q n =
         assert (n <= size q);
         assert (n >= 0);

--- a/src/util/deque.mli
+++ b/src/util/deque.mli
@@ -2,7 +2,7 @@
  * deque.ml --- Persistent functional double-ended queues
  *
  *
- * Copyright (C) 2008-2010  INRIA and Microsoft Corporation
+ * Copyright (C) 2008-2019  INRIA and Microsoft Corporation
  *)
 
 type 'a dq
@@ -16,6 +16,7 @@ val rear  : 'a dq -> ('a dq * 'a) option
 val rev   : 'a dq -> 'a dq
 val null  : 'a dq -> bool
 val nth   : ?backwards:bool -> 'a dq -> int -> 'a option
+val first_n : 'a dq -> int -> 'a dq
 val map   : (int -> 'a -> 'b) -> 'a dq -> 'b dq
 val iter  : (int -> 'a -> unit) -> 'a dq -> unit
 

--- a/src/util/ext.ml
+++ b/src/util/ext.ml
@@ -134,12 +134,11 @@ module Std = struct
   let input_all : ?bsize:int -> in_channel -> string =
     fun ?(bsize = 19) ch ->
       let buf = Buffer.create bsize in
-(*      let str = String.create 64 in *)
       let str = Bytes.create 64 in
       let rec loop () =
         let hmany = Pervasives.input ch str 0 64 in
         if hmany > 0 then begin
-          Buffer.add_substring buf str 0 hmany ;
+          Buffer.add_substring buf (Bytes.to_string str) 0 hmany ;
           loop ()
         end
       in

--- a/src/util/ext.ml
+++ b/src/util/ext.ml
@@ -138,7 +138,7 @@ module Std = struct
       let rec loop () =
         let hmany = Pervasives.input ch str 0 64 in
         if hmany > 0 then begin
-          Buffer.add_substring buf (Bytes.to_string str) 0 hmany ;
+          Buffer.add_subbytes buf str 0 hmany ;
           loop ()
         end
       in

--- a/src/util/property.ml
+++ b/src/util/property.ml
@@ -32,6 +32,7 @@ type pid =
 
 type prop = pid * Obj.t
 
+(* [(Pid(7), Obj.t); ...]  *)
 type props = prop list
 
 type 'a pfuncs = {
@@ -137,4 +138,3 @@ let print_prop = function
 
 let print_all_props = function
   | {props = ls} -> List.iter print_prop ls
-

--- a/src/util/util.ml
+++ b/src/util/util.ml
@@ -44,6 +44,7 @@ let location ?(cap=true) lw = match query_locus lw with
 
 (* FIXME get rid of nonl *)
 let kfprintf ?debug ?at ?prefix ?nonl cont ff fmt =
+  (* Print `prefix` only if `at` is not `None`. *)
   match debug with
   | Some dbg when not (Params.debugging dbg) ->
       Format.ikfprintf cont ff fmt

--- a/test/fast/enabled_cdot/Cdot_test.tla
+++ b/test/fast/enabled_cdot/Cdot_test.tla
@@ -1,0 +1,69 @@
+---------------------------- MODULE Cdot_test ----------------------------------
+(* Tests for the expansion of the operator \cdot. *)
+(* EXTENDS TLAPS *)
+
+(* The proof directives below are from the module `TLAPS`.
+Including them here to compare the number of definitions
+with when extending the module `TLAPS`.
+*)
+
+Zenon == TRUE (*{ by (prover:"zenon") }*)
+
+ExpandENABLED == TRUE  (*{ by (prover:"expandenabled") }*)
+ExpandCdot == TRUE  (*{ by (prover:"expandcdot") }*)
+AutoUSE == TRUE  (*{ by (prover:"autouse") }*)
+
+
+--------------------------------------------------------------------------------
+(* Unit test with a single variable. *)
+
+VARIABLE x
+
+R == x' = TRUE
+
+A == /\ x = FALSE
+     /\ R
+
+B == /\ x = TRUE
+     /\ x' = FALSE
+
+C == A \cdot B
+
+D == /\ x = FALSE
+     /\ x' = FALSE
+
+
+THEOREM C <=> D
+PROOF
+BY ExpandCdot, Zenon DEF A, B, R, C, D
+
+
+THEOREM C <=> D
+PROOF
+BY ExpandCdot, AutoUSE, Zenon DEF C, D
+
+
+--------------------------------------------------------------------------------
+(* Unit test with two variables. *)
+
+VARIABLE y
+
+
+A2 == /\ x = TRUE /\ y = FALSE
+      /\ x' = FALSE /\ y' = TRUE
+
+B2 == /\ x = FALSE /\ y = TRUE
+      /\ x' = TRUE /\ y' = TRUE
+
+C2 == A2 \cdot B2
+
+D2 == /\ x = TRUE /\ y = FALSE
+      /\ x' = TRUE /\ y' = TRUE
+
+
+THEOREM C2 <=> D2
+PROOF
+BY ExpandCdot, Zenon DEF A2, B2, C2, D2
+
+
+================================================================================

--- a/test/fast/enabled_cdot/ENABLEDaxioms_test.tla
+++ b/test/fast/enabled_cdot/ENABLEDaxioms_test.tla
@@ -1,0 +1,219 @@
+------------------------- MODULE ENABLEDaxioms_test ----------------------------
+(* Unit tests for the implementation of proof rules about `ENABLED`. *)
+EXTENDS TLAPS
+
+
+VARIABLE x, y, z
+
+
+P == x = 1
+A == x' = 1 /\ y' = 1
+B == z' = 1
+R == y' = 1 /\ x' = 1
+
+--------------------------------------------------------------------------------
+(* Proving
+
+
+    P,
+    P \in BOOLEAN,
+    A \in BOOLEAN
+|-
+    (P /\ ENABLED A) <=> ENABLED (P /\ A)
+*)
+
+
+THEOREM
+    ASSUME P
+    PROVE P /\ ENABLED A
+PROOF
+<1>1. P \in BOOLEAN
+    BY DEF P
+<1>2. A \in BOOLEAN
+    BY DEF A
+<1>3. ENABLED (P /\ A)
+    BY ExpandENABLED, AutoUSE
+<1> QED
+    BY <1>1, <1>2, <1>3, ENABLEDaxioms
+
+
+THEOREM
+    ASSUME P
+    PROVE ENABLED (P /\ A)
+PROOF
+<1>1. P \in BOOLEAN
+    BY DEF P
+<1>2. A \in BOOLEAN
+    BY DEF A
+<1>3. P /\ ENABLED A
+    <2>1. ENABLED A
+        BY ExpandENABLED, AutoUSE
+    <2> QED
+        BY <2>1
+<1> QED
+    BY <1>1, <1>2, <1>3, ENABLEDaxioms
+
+--------------------------------------------------------------------------------
+(* Proving
+
+
+    A \in BOOLEAN,
+    B \in BOOLEAN
+|-
+    ENABLED (A /\ B) <=> (ENABLED A /\ ENABLED B)
+*)
+
+
+THEOREM
+    (ENABLED A) /\ ENABLED B
+PROOF
+<1>1. A \in BOOLEAN
+    BY DEF A
+<1>2. B \in BOOLEAN
+    BY DEF B
+<1>3. ENABLED (A /\ B)
+    BY ExpandENABLED, AutoUSE
+<1> QED
+    BY <1>1, <1>2, <1>3, ENABLEDaxioms
+
+
+THEOREM
+    ENABLED (A /\ B)
+PROOF
+<1>1. A \in BOOLEAN
+    BY DEF A
+<1>2. B \in BOOLEAN
+    BY DEF B
+<1>3. (ENABLED A) /\ (ENABLED B)
+    BY ExpandENABLED, AutoUSE
+<1> QED
+    BY <1>1, <1>2, <1>3, ENABLEDaxioms
+
+--------------------------------------------------------------------------------
+
+THEOREM
+    ASSUME P
+    PROVE ENABLED (P /\ B)
+PROOF
+<1>1. P \in BOOLEAN
+    BY DEF P
+<1>2. B \in BOOLEAN
+    BY DEF B
+<1>3. (ENABLED P) /\ ENABLED B
+    <2>1. ENABLED P
+        BY ExpandENABLED, AutoUSE
+    <2>2. ENABLED B
+        BY ExpandENABLED, AutoUSE
+    <2> QED
+        BY <2>1, <2>2
+<1> QED
+    BY <1>1, <1>2, <1>3, ENABLEDaxioms
+
+--------------------------------------------------------------------------------
+(* Proving
+
+
+    A \in BOOLEAN,
+    B \in BOOLEAN
+|-
+    ENABLED (A \/ B) <=> (ENABLED A \/ ENABLED B)
+*)
+
+
+THEOREM
+    ENABLED (A \/ B)
+PROOF
+<1>1. A \in BOOLEAN
+    BY DEF A
+<1>2. B \in BOOLEAN
+    BY DEF B
+<1>3. (ENABLED A) \/ (ENABLED B)
+    <2>1. ENABLED A
+        BY ExpandENABLED, AutoUSE
+    <2>2. ENABLED B
+        BY ExpandENABLED, AutoUSE
+    <2> QED
+        BY <2>1, <2>2
+<1> QED
+    BY <1>1, <1>2, <1>3, ENABLEDaxioms
+
+
+THEOREM
+    (ENABLED A) \/ (ENABLED B)
+PROOF
+<1>1. A \in BOOLEAN
+    BY DEF A
+<1>2. B \in BOOLEAN
+    BY DEF B
+<1>3. ENABLED (A \/ B)
+    BY ExpandENABLED, AutoUSE
+<1> QED
+    BY <1>1, <1>2, <1>3, ENABLEDaxioms
+
+--------------------------------------------------------------------------------
+(* Proving
+
+
+    A \in BOOLEAN,
+    R \in BOOLEAN,
+    A = R
+|-
+    (ENABLED A) <=> (ENABLED R)
+*)
+
+
+THEOREM
+    (ENABLED A) <=> (ENABLED R)
+PROOF
+<1>1. A \in BOOLEAN
+    BY DEF A
+<1>2. R \in BOOLEAN
+    BY DEF R
+<1>3. A = R
+    BY DEF A, R
+<1> QED
+    BY <1>1, <1>2, <1>3, ENABLEDaxioms
+
+--------------------------------------------------------------------------------
+(* Proving
+
+
+    A <=> R
+|-
+    (ENABLED A) <=> ENABLED R
+*)
+
+
+THEOREM
+    (ENABLED A)  <=>  ENABLED R
+PROOF
+<1>1. A <=> R
+    BY DEF A, R
+<1> QED
+    BY <1>1, ENABLEDaxioms
+
+--------------------------------------------------------------------------------
+(* Proving
+
+
+    A \in BOOLEAN,
+    R \in BOOLEAN,
+    A => R
+|-
+    (ENABLED A) => ENABLED R
+*)
+
+
+THEOREM
+    (ENABLED A)  =>  ENABLED R
+PROOF
+<1>1. A \in BOOLEAN
+    BY DEF A
+<1>2. R \in BOOLEAN
+    BY DEF R
+<1>3. A => R
+    BY DEF A, R
+<1> QED
+    BY <1>1, <1>2, <1>3, ENABLEDaxioms
+
+================================================================================

--- a/test/fast/enabled_cdot/Enabled_test.tla
+++ b/test/fast/enabled_cdot/Enabled_test.tla
@@ -1,0 +1,158 @@
+---------------------------- MODULE Enabled_test -------------------------------
+(* Unit tests for expanding `ENABLED`. *)
+EXTENDS TLAPS
+
+
+VARIABLE x, y, z
+
+P(u) == u'
+Q == y
+R == x'
+
+
+THEOREM
+    (x = TRUE)  =>  ENABLED x
+PROOF
+    BY ExpandENABLED
+
+
+THEOREM
+    ENABLED (x')
+PROOF
+    BY ExpandENABLED
+
+
+THEOREM
+    ENABLED R
+PROOF
+    BY ExpandENABLED DEF R
+
+
+THEOREM
+    ENABLED R
+PROOF
+    BY ExpandENABLED, AutoUSE
+
+
+THEOREM
+    ENABLED P(x)
+PROOF
+    BY ExpandENABLED DEF P
+
+
+THEOREM
+    ENABLED P(x)
+PROOF
+    BY ExpandENABLED, AutoUSE
+
+
+THEOREM
+    ENABLED (P(x) \/ Q)
+PROOF
+    BY ExpandENABLED DEF P
+
+
+THEOREM
+    ENABLED (P(x) \/ Q)
+PROOF
+    BY ExpandENABLED, AutoUSE
+
+--------------------------------------------------------------------------------
+
+Yunprimed == y
+F == ENABLED (z' /\ Yunprimed)
+G == /\ Yunprimed
+     /\ \E zprime, yprime:  zprime /\ yprime
+
+
+THEOREM EnabledEliminationWithUnexpanded ==
+    F = G
+PROOF
+    BY ExpandENABLED DEF F, G, Yunprimed
+    (* This proof is sound with the operator Yunprimed expanded or not. *)
+
+
+THEOREM
+    F = G
+PROOF
+    BY ExpandENABLED, AutoUSE DEF F, G
+
+
+--------------------------------------------------------------------------------
+
+THEOREM
+   ASSUME
+       NEW A,
+       A <=> ENABLED Yunprimed
+   PROVE
+       A <=> ENABLED (z' /\ y)
+PROOF
+    BY ExpandENABLED DEF Yunprimed
+
+--------------------------------------------------------------------------------
+
+A == (x \in BOOLEAN) /\ (x' = ~ x)
+B == ENABLED (x \in BOOLEAN /\ << A >>_x)
+BwithAexpanded ==
+    ENABLED /\ x \in BOOLEAN
+            /\ x' = ~ x
+            /\ x' # x
+
+
+THEOREM
+    A => B
+PROOF
+    BY ExpandENABLED DEF A, B
+
+
+THEOREM
+    A => B
+PROOF
+    BY ExpandENABLED, AutoUSE DEF A, B
+
+
+THEOREM
+    B <=> BwithAexpanded
+PROOF
+    BY ExpandENABLED DEF A, B, BwithAexpanded
+
+
+THEOREM
+    B <=> BwithAexpanded
+PROOF
+    BY ExpandENABLED, AutoUSE DEF B, BwithAexpanded
+
+--------------------------------------------------------------------------------
+
+THEOREM
+    (ENABLED (y /\ x')) = ENABLED (x' /\ y)
+PROOF
+    BY ExpandENABLED
+
+--------------------------------------------------------------------------------
+
+C == x' = x
+D == ENABLED C
+
+
+THEOREM
+    C => D
+PROOF
+    BY ExpandENABLED DEF C, D
+
+
+--------------------------------------------------------------------------------
+
+
+THEOREM
+    (ENABLED y /\ x') => ENABLED (y /\ x')
+PROOF
+    BY ExpandENABLED
+
+
+THEOREM
+    ((ENABLED y) /\ x')  <=>  ENABLED y /\ x'
+PROOF
+    BY ExpandENABLED
+
+================================================================================

--- a/test/fast/enabled_cdot/ExpandENABLED_LET_test.tla
+++ b/test/fast/enabled_cdot/ExpandENABLED_LET_test.tla
@@ -1,0 +1,16 @@
+-------------------------- MODULE ExpandENABLED_LET_test -----------------------
+(* Unit test of `ExpandENABLED` with `LET` in proof obligation. *)
+EXTENDS TLAPS
+
+
+THEOREM
+    ASSUME VARIABLE x
+    PROVE
+        LET
+            Foo(r) == r
+        IN
+            x => ENABLED /\ Foo(x)
+                         /\ Foo(x')
+PROOF
+    BY ExpandENABLED, Zenon
+================================================================================

--- a/test/fast/enabled_cdot/ExpandOnlyCdot_test.tla
+++ b/test/fast/enabled_cdot/ExpandOnlyCdot_test.tla
@@ -1,0 +1,12 @@
+------------------------ MODULE ExpandOnlyCdot_test ----------------------------
+(* Test with `ExpandCdot` and `ENABLED` occurs in scope of `\cdot`.
+
+The proof directive `ExpandENABLED` is not given.
+*)
+EXTENDS TLAPS
+
+
+THEOREM ((ENABLED TRUE) \cdot TRUE)
+BY ExpandCdot
+================================================================================
+stderr: status:failed

--- a/test/fast/enabled_cdot/ExpandOnlyENABLED_test.tla
+++ b/test/fast/enabled_cdot/ExpandOnlyENABLED_test.tla
@@ -1,0 +1,12 @@
+-------------------------- MODULE ExpandOnlyENABLED_test -----------------------
+(* Test with `ExpandENABLED` and `\cdot` occurs in scope of `ENABLED`.
+
+The proof directive `ExpandCdot` is not given.
+*)
+EXTENDS TLAPS
+
+
+THEOREM ENABLED (TRUE \cdot TRUE)
+BY ExpandENABLED
+================================================================================
+stderr: status:failed

--- a/test/fast/enabled_cdot/Level_test.tla
+++ b/test/fast/enabled_cdot/Level_test.tla
@@ -1,0 +1,115 @@
+------------------------------ MODULE Level_test -------------------------------
+(* Tests for computing expression levels. *)
+EXTENDS TLAPS, Integers
+
+
+CONSTANT c
+VARIABLES x, y
+
+
+P == ENABLED (x')
+
+f(g) == TRUE
+h(r, w) == TRUE
+
+Q == /\ IF x THEN x' ELSE c
+     /\ 1 + 2
+        (* {r \in S:  P(r)} set such that *)
+     /\ {r \in {1, 2}:  TRUE}
+     /\ {r \in {1, 2}:  c}
+     /\ {r \in {1, 2}:  x}
+     /\ {r \in {1, 2}:  x'}
+     /\ {r \in {1, 2}:  r + 1}
+     /\ {r \in {1, 2}:  r + x}
+     /\ {r \in {1, 2}:  r + x'}
+     /\ {r \in x:  TRUE}
+     /\ {r \in x':  TRUE}
+        (* {f(z):  z \in S} *)
+     /\ {f(g):  g \in x}
+     /\ {f(g):  g \in x'}
+     /\ {h(z, w):  z \in x,  w \in x'}
+        (* {1, 2, 3} set enumeration *)
+     /\ {1, 2, 3}
+     /\ {c, 1}
+     /\ {c, x}
+     /\ {x, 1}
+     /\ {x, x'}
+     /\ {x', 1}
+     /\ {c, x'}
+     /\ {c, x, x'}
+        (* Tuples *)
+     /\ << 1, 2, 3 >>
+     /\ << c, 1, 2 >>
+     /\ << x, 1, 2 >>
+     /\ << x, 1, c >>
+     /\ << x, x', c >>
+        (* Function application *)
+     /\ 1[1]
+     /\ c[1]
+     /\ x[1]
+     /\ x[c]
+     /\ x[x']
+     /\ (x')[x]
+        (* [f EXCEPT ![1] = 2] *)
+     /\ [c EXCEPT ![1] = 2]
+     /\ [c EXCEPT ![x] = 2]
+     /\ [c EXCEPT ![x'] = 2]
+     /\ [c EXCEPT ![1] = x]
+     /\ [c EXCEPT ![1] = x']
+
+     /\ [x EXCEPT ![1] = 2]
+     /\ [x EXCEPT ![c] = 2]
+     /\ [x EXCEPT ![x] = 2]
+     /\ [x EXCEPT ![x'] = 2]
+
+     /\ [x EXCEPT ![1] = c]
+     /\ [x EXCEPT ![1] = x]
+     /\ [x EXCEPT ![1] = x']
+
+     /\ [x' EXCEPT ![1] = 2]
+     /\ [x' EXCEPT ![c] = 2]
+     /\ [x' EXCEPT ![x] = 2]
+     /\ [x' EXCEPT ![x'] = 2]
+
+     /\ [x' EXCEPT ![1] = c]
+     /\ [x' EXCEPT ![1] = x]
+     /\ [x' EXCEPT ![1] = x']
+        (* rigid quantification *)
+     /\ \E r:  r
+     /\ \E r \in {1}:  r
+     /\ \E r, w:  r /\ w
+     /\ \E r \in {1}, w \in {1}:  r /\ w
+     /\ \E r \in {1}, w \in {2}:  r /\ w
+     /\ \E r, w \in {1}:  r /\ w
+     /\ \E r \in {1, 2}:  r
+     /\ \E r \in x:  r
+     /\ \E r \in x':  r
+     /\ \E r:  c
+     /\ \E r:  x
+     /\ \E r:  x'
+     /\ \E r, w:  x'
+        (* CHOOSE *)
+     /\ CHOOSE r:  r = 1
+        (* ENABLED *)
+     /\ ENABLED c
+     /\ ENABLED x
+     /\ ENABLED (x + 1)
+     /\ ENABLED (x')
+     /\ ENABLED (x + x')
+        (* [A]_e *)
+     /\ [x' = x + 1]_x
+        (* << A >>_e *)
+     /\ << x' = x + 1 >>_x
+     /\ UNCHANGED x
+     /\ UNCHANGED << x, y >>
+
+     /\ LET R(w) == TRUE
+        IN R(TRUE)
+
+
+THEOREM ENABLED Q
+PROOF
+    BY ExpandENABLED DEF Q
+
+================================================================================
+stderr: status:failed

--- a/test/fast/enabled_cdot/NestedCdot_test.tla
+++ b/test/fast/enabled_cdot/NestedCdot_test.tla
@@ -1,0 +1,53 @@
+---------------------------- MODULE NestedCdot_test ----------------------------
+(* Test proof directive `ExpandCdot` with nested occurrences of `\cdot`. *)
+EXTENDS Naturals
+
+
+Zenon == TRUE (*{ by (prover:"zenon") }*)
+ExpandCdot == TRUE  (*{ by (prover:"expandcdot") }*)
+AutoUSE == TRUE  (*{ by (prover:"autouse") }*)
+
+--------------------------------------------------------------------------------
+
+THEOREM
+    ASSUME VARIABLE x
+    PROVE (
+        (x = 0 /\ x' = 1) \cdot (
+            ((x = 1 /\ x' = 2) \cdot (x = 2 /\ x' = 3))  )
+        )
+        =
+        ((x = 0 /\ x' = 1) \cdot (x = 1) /\ (x' = 3))
+PROOF
+BY ExpandCdot, Zenon
+
+
+THEOREM
+    ASSUME VARIABLE x
+    PROVE (
+        ((x = 0 /\ x' = 1) \cdot (x = 1) /\ (x' = 3)) )
+        <=>
+        ((x = 0) /\ (x' = 3))
+PROOF
+BY ExpandCdot, Zenon
+
+--------------------------------------------------------------------------------
+VARIABLE x
+
+
+A == (x = 0 /\ x' = 1) \cdot (
+    ((x = 1 /\ x' = 2) \cdot (x = 2 /\ x' = 3))  )
+
+
+THEOREM  ((x = 0) /\ (x' = 3))  =>  A
+PROOF
+BY ExpandCdot, Zenon DEF A
+--------------------------------------------------------------------------------
+
+P == (x = 1 /\ x' = 2) \cdot (x = 2 /\ x' = 3)
+Q == (x = 0 /\ x' = 1) \cdot P
+
+
+THEOREM  ((x = 0) /\ (x' = 3))  =>  Q
+PROOF
+BY ExpandCdot, Zenon, AutoUSE DEF Q
+================================================================================

--- a/test/fast/enabled_cdot/NestedENABLED_from_AutoUSE_test.tla
+++ b/test/fast/enabled_cdot/NestedENABLED_from_AutoUSE_test.tla
@@ -1,0 +1,27 @@
+--------------------- MODULE NestedENABLED_from_AutoUSE_test -------------------
+(* Test for multiply nested `ENABLED` with definitions that need expansion. *)
+EXTENDS TLAPS
+
+
+VARIABLE x
+
+
+A == ENABLED (x /\ x')
+B == ENABLED (x /\ A')
+C == ENABLED (x /\ B')
+D == ENABLED (x /\ C')
+E == ENABLED (x /\ D')
+F == ENABLED (x /\ E')
+G == ENABLED (x /\ F')
+H == ENABLED (x /\ G')
+I == ENABLED (x /\ H')
+J == ENABLED (x /\ I')
+
+
+THEOREM
+    ENABLED (J')
+PROOF
+BY ExpandENABLED, Isa, AutoUSE
+
+
+================================================================================

--- a/test/fast/enabled_cdot/NestedENABLED_test.tla
+++ b/test/fast/enabled_cdot/NestedENABLED_test.tla
@@ -1,0 +1,62 @@
+---------------------- MODULE NestedENABLED_test -------------------------------
+(* Unit test of `ENABLED` and `\cdot` occurring in scope of `ENABLED`.
+
+This module tests nesting of `ENABLED` without occurrence of definitions
+(so without expansion of definitions by the user or by `AutoUSE`.
+*)
+EXTENDS TLAPS
+
+
+(* `\cdot` occurs in scope of `ENABLED` and index depth of `z` is larger
+than the number of bounds in the quantifier that replaces `ENABLED`.
+
+This theorem tests the shifting of indices after `Lamda`s have been
+introduced and before anonymization of the newly introduced `Lambda`
+parameters.
+
+
+*)
+THEOREM
+    (* The declarations are in a sequent to ensure that the index of `z`
+    remains small, even if this theorem is moved to within the module,
+    which otherwise could change the number of theorems in the context,
+    thus the depth of declarations in the deque of the context,
+    so the indices (thus the value of the `z` index would be above the
+    value checked at `Expr.Subst.app_ix` for the first pattern case of
+    `Bump`). This pertains to testing the functions
+    `Expr.Action.shift_indices_after_lambdify` and
+    `Expr.Action.shift_indices`.
+    *)
+    ASSUME VARIABLE w, VARIABLE x, VARIABLE y, VARIABLE z
+    PROVE (z = 0) =>
+        ENABLED (
+            (z = 0 /\ z' = 1 /\ x' /\ y' /\ w')
+            \cdot
+            (z = 1 /\ z' = 2))
+PROOF
+    BY ExpandENABLED, ExpandCdot, Zenon
+
+--------------------------------------------------------------------------------
+VARIABLE x, y, z
+
+
+(* `ENABLED` occurs in scope of `ENABLED`. *)
+THEOREM
+    ENABLED /\ x'
+            /\ ENABLED (y' /\ ENABLED (z'))
+            /\ ENABLED (x')
+PROOF
+    BY ExpandENABLED, Zenon
+
+
+(* `\cdot` occurs in scope of `ENABLED`. *)
+THEOREM
+    (x = 0) =>
+        ENABLED (
+            (x = 0 /\ x' = 1)
+            \cdot
+            (x = 1 /\ x' = 2))
+PROOF
+    BY ExpandENABLED, ExpandCdot, Zenon
+
+================================================================================

--- a/test/fast/fingerprint/load_v8old_test.tla
+++ b/test/fast/fingerprint/load_v8old_test.tla
@@ -124,8 +124,9 @@ f == 42
 THEOREM f' = f
 OBVIOUS
 ================================================
-command: rm -rf load_v8old_test.tlaps
-command: cp -r load_v8old_test.tlaps.testbase load_v8old_test.tlaps
+command: rm -rf __tlacache__
+command: mkdir __tlacache__
+command: cp -r load_v8old_test.tlaps.testbase __tlacache__/load_v8old_test.tlaps
 command: ${TLAPM} --toolbox 0 0 --isaprove ${FILE}
 stdout: fingerprints written
 stderr: Translating fingerprints from version 8

--- a/todo.txt
+++ b/todo.txt
@@ -1,8 +1,8 @@
 Action Items:
 =============
-- Respond to Tom Rodeheffer's 24 September 2013 bug report about 
-  USE/HIDE DEF.  
-  Damen will Look at the code and see how much work it would be to 
+- Respond to Tom Rodeheffer's 24 September 2013 bug report about
+  USE/HIDE DEF.
+  Damen will Look at the code and see how much work it would be to
   implement the missing features.
 
 * Investigate Dan's report of a self-test failing when installing
@@ -21,7 +21,7 @@ Action Items:
   change should usually be made as a Preference.
   Changes made, review in progress.
 
-- Fix TLA and TLAPS web pages. 
+- Fix TLA and TLAPS web pages.
   Jael will identify problems, Tomer will fix Inria site and Leslie will
   fix Microsoft site.
 
@@ -42,17 +42,15 @@ v0.3.x (development branch)
 
 - Handle non-Leibniz user-defined operators.
 
-- ENABLED
-
 - Named Subexpressions
 
-- Module Instantiation
+- Module Instantiation (implemented)
 
-- Implement BY/USE/HIDE MODULE Foo  
+- Implement BY/USE/HIDE MODULE Foo
   (so it importd unnamed theorems from the module as well as named ones)
   and BY/USE/HIDE DEFS MODULE Foo.
-  The requires deciding what USE Foo means if Foo is the 
-  current module.  In particular, does a global USE mark as used 
+  The requires deciding what USE Foo means if Foo is the
+  current module.  In particular, does a global USE mark as used
   only the theorems encountered so far or all later theorems as well.
 
 ==================================================================
@@ -63,7 +61,7 @@ Isabelle / Zenon
   - Integers
   - Sequences
   - FiniteSets
-  - TLC: @@ and :> 
+  - TLC: @@ and :>
     => Isabelle supports these, but I doubt that the PM does (SM 2013-11-07)
   - Reals
 
@@ -73,17 +71,17 @@ Isabelle / Zenon
 
 Misc
 -------------
-- Change documentation and PM so definition in named 
+- Change documentation and PM so definition in named
   THEOREM/ASSUMPTION is by default USEd.
 
   - done on PM side
 
 - There is now no way to use an unnamed theorem or assumption.  This
-  should be fixed.  
+  should be fixed.
   It will be handled by the USE/BY MODULE Foo construct, which
   will use the unnamed as well as the named theoresm of Foo.
 
-- PM/Zenon/Isabelle does not yet handle expressions 
+- PM/Zenon/Isabelle does not yet handle expressions
       {e : x_1 \in S_1, ... , x_n \in S_n}
   for n > 1.
 
@@ -134,8 +132,8 @@ THEOREM BoundedChooseIntro ==
 OBVIOUS
 
 -------------------------------------------------------
-SETS 
-- expressions of the form {e : x_1 \in S_1, ...  , x_n \in S_n} 
+SETS
+- expressions of the form {e : x_1 \in S_1, ...  , x_n \in S_n}
   for n > 1
 PM: waiting for backend support
 Zenon: 1 week after Isabelle encodes it
@@ -165,14 +163,14 @@ Isabelle: to be done
     [f EXCEPT ![u][v] = x]         (* multiple arguments to exception *)
     [f EXCEPT ![u] = @ + 1]        (* @ expressions *)
 
-PM: simplifies into basic EXCEPT forms using rules on 
+PM: simplifies into basic EXCEPT forms using rules on
     page 304 of TLA+ book. This is suboptimal in the long
     run because this simplification is not checked by
     Isabelle/TLA+.
     2013-11-07 (SM): I believe EXCEPT forms are now fully supported, please check
     and either delete item or explain what should be done.
 Zenon: nothing to do (depend on PM)?
-Isabelle: nothing to do (depend on PM)?    
+Isabelle: nothing to do (depend on PM)?
 
 -------------------------------------------------------
 NUMBERS
@@ -186,7 +184,7 @@ Isabelle: not supported
 MISCELLANEOUS CONSTRUCTS
 
 - INSTANCE
-PM: in progress
+PM: (implemented a version)
 Zenon & Isabelle: no plans (rely on PM)
 
 - RECURSIVE operator definitions
@@ -194,7 +192,7 @@ Zenon & Isabelle: no plans (rely on PM)
 -------------------------------------------------------
 PROOF CONSTRUCTS
 
--  Operators like NEW P(_) in an ASSUME/PROVE 
+-  Operators like NEW P(_) in an ASSUME/PROVE
 PM:
   The following ALREADY works fine.
 
@@ -231,23 +229,14 @@ Zenon: rely on PM
 Isabelle: rely on PM
 
 - STATE, ACTION, TEMPORAL declarations in ASSUME/PROVEs
-   Currently, the PM declares an error if it finds such a 
-   declaration.
 PM: To be done by appropriate front ends.
 Zenon: rely on PM?
 Isabelle: Extension to temporal logic will handle temporal formulas.
 
-- USE/HIDE MODULE 
+- USE/HIDE MODULE
 PM:       in progress
 Zenon:    Nothing to do?
 Isabelle: Nothing to do (rely on PM)
--------------------------------------------------------
-ACTION OPERATORS
-- ENABLED
-  To be handled by specific front end.
-
-\cdot (action composition)
-  To be handled by specific front end?
 -------------------------------------------------------
 TEMPORAL OPERATORS
   To be handled by specific front end(s)
@@ -296,7 +285,7 @@ MODULE RealTime
 
 -------------------------------------------------------
 ERRORS
-  Currently, error reporting is pretty bad.  
+  Currently, error reporting is pretty bad.
 PM: in progress
 Zenon: not sure how and what to improve
 Isabelle: Nothing much can be done?


### PR DESCRIPTION
These changes:

- add the following proof directives to the module `library/TLAPS.tla`:
  - `ENABLEDaxioms`: apply proof rules about the operator `ENABLED` (implemented in the module `src/expr/e_action.ml`), and ensure for soundness that assumptions are of appropriate expression level (implemented in the module `src/module/m_elab.ml`)
  - `ExpandENABLED`: replace the operator `ENABLED` with rigid quantification of primed occurrences of variables (implemented in the module `src/expr/e_action.ml`)
  - `ExpandCdot`: replace the operator `\cdot` with rigid quantification over primed and unprimed occurrences of variables (implemented in the module `src/expr/e_action.ml`)
  - `AutoUSE`: expand defined operators where needed to soundly replace the operators `ENABLED` and `\cdot` with rigid quantification, raise errors for declared operators and parameters of operators (implemented in the module `src/expr/e_action.ml`)
  - `Lambdify`: replace the operator `ENABLED` and `\cdot` with constant-level expressions that include `LAMBDA` expressions with normalized parameter names (implemented in the module `src/expr/e_action.ml`)
  - `LevelComparison`: prove sequents with modified levels of declared operators, for example replace an `ACTION` declaration with a `STATE` declaration (implemented in the module `src/expr/e_level_comparison.ml`)
- computation of TLA+ expression levels (implemented in the module `src/expr/e_levels.ml`)
- add version 13 of the fingerprints file format, which includes the newly implemented proof directives (implemented in the module `src/backend/fpfile.ml`)
- add command-line option `--line <int>` for line to prove (abbreviates `--toolbox n n`) (implemented in the module `src/tlapm_args.ml`)
- add command-line option `--smt-logic <logic>` for setting the SMT solver logic, with default the logic UFNIA (implemented in the modules `src/backend/smt.ml`, `src/params.ml`, `src/tlapm_args.ml`)
- save fingerprints and auxiliary files that correspond to the file `filename.tla` in the directory `__tlacache__/filename.tlaps` (implemented in the module `src/tlapm.ml`, updated test file `test/fast/fingerprint/load_v8old_test.tla`)
- save kind of declaration (`CONSTANT`, `STATE`, `ACTION`, `TEMPORAL`, unknown) in fingerprints (implemented in the module `src/backend/fingerprints.ml`)
- save proof directives that appear in `BY` statements in the fingerprints, to ensure that proof obligations with the same assertions and different `BY` statements result in different fingerprints (implemented in the module `src/backend/fingerprints.ml`)
- add tests for the newly implemented proof directives to the directory `test/fast/enabled_cdot/`:
  - `Cdot_test.tla`
  - `ENABLEDaxioms_test.tla`
  - `Enabled_test.tla`
  - `ExpandENABLED_LET_test.tla`
  - `ExpandOnlyCdot_test.tla`
  - `ExpandOnlyENABLED_test.tla`
  - `Level_test.tla`
  - `NestedCdot_test.tla`
  - `NestedENABLED_from_AutoUSE_test.tla`
  - `NestedENABLED_test.tla`
- bug fixes to coalescing (in the module `src/frontend/coalesce.ml`)
- prepend `CONSTANT_`, `STATE_`, `ACTION_`, `TEMPORAL_`, `Unknown_`, `VARIABLE_` to coalesced identifier, to represent level information about declared and defined operators and avoid related unsoundness bugs (implemented in `src/frontend/coalesce.ml`)
- reimplement substitutivity computation (in the module `src/expr/e_substitutive.ml`)
- add class `map` to module `src/expr/e_subst.ml` (to enable subclassing)
- add class `map_visible_hyp` to module `src/expr/e_subst.ml` (substitution that visits only visible hypotheses in a sequent's context)
- add classes `map_visible_hyp`, `iter_visible_hyp`, `map_rename` to the module `src/expr/e_visit.ml`
- add functions `set_to_list`, `collect_unprimed_vars`, `collect_primed_vars` to the module `src/expr/e_visit.ml`
- call function `map_visible_hyp` from module `src/frontend/action.ml`
- call level computation in `src/frontend/action.ml`, instead of `Expr.Constness.is_const`
- bug fix in `src/frontend/action.ml` to add `ENABLED` in pattern case
- bug fix in `src/frontend/action.ml` to assert false for the operators `UNCHANGED`, `\cdot`, `~>`, `-+->`, `[]`, `<>`, `\AA`, `\EE`, subscript, temporal subscript, `WF_`, `SF_` in pattern case
- add comments to the types in the module `src/expr/e_t.ml`
- add functions `visibility_to_string`, `print_cx`, `cx_front`, `scx_front`, `find_hyp_named`, `expr_locus`, `format_locus`, `shape_to_arity`, `number_of_hyp`, `sequent_stats` to the module `src/expr/e_t.ml`
- add the example of incrementing an integer-valued variable `examples-draft/SimpleExampleWF.tla`
- activate proving for submodules (implemented in the module `src/module/m_parser.ml`)
- modules from `INSTANCE` and `EXTENDS` statements could be submodules of a module that the module extends, and is itself another file (implemented in the module `src/module/m_dep.ml`, `src/module/m_save.ml`)
- refactor module `src/module/m_elab.ml`, part moved to the module `src/module/m_subst.ml` (described below)
- add visitor of TLA+ module syntax graphs (implemented in the module `src/module/m_visit.ml`)
- add utilities for performing substitutions in TLA+ module syntax graphs (implemented in the module `src/module/m_subst.ml`)
- refactor `src/tlapm.ml`, change error messages, printing of count of failed obligations
- `failwith_unsupp` for the operators `~>`, `ENABLED`, `\cdot`, `-+->`, `[]`, `<>` in the Isabelle and Zenon backends (implemented in the modules `src/backend/isabelle.ml`, src/backend/zenon.ml)
- coalesce defined operator occurrences, operator application, and first-order quantification in `src/backend/ls4.ml`
- update the modules `src/backend/prep.ml`, `src/method.ml`, `src/method_prs.ml` with the newly implemented proof directives
- add `~>` to temporal operators in pattern case in the module `src/expr/e_elab.ml`
- add function `first_n` to module `src/util/deque.ml`
- augment error message in the module `src/expr/e_deref.ml`
- `BSeq` was a binary operator (implemented in the module `src/module/m_standard.ml`)
- update the documentation file `todo.txt`
- update the file `src/Makefile`
- update the generated file `src/.depend`