### PR TITLE
update to OCaml v4.11.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [macos-latest, ubuntu-latest]
-        ocaml-version: [ '4.08.1' ]
+        ocaml-version: [ '4.11.0' ]
         include:
         - operating-system: macos-latest
           INSTALLER: tlaps-1.4.5-i386-darwin-inst.bin

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: Build and Package TLA Proof Manager
 on: [push]
 
-## The 'release' job creates an empty Github (draft) release before the 'publish' job 
+## The 'release' job creates an empty Github (draft) release before the 'publish' job
 ## below builds and uploads installers into the release.  This complexity is required
 ## because the standard Github release action cannot be executed as part of the matrix
 ## job (the first runner to create the release wins but the others fail).  In other words,
@@ -47,12 +47,12 @@ jobs:
     name: Build and Test
     needs: [release]
     runs-on: ${{ matrix.operating-system }}
-    strategy: 
+    strategy:
       fail-fast: false
       matrix:
         operating-system: [macos-latest, ubuntu-latest]
         ocaml-version: [ '4.08.1' ]
-        include: 
+        include:
         - operating-system: macos-latest
           INSTALLER: tlaps-1.4.5-i386-darwin-inst.bin
           DOWNLOADS: tlaps-1.4.5-i386-darwin-inst
@@ -101,7 +101,7 @@ jobs:
             cd ../..
             PATH=$(pwd)/bin:$(pwd)/lib/tlaps/bin:$PATH make test
       - name: Upload Release Asset
-        id: upload-release-asset 
+        id: upload-release-asset
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -114,7 +114,7 @@ jobs:
       - name: Download and Test TLAPM installer
         if: matrix.operating-system == 'ubuntu-latest'
         ## The test suite has known failures, thus keep going until the
-        ## test suite has been fixed (TODO). 
+        ## test suite has been fixed (TODO).
         continue-on-error: true
         run: |
             ls -lah
@@ -128,4 +128,3 @@ jobs:
       - name: Print Test Results
         if: matrix.operating-system == 'ubuntu-latest'
         run: cat test/tests.log
-

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [macos-latest, ubuntu-latest]
-        ocaml-version: [ '4.08.1' ]
+        ocaml-version: [ '4.11.0' ]
         include:
         - operating-system: macos-latest
           INSTALLER: tlaps-1.4.5-i386-darwin-inst.bin

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,12 +5,12 @@ jobs:
   test:
     name: Build and Test
     runs-on: ${{ matrix.operating-system }}
-    strategy: 
+    strategy:
       fail-fast: false
       matrix:
         operating-system: [macos-latest, ubuntu-latest]
         ocaml-version: [ '4.08.1' ]
-        include: 
+        include:
         - operating-system: macos-latest
           INSTALLER: tlaps-1.4.5-i386-darwin-inst.bin
           DOWNLOADS: tlaps-1.4.5-i386-darwin-inst
@@ -49,4 +49,3 @@ jobs:
       - name: Print Test Results
         if: matrix.operating-system == 'ubuntu-latest'
         run: cat test/tests.log
-

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@
 #
 
 COMPFLAGS = -annot -g -warn-error +1+2+5+6+8+10..26+29..31+36 \
-            -unsafe-string ${ADDCOMPFLAGS}
+            ${ADDCOMPFLAGS}
 LINKFLAGS = -g ${ADDLINKFLAGS}
 
 OPTTOOLS =

--- a/src/alexer.mli
+++ b/src/alexer.mli
@@ -12,7 +12,7 @@ open Tla_parser
 
 (** Lex a channel *)
 val lex_channel :
-  string -> Pervasives.in_channel -> Token.token LazyList.t * Loc.locus
+  string -> Stdlib.in_channel -> Token.token LazyList.t * Loc.locus
 
 (** Main lexing function *)
 val lex : string -> Token.token LazyList.t * Loc.locus

--- a/src/alexer.mll
+++ b/src/alexer.mll
@@ -287,7 +287,7 @@ and comment depth = parse
 
   let lex fn =
     let ich =
-      try Pervasives.open_in fn
+      try Stdlib.open_in fn
       with Sys_error msg -> Errors.fatal "Cannot open file: %s" msg
     in
     lex_channel fn ich

--- a/src/alexer.mll
+++ b/src/alexer.mll
@@ -93,14 +93,13 @@ and token = parse
   | (numeral+ as i)
       { [ NUM (i, "") ] }
   | ("\\b" ['0' '1']+ as b)
-      { Bytes.set b 0 '0' ;
+      { let b = "0" ^ (String.sub b 1 ((String.length b) - 1)) in
         [ NUM (string_of_int (int_of_string b), "") ] }
   | ("\\o" ['0'-'7']+ as o)
-      { Bytes.set o 0 '0' ;
+      { let o = "0" ^ (String.sub o 1 ((String.length o) - 1)) in
         [ NUM (string_of_int (int_of_string o), "") ] }
   | ("\\h" (numeral | ['a'-'f' 'A'-'F'])+ as h)
-      { Bytes.set h 0 '0' ;
-        Bytes.set h 1 'x' ;
+      { let h = "0x" ^ (String.sub h 2 ((String.length h) - 2)) in
         [ NUM (string_of_int (int_of_string h), "") ] }
 
   (* strings *)

--- a/src/ctx.ml
+++ b/src/ctx.ml
@@ -25,7 +25,7 @@ end
 module M = EMap (String)
 module IM = EMap (struct
                     type t = ident
-                    let compare = Pervasives.compare
+                    let compare = Stdlib.compare
                   end)
 
 type 'a ctx = {

--- a/src/loc.ml
+++ b/src/loc.ml
@@ -109,7 +109,7 @@ let string_of_pt ?(file="<nofile>") l =
   string_of_locus { start = l ; stop = l ; file = file }
 
 let compare r s =
-  match Pervasives.compare (line r.start) (line s.start) with
+  match Stdlib.compare (line r.start) (line s.start) with
     | 0 ->
-        Pervasives.compare (column r.start) (column s.start)
+        Stdlib.compare (column r.start) (column s.start)
     | c -> c

--- a/src/pars.mli
+++ b/src/pars.mli
@@ -11,7 +11,7 @@ module Error : sig
   val err_add_internal : string -> error -> error
   val err_add_expecting : string -> error -> error
   val err_set_unexpected : string -> error -> error
-  val print_error : ?verbose:bool -> Pervasives.out_channel -> error -> unit
+  val print_error : ?verbose:bool -> Stdlib.out_channel -> error -> unit
 end;;
 
 module Intf : sig

--- a/src/pars/error.mli
+++ b/src/pars/error.mli
@@ -29,5 +29,4 @@ val err_set_unexpected : string -> error -> error
   (** Set the "unexpected" message (adding one if it doesn't exist) *)
 
 (** Print the error on a given output channel. *)
-val print_error : ?verbose:bool -> Pervasives.out_channel -> error -> unit
-
+val print_error : ?verbose:bool -> Stdlib.out_channel -> error -> unit

--- a/src/util/ext.ml
+++ b/src/util/ext.ml
@@ -97,7 +97,7 @@ module List = struct
   ;;
   let unique ?(cmp = (=)) xs = rev (rev_unique cmp xs []);;
 
-  let sort ?(cmp = Pervasives.compare) = List.sort cmp
+  let sort ?(cmp = Stdlib.compare) = List.sort cmp
 
   exception Invalid_index
 
@@ -136,7 +136,7 @@ module Std = struct
       let buf = Buffer.create bsize in
       let str = Bytes.create 64 in
       let rec loop () =
-        let hmany = Pervasives.input ch str 0 64 in
+        let hmany = Stdlib.input ch str 0 64 in
         if hmany > 0 then begin
           Buffer.add_subbytes buf str 0 hmany ;
           loop ()
@@ -149,16 +149,16 @@ module Std = struct
     fun ?(bin = false) fname ->
       let fsize = (Unix.stat fname).Unix.st_size in
       let ch =
-        if bin then Pervasives.open_in_bin fname
-        else Pervasives.open_in fname in
+        if bin then Stdlib.open_in_bin fname
+        else Stdlib.open_in fname in
       finally
-        (fun () -> Pervasives.close_in ch)
+        (fun () -> Stdlib.close_in ch)
         (input_all ~bsize:fsize) ch
 
   let input_list ch =
     let accu = ref [] in
     try while true do
-      accu := Pervasives.input_line ch :: !accu;
+      accu := Stdlib.input_line ch :: !accu;
     done; assert false
     with End_of_file -> List.rev !accu
   ;;

--- a/src/util/util.ml
+++ b/src/util/util.ml
@@ -17,7 +17,7 @@ let pp_print_hint ff h = Format.pp_print_string ff h.core
 
 module HC = struct
   type t = hint
-  let compare x y = Pervasives.compare x.core y.core
+  let compare x y = Stdlib.compare x.core y.core
 end
 
 module Coll = struct

--- a/src/util/util.mli
+++ b/src/util/util.mli
@@ -38,17 +38,17 @@ end
 
 val sprintf :
   ?debug:string -> ?at:('a wrapped) -> ?prefix:string -> ?nonl:unit ->
-  ('r, Format.formatter, unit, string) Pervasives.format4 -> 'r
+  ('r, Format.formatter, unit, string) Stdlib.format4 -> 'r
 val printf  :
   ?debug:string -> ?at:('a wrapped) -> ?prefix:string -> ?nonl:unit ->
-  ('r, Format.formatter, unit) Pervasives.format -> 'r
+  ('r, Format.formatter, unit) Stdlib.format -> 'r
 val eprintf :
   ?debug:string -> ?at:('a wrapped) -> ?prefix:string -> ?nonl:unit ->
-  ('r, Format.formatter, unit) Pervasives.format -> 'r
+  ('r, Format.formatter, unit) Stdlib.format -> 'r
 val fprintf :
   ?debug:string -> ?at:('a wrapped) -> ?prefix:string -> ?nonl:unit ->
   Format.formatter ->
-  ('r, Format.formatter, unit) Pervasives.format -> 'r
+  ('r, Format.formatter, unit) Stdlib.format -> 'r
 
 (** {3 Convenience functions for exceptions} *)
 

--- a/tools/installer/tlaps-release.sh.in
+++ b/tools/installer/tlaps-release.sh.in
@@ -632,7 +632,7 @@ let () =
 
 EOF
 
-ocamlopt -unsafe-string -w -3 -o "$TARGET" unix.cmxa str.cmxa "$SOURCE"
+ocamlopt -w -3 -o "$TARGET" unix.cmxa str.cmxa "$SOURCE"
 strip "$TARGET" || exit 0
 cat "$TLAPSVER.tar.gz" >> "$TARGET"
 rm -f "$TLAPSVER.tar.gz"

--- a/tools/installer/tlaps-release.sh.in
+++ b/tools/installer/tlaps-release.sh.in
@@ -371,13 +371,13 @@ let path ents = match ents with
      List.fold_left Filename.concat head rest
 
 let fatal_error fmt =
-  output_string Pervasives.stderr "FATAL ERROR: " ;
+  output_string Stdlib.stderr "FATAL ERROR: " ;
   kfprintf
     (fun _ ->
-       output_string Pervasives.stderr "\\n\\n    *** ABORT ***.\\n" ;
-       flush Pervasives.stderr ;
-       Pervasives.exit 2)
-    Pervasives.stderr fmt
+       output_string Stdlib.stderr "\\n\\n    *** ABORT ***.\\n" ;
+       flush Stdlib.stderr ;
+       Stdlib.exit 2)
+    Stdlib.stderr fmt
 
 let rm_ifempty path = try begin
   let d = opendir path in

--- a/tools/installer/tlaps-release.sh.in
+++ b/tools/installer/tlaps-release.sh.in
@@ -575,8 +575,8 @@ let () =
     replace_first
       (regexp "^ISABELLE_HOME_USER=.*\$")
       ("ISABELLE_HOME_USER=" ^ path [ !output_dir ; "lib" ; "tlaps" ])
-      isabelle_settings in
-  if isabelle_settings = isabelle_settings_modified then
+      (Bytes.to_string isabelle_settings) in
+  if (Bytes.to_string isabelle_settings) = isabelle_settings_modified then
     fatal_error "Could not modify %s." isabelle_settings_file ;
   let isabelle_settings_modified2 =
     replace_first

--- a/tools/installer/tlaps-release.sh.in
+++ b/tools/installer/tlaps-release.sh.in
@@ -472,10 +472,10 @@ let input_all ic =
     if n = 0 then
       let res = Bytes.create total in
       let pos = total - ofs in
-      let _ = String.blit buf 0 res pos ofs in
+      let _ = Bytes.blit buf 0 res pos ofs in
       let coll pos buf =
         let new_pos = pos - buf_len in
-        String.blit buf 0 res new_pos buf_len;
+        Bytes.blit buf 0 res new_pos buf_len;
         new_pos in
       let _ = List.fold_left coll pos acc in
       res

--- a/tools/installer/tlaps-release.sh.in
+++ b/tools/installer/tlaps-release.sh.in
@@ -470,7 +470,7 @@ let input_all ic =
   let rec loop acc total buf ofs =
     let n = input ic buf ofs (buf_len - ofs) in
     if n = 0 then
-      let res = String.create total in
+      let res = Bytes.create total in
       let pos = total - ofs in
       let _ = String.blit buf 0 res pos ofs in
       let coll pos buf =
@@ -483,9 +483,9 @@ let input_all ic =
       let new_ofs = ofs + n in
       let new_total = total + n in
       if new_ofs = buf_len then
-        loop (buf :: acc) new_total (String.create buf_len) 0
+        loop (buf :: acc) new_total (Bytes.create buf_len) 0
       else loop acc new_total buf new_ofs in
-  loop [] 0 (String.create buf_len) 0
+  loop [] 0 (Bytes.create buf_len) 0
 
 let input_file ?(bin=false) fname =
   let ch = (if bin then open_in_bin else open_in) fname in

--- a/tools/installer/tlaps-release.sh.in
+++ b/tools/installer/tlaps-release.sh.in
@@ -16,7 +16,7 @@ case "@EXE@" in
   *) TARGET_FILE="$TLAPSVER-inst@EXE@";;
 esac
 TARGET="$OLDPWD/$TARGET_FILE"
-
+GIT_BRANCH="`git rev-parse --abbrev-ref HEAD`"
 PS_DIR="$(pwd)/../.."
 PM_DIR="$(pwd)/../.."
 
@@ -26,7 +26,7 @@ This script builds a binary distribution of the TLA+ Proof System
 version @VERSION@, compiled with OCaml version @OCAMLCVER@.
 
 Target: ${TARGET}
-SVN branch: ${SVN_PATH}
+Git branch: ${GIT_BRANCH}
 
 EOF
 


### PR DESCRIPTION
These changes update to OCaml v4.11.0, while staying compatible with OCaml v4.08.1 (including building of the installer). The CI environment is updated to use OCaml v4.11.0.