### PR TITLE
API: change default aux dir to `.tlacache`

### DIFF
--- a/src/tlapm.ml
+++ b/src/tlapm.ml
@@ -59,7 +59,7 @@ end
 
 
 let mkdir_tlaps t =
-    let cachedir = "__tlacache__" in
+    let cachedir = ".tlacache" in
     let tlapsdir = cachedir ^ "/" ^ t.core.name.core ^ ".tlaps" in
     if not (Sys.file_exists cachedir) then Unix.mkdir cachedir 0o777;
     if not (Sys.file_exists tlapsdir) then Unix.mkdir tlapsdir 0o777;

--- a/test/fast/fingerprint/load_v8old_test.tla.disabled
+++ b/test/fast/fingerprint/load_v8old_test.tla.disabled
@@ -3,7 +3,7 @@ EXTENDS Integers, Sequences, TLAPS, TLC
 
 THEOREM ASSUME NEW N \in Nat
         PROVE  N+N = 2*N
-BY SMT  \* PROVED 
+BY SMT  \* PROVED
 
 THEOREM ASSUME NEW N \in Nat, NEW M \in Nat
         PROVE  N*M = N*(M-1) + N
@@ -12,11 +12,11 @@ BY SMT   \* PROVED
 
 THEOREM ASSUME NEW F(_), F(1) \in Nat
         PROVE  F(1) + 1 > F(1)
-BY SMT  \* PROVED 
+BY SMT  \* PROVED
 
 THEOREM ASSUME NEW F(_), NEW x, F(x) \in Nat
         PROVE  F(x) + 1 > F(x)
-BY SMT \* PROVED 
+BY SMT \* PROVED
 
 THEOREM ASSUME NEW S, NEW f \in [S -> Nat], NEW x \in S
 PROVE  f[x] + 1 > f[x]
@@ -27,7 +27,7 @@ PROVE  F(x) + 1 > F(x)
 BY SMT \* PROVED
 
 THEOREM ASSUME NEW S, NEW f \in [S -> Nat], NEW x \in S
-        PROVE  [f EXCEPT ![x]=2][x]+1 = 3        
+        PROVE  [f EXCEPT ![x]=2][x]+1 = 3
 BY SMT \* PROVED
 
 
@@ -47,7 +47,7 @@ BY SMT \* NOT PROVED (unknown exception)
 
 THEOREM ASSUME NEW F(_)
         PROVE  F(1+1) = F(2)
-BY SMT \* NOT PROVED  
+BY SMT \* NOT PROVED
 
 THEOREM ASSUME NEW F(_), NEW S, \A i \in Nat : F(i) \in S
         PROVE  F(1+1) = F(2)
@@ -82,7 +82,7 @@ BY SMT \* PROVED
 
 LEMMA Induction == ASSUME NEW P(_),
                           P(0),
-                          ASSUME NEW i \in Nat , P(i) 
+                          ASSUME NEW i \in Nat , P(i)
                           PROVE  P(i+1)
                    PROVE  \A i \in Nat : P(i)
 
@@ -103,7 +103,7 @@ OBVIOUS
 
 THEOREM \A S, x : \A T \in S : x \in T => x \in UNION S
              OBVIOUS
-F[i \in Nat] == F[i-1]     
+F[i \in Nat] == F[i-1]
 THEOREM F = CHOOSE f : /\ f = [i \in DOMAIN f |-> f[i]]
                        /\ DOMAIN f = Nat
                        /\ \A i \in Nat : f[i] = f[i-1]
@@ -124,9 +124,9 @@ f == 42
 THEOREM f' = f
 OBVIOUS
 ================================================
-command: rm -rf __tlacache__
-command: mkdir __tlacache__
-command: cp -r load_v8old_test.tlaps.testbase __tlacache__/load_v8old_test.tlaps
+command: rm -rf .tlacache
+command: mkdir .tlacache
+command: cp -r load_v8old_test.tlaps.testbase .tlacache/load_v8old_test.tlaps
 command: ${TLAPM} --toolbox 0 0 --isaprove ${FILE}
 stdout: fingerprints written
 stderr: Translating fingerprints from version 8


### PR DESCRIPTION
This change makes `.tlacache` the default auxiliary directory, following #16.

In the future, a command-line option could be added for specifying the auxiliary directory.