### PR TITLE
`INSTANCE` within `LET`, `ENABLED` in parametrized `INSTANCE`, `ENABLED` in instantiated operators with parameters, and related changes

### DIFF
--- a/src/backend/fingerprints.ml
+++ b/src/backend/fingerprints.ml
@@ -516,8 +516,10 @@ and fp_let counthyp countvar stack buf ds e =
             Stack.push stack (Identvar hint.core, ref false);
             spin stack ds;
             ignore(Stack.pop stack)
+        | Instance _ ->
+            Errors.bug ~at:d "Backend.Fingerprints.fp_let: INSTANCE 3"
         | _ ->
-            Errors.bug ~at:d "Backend.Fingerprint.fp_let: INSTANCE 3"
+            Errors.bug ~at:d "Backend.Fingerprints.fp_let: other"
       end
   in
   spin stack ds

--- a/src/backend/fingerprints.ml
+++ b/src/backend/fingerprints.ml
@@ -510,7 +510,8 @@ and fp_let counthyp countvar stack buf ds e =
   let rec spin stack = function
     | [] -> fp_expr counthyp countvar stack buf e
     | d :: ds -> begin match d.core with
-        | Operator (hint, e) ->
+        | Operator (hint, e)
+        | Bpragma (hint, e, _) ->
             fp_expr counthyp countvar stack buf e ;
             Buffer.add_char buf '.' ;
             Stack.push stack (Identvar hint.core, ref false);

--- a/src/expr/e_elab.ml
+++ b/src/expr/e_elab.ml
@@ -150,7 +150,8 @@ let let_normalize =
         | Let ([], e) -> self#expr scx e
         | Let (d :: ds, e) -> begin
             match d.core with
-              | Operator (n, nexp) ->
+              | Operator (n, nexp)
+              | Bpragma (n, nexp, _) ->
                   let op = self#expr scx nexp in
                   let e = Let (ds, e) @@ dest in
                   let e = app_expr (scons op (shift 0)) e in

--- a/src/expr/e_elab.ml
+++ b/src/expr/e_elab.ml
@@ -155,6 +155,11 @@ let let_normalize =
                   let e = Let (ds, e) @@ dest in
                   let e = app_expr (scons op (shift 0)) e in
                   self#expr scx e
+              | Instance (name, _) ->
+                  Errors.bug ~at:d (
+                      "Found INSTANCE in Expr.Elab.let_normalize, " ^
+                      "all INSTANCE statements have been replaced " ^
+                      "with definitions in Module.Elab ")
               | _ ->
                   Errors.bug ~at:d "Expr.Elab.let_normalize"
           end

--- a/src/module/m_dep.ml
+++ b/src/module/m_dep.ml
@@ -40,6 +40,7 @@ let external_deps m =
         let m = subm.core in
         locals := Hs.add m.name !locals ;
         submodules := Sm.add m.name.core subm !submodules;
+        List.iter (fun s -> deps := Hs.add s !deps) subm.core.extendees;
         List.iter visit m.body
     | Anoninst (ins, _) ->
         ignore (mapper#defn ((), Deque.empty)

--- a/src/module/m_elab.ml
+++ b/src/module/m_elab.ml
@@ -236,7 +236,7 @@ let lambdify_definition cx df =
         | Bpragma (_, expr, _) -> expr
         | _ -> assert false in
     let expr = match expr.core with
-        | Lambda _ -> expr  (* arity < _, ... > *)
+        | Lambda _  (* arity < _, ... > *)
         | _ ->  (* arity _ *)
             let expr = lambdify_expr cx expr in
             Expr.Levels.rm_expr_level cx expr

--- a/src/module/m_elab.ml
+++ b/src/module/m_elab.ml
@@ -580,9 +580,18 @@ let anon = object (self : 'self)
           | mu :: mus ->
               begin match mu.core with
               | Definition (df, _, _, _) -> make_defs (df :: sofar) mus
-              | _ ->
-                  let (_, mus) = M_subst.app_modunits (shift (-1)) mus in
-                  make_defs sofar mus
+              | Constants _
+              | Recursives _
+              | Variables _
+              | Axiom _
+              | Theorem _
+              | Submod _
+              | Mutate _
+              | Anoninst _ ->
+                let mu_hyps = M_t.hyps_of_modunit mu in
+                let n_hyps = List.length mu_hyps in
+                let (_, mus) = M_subst.app_modunits (shift (-n_hyps)) mus in
+                make_defs sofar mus
               end
         in
         self#defns scx (make_defs [] submus @ dfs)

--- a/src/module/m_fmt.ml
+++ b/src/module/m_fmt.ml
@@ -45,7 +45,7 @@ let rec pp_print_modunit ?(force=false) cx ff mu = match mu.core with
   | Variables vs ->
       let (ncx, vs) = adjs cx vs in
       fprintf ff "@[<b2>VARIABLE%s@ %a@]@,"
-        (if vs = [] then "" else "S")
+        (if ((List.length vs) = 1) then "" else "S")
         (pp_print_delimited pp_print_string) vs ;
       ncx
   | Definition (df, wd, _, ex) ->

--- a/src/tlapm.ml
+++ b/src/tlapm.ml
@@ -480,6 +480,10 @@ let read_new_modules mcx fs =
   end (mcx, []) fs
 
 
+let print_modules mcx =
+    print_string "\nModules loaded so far:\n";
+    Sm.iter (fun name mule -> Printf.printf "Module name: \"%s\"\n" name) mcx
+
 let append_ext_if_not_tla filename =
     if Filename.check_suffix filename ".tla" then
         filename
@@ -508,6 +512,7 @@ let main fs =
   Submodules are read below.
   *)
   let (mcx, mods) = read_new_modules mcx fs in
+  (* print_modules mcx; *)
   if List.length mods = 0 then begin
     Util.eprintf ~prefix:"FATAL: " "could not read any modules successfully!" ;
     failwith "fatal error: could not read any modules";

--- a/test/TOOLS/do_one_test
+++ b/test/TOOLS/do_one_test
@@ -35,13 +35,22 @@ BEGIN {
   check_command = "";
   failed = 0;
   stretch = ENVIRON["STRETCH"];
+  submodule_nesting_depth = 0;
 }
 
 # remove trailing CR from input line
 { sub (/\r$/, ""); }
 
+phase == 0 && /^----[-]*[ ]*MODULE/ {
+  submodule_nesting_depth++;
+  next;
+}
+
 phase == 0 && /^====/ {
-  phase = 1;
+  submodule_nesting_depth--;
+  if (submodule_nesting_depth == 0){
+    phase = 1;
+  }
   next;
 }
 

--- a/test/fast/enabled_cdot/ENABLED_INSTANCE_nullary_op_test.tla
+++ b/test/fast/enabled_cdot/ENABLED_INSTANCE_nullary_op_test.tla
@@ -1,0 +1,18 @@
+---- MODULE ENABLED_INSTANCE_nullary_op_test ----
+EXTENDS TLAPS
+
+---- MODULE Inner ----
+VARIABLE x
+
+A == ENABLED (x')
+
+======================
+
+VARIABLE x
+
+M == INSTANCE Inner
+
+THEOREM M!A
+BY ExpandENABLED DEF M!A
+
+=================================================

--- a/test/fast/enabled_cdot/ENABLED_INSTANCE_nullary_op_two_vars_test.tla
+++ b/test/fast/enabled_cdot/ENABLED_INSTANCE_nullary_op_two_vars_test.tla
@@ -1,0 +1,18 @@
+---- MODULE ENABLED_INSTANCE_nullary_op_two_vars_test ----
+EXTENDS TLAPS
+
+---- MODULE Inner ----
+VARIABLE x, y
+
+A == ENABLED (x' # y')
+
+======================
+
+VARIABLE x
+
+M == INSTANCE Inner WITH y <- x
+
+THEOREM M!A
+BY ExpandENABLED DEF M!A
+
+==========================================================

--- a/test/fast/enabled_cdot/ENABLED_INSTANCE_op_with_args_test.tla
+++ b/test/fast/enabled_cdot/ENABLED_INSTANCE_op_with_args_test.tla
@@ -1,0 +1,18 @@
+---- MODULE ENABLED_INSTANCE_op_with_args_test ----
+EXTENDS TLAPS
+
+---- MODULE Inner ----
+VARIABLE x, y
+
+A(z) == ENABLED (x' # y')
+
+======================
+
+VARIABLE x
+
+M == INSTANCE Inner WITH y <- x
+
+THEOREM M!A(x)
+BY ExpandENABLED DEF M!A
+
+===================================================

--- a/test/fast/enabled_cdot/Level_of_parametric_INSTANCE_test.tla
+++ b/test/fast/enabled_cdot/Level_of_parametric_INSTANCE_test.tla
@@ -1,0 +1,31 @@
+---- MODULE Level_of_parametric_INSTANCE_test ----
+(* Test if the level weights of operators are
+updated in case they have been computed before
+parametric instantiation.
+
+No fingerprints are used in this test to ensure
+that the level computation is performed.
+*)
+
+---- MODULE Inner ----
+VARIABLE x
+
+Foo == x
+======================
+
+(* This horizontal line tests that the test script
+`test/TOOLS/do_one_test` correctly reasons about
+nesting of submodules.
+*)
+--------------------------------------------------
+
+M(x) == INSTANCE Inner
+
+THEOREM TRUE
+<1>1. M!Foo(TRUE) => M!Foo(TRUE)
+    OBVIOUS
+<1> QED
+
+==================================================
+command: ${TLAPM} --nofp --toolbox 0 0 ${FILE}
+nostderr: ending abnormally

--- a/test/fast/language/EXTENDS_in_submodule_test.tla
+++ b/test/fast/language/EXTENDS_in_submodule_test.tla
@@ -1,0 +1,12 @@
+---- MODULE EXTENDS_in_submodule_test ----
+(* Ensure that modules listed in EXTENDS statements
+that are contained in submodules are loaded by `tlapm`.
+*)
+
+
+---- MODULE Inner ----
+EXTENDS TLAPS
+
+======================
+
+==========================================

--- a/test/fast/language/INSTANCE_inside_LET_fingerprint_test.tla
+++ b/test/fast/language/INSTANCE_inside_LET_fingerprint_test.tla
@@ -1,0 +1,27 @@
+---- MODULE INSTANCE_inside_LET_fingerprint_test ----
+(* Module.Elab` replaces each `INSTANCE` statement
+with definitions. If the instantiated module
+extends the module `TLAPS`, then the definitions
+include backend pragmas (constructor `Bpragma`).
+
+If the `INSTANCE` definition appears inside a `LET`,
+then normalization of `LET` and fingerprints need
+to handle `Bpragma` as a case.
+*)
+
+
+---- MODULE Inner ----
+EXTENDS TLAPS
+
+A == TRUE
+======================
+
+
+THEOREM
+    LET M == INSTANCE Inner
+    IN M!A
+OBVIOUS  (* used to raise an assertion failure at:
+    `Backend.Fingerprints.fp_let: other` *)
+
+
+=====================================================

--- a/test/fast/language/INSTANCE_inside_LET_test.tla
+++ b/test/fast/language/INSTANCE_inside_LET_test.tla
@@ -1,0 +1,28 @@
+---- MODULE INSTANCE_inside_LET_test ----
+(* Module.Elab` replaces each `INSTANCE` statement
+with definitions. If the instantiated module
+extends the module `TLAPS`, then the definitions
+include backend pragmas (constructor `Bpragma`).
+
+If the `INSTANCE` definition appears inside a `LET`,
+then normalization of `LET` and fingerprints need
+to handle `Bpragma` as a case.
+*)
+
+
+---- MODULE Inner ----
+EXTENDS TLAPS
+
+A == TRUE
+======================
+
+
+THEOREM
+    LET M == INSTANCE Inner
+    IN M!A
+
+
+THEOREM TRUE
+OBVIOUS  (* used to raise assertion failure at `Expr.Elab.let_normalize` *)
+
+=========================================

--- a/test/fast/language/INSTANCE_shift_due_to_omitted_modunits_test.tla
+++ b/test/fast/language/INSTANCE_shift_due_to_omitted_modunits_test.tla
@@ -1,0 +1,29 @@
+---- MODULE INSTANCE_shift_due_to_omitted_modunits_test ----
+
+
+---- MODULE Inner ----
+EXTENDS TLAPS
+
+VARIABLE y
+
+A == y'
+THEOREM B == []TRUE
+======================
+
+
+VARIABLE z
+
+
+M == INSTANCE Inner WITH y <- z
+
+
+THEOREM
+    \EE x:
+        LET Q == INSTANCE Inner WITH y <- x
+        IN Q!A
+OBVIOUS
+
+
+============================================================
+command: ${TLAPM} --toolbox 0 0 ${FILE}
+nostderr: Assertion failed


### PR DESCRIPTION
These changes include bug fixes:

- cdf6240de4ddd2466a995886950c260477ecf3a7: recomputing the levels of operators after instantiation, because parametric `INSTANCE` changes the arity of operators, and also can change the level of declared identifiers. A change in arity makes the level information of operators outdated, and requires recomputing the operator's level information.

- e27d639689a211d47e3986470c570497b12eb665: bind primed occurrences of variables before instantiation, when these appear in scope of `ENABLED` inside the definition of an operator that takes arguments. This change:
  - ensures correct binding of primed occurrences of variables when instantiating, for example, the operator `A(z) == ENABLED (x' # y')` (as in the added test module)
  - raises an error during operator instantiation if an operator parameter occurs inside the scope of `ENABLED`, for example:
  ```tla
  ---- MODULE RaisesError ----
  ---- MODULE Inner ----
  A(x) == ENABLED (x')
  ======================
  M == INSTANCE Inner
  ============================

- 2ec2b79911436166d994e1ee5d01b7a3ed259b35: in the test scripts, tracking nesting of submodules inside a module, to decide which horizontal line `=====*` terminates the file's module, so that the test commands be read after that `====*` line

- d0b800e58cdb758b7edef04345719dd00f868182: show `VARIABLE` for single variable, `VARIABLES` for multiple variables when formatting modules

- dbe57c610278d85a24abeb079c986b165cecf28f: load modules that occur inside an `EXTENDS` that itself appears inside a submodule

- d114852d3dfcaff000d5c9096ac90e5fb44030e4: module units need to be correctly shifted when instantiating. The shift depends on how many hypotheses each of the omitted module units introduced in the module context (and this number is not `1`, which was previously used)

- a5035a822f6552a956b8d78b82792f30ea65ceff, 4815b340f10f5c650ece9826c5b84515c551ecc7: allow `INSTANCE` statements to occur within `LET`: there were errors when the instantiated module (e.g., `TLAPS`) included backend pragmas, because only definitions were expected in normalization of `LET` expressions, and in fingerprinting of `LET` expressions.

Test cases are also added for each change. Please find more details in the commits messages.