### PR TITLE
BUG: lex keywords in WF_, SF_ subscripts

### DIFF
--- a/src/alexer.mll
+++ b/src/alexer.mll
@@ -39,6 +39,16 @@ let namechar = (letter | numeral | '_')
 
 let name     = namechar* letter namechar*
 
+let keyword = (
+  "ASSUME"|"ASSUMPTION"|"AXIOM"|"BOOLEAN"|"CASE"|"CHOOSE"|"CONSTANT"
+  |"CONSTANTS"|"BY"|"DEF"|"DEFINE"|"DEFS"|"LAMBDA"|"OBVIOUS"|"ELSE"
+  |"EXCEPT"|"EXTENDS"|"IF"|"IN"|"INSTANCE"|"LET"|"HAVE"|"TRUE"|"FALSE"
+  |"HIDE"|"PROOF"|"PROVE"|"STATE"|"OMITTED"|"LOCAL"|"MODULE"|"OTHER"
+  |"THEN"|"THEOREM"|"UNCHANGED"|"QED"|"RECURSIVE"|"WITNESS"|"STRING"
+  |"SUFFICES"|"ACTION"|"LEMMA"|"COROLLARY"|"VARIABLE"|"VARIABLES"|"WITH"
+  |"TAKE"
+  |"USE"|"PICK"|"NEW"|"TEMPORAL"|"PROPOSITION"|"ONLY")
+
 rule modfile = parse
   | "----" '-'* ' '* "MODULE"
       { [ PUNCT "----"; KWD "MODULE" ] }
@@ -135,19 +145,14 @@ and token = parse
   (* names and reserved words *)
 
   (* WF_ and WF_ are treated as punctuation *)
+  | ("WF_" | "SF_" as f) (keyword as kwd)
+      { [ PUNCT f ; KWD kwd ] }
   | ("WF_" | "SF_" as f) (name as rest)
       { [ PUNCT f ; ID rest ] }
   | ("WF_"|"SF_" as f)
       { [ PUNCT f ] }
 
-  | ("ASSUME"|"ASSUMPTION"|"AXIOM"|"BOOLEAN"|"CASE"|"CHOOSE"|"CONSTANT"
-    |"CONSTANTS"|"BY"|"DEF"|"DEFINE"|"DEFS"|"LAMBDA"|"OBVIOUS"|"ELSE"
-    |"EXCEPT"|"EXTENDS"|"IF"|"IN"|"INSTANCE"|"LET"|"HAVE"|"TRUE"|"FALSE"
-    |"HIDE"|"PROOF"|"PROVE"|"STATE"|"OMITTED"|"LOCAL"|"MODULE"|"OTHER"
-    |"THEN"|"THEOREM"|"UNCHANGED"|"QED"|"RECURSIVE"|"WITNESS"|"STRING"
-    |"SUFFICES"|"ACTION"|"LEMMA"|"COROLLARY"|"VARIABLE"|"VARIABLES"|"WITH"
-    |"TAKE"
-    |"USE"|"PICK"|"NEW"|"TEMPORAL"|"PROPOSITION"|"ONLY" as kwd)
+  | (keyword as kwd)
       { [ KWD kwd ] }
 
   | (name as nm)

--- a/test/fast/language/WFTRUE_test.tla
+++ b/test/fast/language/WFTRUE_test.tla
@@ -1,0 +1,12 @@
+---- MODULE WFTRUE_test ----
+(* The lexer was not identifying
+keywords in fairness subscripts.
+For example, WF_TRUE was lexed
+as [PUNCT "WF_"; ID "TRUE"],
+instead of [PUNCT "WF_"; KWD "TRUE"].
+*)
+
+THEOREM WF_TRUE(TRUE) <=> WF_(TRUE)(TRUE)
+OBVIOUS
+
+=============================


### PR DESCRIPTION
This change ensures that `TRUE` and `FALSE`
can be used as fairness subscripts, for
example `WF_TRUE(TRUE)`.

Previously, the string `WF_TRUE` was lexed
as punctutation `WF_` followed by an
identifier `TRUE`, instead of the keyword `TRUE`.

This commit adds also a test module for this case.