### PR TITLE
correctly interpret multiple `EXCEPT` assignments

### DIFF
--- a/src/expr/e_elab.ml
+++ b/src/expr/e_elab.ml
@@ -33,8 +33,8 @@ let desugar =
       | Except (f, xs) ->
           let at_save = !current_at in
           let f = self#expr scx f in
-          let xs = List.map begin
-            fun (trail, bod) ->
+          let f = List.fold_left begin
+            fun f (trail, bod) ->
               let (trail, at) = List.fold_left begin
                 fun (trail, f) -> function
                   | Except_dot x -> (Except_dot x :: trail, { f with core = Dot (f, x) })
@@ -46,9 +46,9 @@ let desugar =
               let () = current_at := Some (at, Deque.size (snd scx)) in
               let bod = self#expr scx bod in
               let () = current_at := at_save in
-              (trail, bod)
-          end xs in
-          { e with core = Except (f, xs) }
+              {e with core = Except (f, [(trail, bod)])}
+          end f xs in
+          f
       | _ ->
           super#expr scx e
   end in

--- a/test/fast/language/DuplicateEXCEPT.tla
+++ b/test/fast/language/DuplicateEXCEPT.tla
@@ -1,0 +1,34 @@
+----------------------------- MODULE DuplicateEXCEPT ---------------------------
+(* Test that comma-separated assignments in `EXCEPT` are correctly interpreted.
+
+Multiple assignments in an `EXCEPT` constructor mean nesting of `EXCEPT`
+constructors, as defined in [1, page 304].
+
+
+Reference
+=========
+
+[1] Leslie Lamport, Specifying Systems, Addison-Wesley, 2002
+*)
+EXTENDS Integers
+
+
+f == [x \in {1} |-> x]
+
+
+THEOREM [f EXCEPT ![1] = @ + 1, ![1] = @ + 2][1] = 4
+BY DEF f
+
+
+(*
+Correctly expanding the left-hand side of the equality in the theorem above
+yields:
+
+[[[x \in {1} |-> x] EXCEPT ![1] = [x \in {1} |-> x][1] + 1]
+    EXCEPT ![1] = [
+        [x \in {1} |-> x] EXCEPT ![1] = [x \in {1} |-> x][1] + 1
+        ][1] + 2][1]
+*)
+
+
+================================================================================

--- a/test/fast/language/EXCEPTMultipleBrackets_test.tla
+++ b/test/fast/language/EXCEPTMultipleBrackets_test.tla
@@ -1,0 +1,29 @@
+----------------------- MODULE EXCEPTMultipleBrackets_test ---------------------
+(* Test that consecutive brackets and `@` in an `EXCEPT` assignment are
+correctly interpreted in the presence of multiple (comma-separated) assignments.
+*)
+EXTENDS Integers
+
+
+f == [x \in {1} |-> [y \in {2} |-> 3]]
+g == [f EXCEPT ![1][2] = 1]
+
+
+THEOREM g[1][2] = 1
+BY DEF g, f
+
+
+h == [f EXCEPT ![1][2] = @ + 1]
+
+
+THEOREM h[1][2] = 4
+BY DEF h, f
+
+
+t == [f EXCEPT ![1][2] = 1, ![1][2] = @ + 1]
+
+
+THEOREM t[1][2] = 2
+BY DEF t, f
+
+================================================================================


### PR DESCRIPTION
These changes ensure that `@` and multiple assignments in an `EXCEPT` are correctly interpreted.