### PR TITLE
parse tuple syntax in function constructors and comma-separated arguments in `EXCEPT` assignments

### DIFF
--- a/src/expr/e_parser.ml
+++ b/src/expr/e_parser.ml
@@ -357,26 +357,54 @@ and atomic_expr b = lazy begin
     locate begin
       punct "[" >>>
         choice [
+          (* Record constructor:  [name1 |-> e1, ...] *)
           enabled (anyname <<< punct "|->") >*>
             sep1 (punct ",") (anyname <<< punct "|->" <**> use (expr b))
           <<< punct "]"
           <$> (fun fs -> Record fs) ;
 
+          (* Set of records:  [name1: Values1, ...] *)
           enabled (anyname <<< punct ":") >*>
             sep1 (punct ",") (anyname <<< punct ":" <*> use (expr b))
           <<< punct "]"
           <$> (fun fs -> Rect fs) ;
 
+          (* EXCEPT expression, examples:
+
+          [f EXCEPT ![1] = 2]
+          [f EXCEPT ![1] = 3, ![2] = 4]
+          [f EXCEPT ![1, 2] = 3]
+          [f EXCEPT !["a"] = 3, !["b"] = 4]
+          [f EXCEPT !.a = 3, !.b = 4]
+          [f EXCEPT !.a = 3, !["b"] = 4]
+          *)
           begin
             let rec exspec b = lazy begin
-              punct "!" >>> use (trail b) <<< infix "=" <*> (use (expr true)) (* choice [ attempt (punct "@" <!> At true);  use expr ] *)
+              (* except equality, examples:
+
+              ![1] = 2
+              !["a"] = 2
+              !.a = 2
+              ![1, 2] = 3
+              *)
+              punct "!" >>> use (trail b) <<< infix "=" <*> (use (expr true))
+              (* choice [ attempt (punct "@" <!> At true);  use expr ] *)
             end
             and trail b = lazy begin
               star1 begin
                 choice [
+                  (* field reference:  .name *)
                   punct "." >>> anyname <$> (fun x -> Except_dot x) ;
+                  (* application, examples:
+
+                  [arg]
+                  [arg1, arg2]
+                  *)
                   punct "[" >>> alt [
+                        (* single expression within square brackets:  [arg] *)
                         (use (expr b)) <<< punct "]";
+                        (* comma-separated list of expressions,
+                        within square brackets:  [arg1, ..., argN] *)
                         (sep1 (punct ",") (use (expr b)))
                             <$> (fun es -> noprops (Tuple es))
                             <<< punct "]"
@@ -390,13 +418,46 @@ and atomic_expr b = lazy begin
               <$> (fun (e, xs) -> Except (e, xs))
           end ;
 
+          (* Function constructor, examples:
+
+          [x \in S |-> e]
+          [<<x, y>> \in S \X R |-> e]
+          [<<x, y>> \in S \X R, z \in Q |-> e]
+          *)
           attempt (use (func_boundeds b) <<< punct "|->") <**> use (expr b)
           <<< punct "]"
           <$> begin
             fun ((bs, letin), e) ->
+                (* decide whether to insert a `LET...IN`
+                for representing bound identifiers described by bounded
+                tuples in the source
+                *)
                 if ((List.length letin) = 0) then
+                    (* no `LET...IN` needed, because no tuple declarations
+                    appear in the function constructor, for example:
+
+                    [x \in S |-> x + 1]
+
+                    is represented with `bs` containing the declaration
+                    `x \in S`, and `e` the expression `x + 1`.
+                    *)
                     Fcn (bs, e)
                 else begin
+                    (* insert a `LET...IN`, needed to represent tuple
+                    declarations, for example:
+
+                    [<<x, y>> \in S,  r, w \in Q |-> x + y - r - w]
+
+                    is represented with `bs` containing the declarations
+                    `fcnbnd#xy \in S`, `r \in Q`, `w \in Ditto`, and
+                    `e` the expression
+
+                        LET
+                            x == fcnbnd#xy[1]
+                            y == fcnbnd#xy[2]
+                        IN
+                            x + y - r - w
+                    *)
                     let e_ = Let (letin, e) in
                     let e = noprops e_ in
                     Fcn (bs, e)
@@ -405,9 +466,11 @@ and atomic_expr b = lazy begin
 
           use (expr b) >>= begin fun e ->
             choice [
+              (* Set of functions:  [Domain -> Range] *)
               punct "->" >*> use (expr b) <<< punct "]"
               <$> (fun f -> Arrow (e, f)) ;
 
+              (* Box action operator:  [A]_e *)
               punct "]_" >>> use (sub_expr b)
               <$> (fun v -> Sub (Box, e, v)) ;
             ]
@@ -609,8 +672,21 @@ and boundeds b = lazy begin
   end
 end
 
+(* comma-separated listed of declarations within function constructor *)
 and func_boundeds b = lazy begin
+    (* comma-separated list of declarations, examples:
+
+    m \in S
+    a, b \in R
+    m \in S,  a, b \in R
+    m \in S,  a, b \in R,  <<x, y>> \in A \X B
+    *)
     sep1 (punct ",") (choice [
+        (* bounded constants, examples:
+
+        m \in S
+        a, b \in R
+        *)
         (sep1 (punct ",") hint <*> (infix "\\in" >*> use (expr b)))
             <$> begin
                 fun (vs, dom) ->
@@ -622,37 +698,145 @@ and func_boundeds b = lazy begin
                     let letin = [] in
                     (bounds, letin)
             end;
+        (* bounded tuples of constants, examples:
+
+        <<x, y>> \in S
+        <<a, b, c >> \in A \X B \X C
+
+        A function constructor is represented with `Fcn`,
+        which takes `bounds` as first argument.
+        `bounds` represents a list of bound identifiers (constants here).
+
+        So the tuples need to be converted to individual identifier bounds.
+        This is done by introducing intermediate definitions in a `LET...IN`.
+        Each bounded tuple (like `<<x, y>>` above) is replaced by a fresh
+        identifier of the form:
+
+            fcnbnd#concatenated_names
+
+        where "concatenated_names" results from concatenating the identifiers
+        that occur within the tuple. For example, `<<x, y>>` is replaced by
+
+            fcnbnd#xy
+
+        The fresh identifier is used inside the `LET...IN` for defining each
+        of the identifiers that occurred within the tuple. For example,
+        `[<<x, y>> \in S |-> ...]` becomes:
+
+            [fcnbnd#xy \in S:
+                LET
+                    x == fcnbnd#xy[1]
+                    y == fcnbnd#xy[2]
+                IN
+                    ...]
+
+        The hashmark is used within the identifier fcnbnd#... to ensure that
+        the fresh identifier is different from all other identifiers in the
+        current context, without the need to inspect the context (which is
+        not available while parsing). The syntax of TLA+ ensures this,
+        because no identifier in TLA+ source can contain a hashmark.
+
+        In each function constructor, the concatenation of identifiers
+        (like "xy" above) is unique, because the TLA+ syntax ensures that
+        each identifier is unique within its context. Therefore, each bounded
+        tuple within a function constructor will be replaced by a unique
+        fresh identifier (unique within that context and that context's
+        extensions).
+        *)
         ((punct "<<" >>> (sep (punct ",") hint) <<< punct ">>")
             <*> (infix "\\in" >*> use (expr b)))
             <$> begin
                 fun (vs, dom) ->
                     (* bounds *)
+                    (* names of identifiers that appear within the tuple,
+                    for example "x", "y" from the tuple `<x, y>`
+                    *)
                     let nms = List.map (fun h -> h.core) vs in
+                    (* suffix of fresh identifier that will represent the tuple,
+                    for example "xy" from the tuple `<x, y>`
+                    *)
                     let name = String.concat "" nms in
+                    (* fresh identifier that will represent the tuple,
+                    for example "fcnbnd#xy" from the tuple `<x, y>`
+                    *)
                     let v = noprops ("fcnbnd#" ^ name) in
+                    (* bounded constant declaration for the fresh identifier,
+                    for example `fcnbnd#xy \in S` from `<x, y> \in S`
+                    *)
                     let hd = (v, Constant, Domain dom) in
+                    (* a list with a single element, in preparation for
+                    later concatenation
+                    *)
                     let bounds = [hd] in
-                    (* `LET...IN` definitions *)
+                    (* `LET...IN` definitions
+
+                    We now create the definitions of the identifiers that
+                    appeared inside the tuple declaration, using in the
+                    definiens the fresh identifier `v` that has just been
+                    introduced.
+
+                    For example, the tuple declaration `<<x, y>> \in S`
+                    would here result in the creation of two definitions:
+
+                        x == fcnbnd#xy[1]
+                        y == fcnbnd#xy[2]
+                    *)
                     let letin =
+                        (* create one definition for each identifier that
+                        appears inside the tuple declaration
+                        *)
                         List.mapi begin
-                        fun i op ->
+                        fun i op ->  (* arguments:
+                            - `i` is the 0-based index of the tuple element
+                            - `op` is the tuple element (an identifier)
+                            *)
                             let e =
+                                (* tuple identifier, for example "fcnbnd#xy" *)
                                 let f = noprops (Opaque v.core) in
+                                (* 1-based index numeral *)
                                 let idx =
                                     let i_str = string_of_int (i + 1) in
                                     let num = Num (i_str, "") in
                                     noprops num in
+                                (* function application on the index,
+                                for example:  fcnbnd#xy[1]
+                                *)
                                 let e_ = FcnApp (f, [idx]) in
                                 noprops e_ in
+                            (* definition for `op`, for example:
+
+                            x == fcnbnd#xy[1]
+
+                            The result is of type `defn`.
+                            *)
                             let defn_ = Operator (op, e) in
                             noprops defn_
                         end vs in
+                    (* Bundle the constant declarations of fresh
+                    identifiers (in `bounds`) and the definitions (in terms of
+                    these fresh identifiers) of the identifiers that appeared
+                    in the tuple declaration (these definitions are in `letin`).
+
+                    These definitions are used at the call site to construct
+                    a new `LET...IN` expression that wraps the function's
+                    value expression (the `e` in `[... |-> e]`).
+
+                    The declarations are used, together with this `LET...IN`
+                    expression, to populate a function constructor `Fcn`.
+                    *)
                     (bounds, letin)
             end
         ])
     <$> begin
       fun bss ->
+        (* Unzip the two lists.
+        `bss` is a list of pairs of lists, so `bounds` is a list of lists
+        and so is `letin`.
+        *)
         let (bounds, letin) = List.split bss in
+        (* Flatten each list of lists into a list.
+        At this point we return a list of bounds that
+        *)
         (List.concat bounds, List.concat letin)
     end
 end

--- a/src/expr/e_parser.ml
+++ b/src/expr/e_parser.ml
@@ -835,7 +835,10 @@ and func_boundeds b = lazy begin
         *)
         let (bounds, letin) = List.split bss in
         (* Flatten each list of lists into a list.
-        At this point we return a list of bounds that
+        At this point we return a list of bounds that will be used in a `Fcn`,
+        and a (possibly empty) list of operator definitions that
+        will be used (if nonempty) to form a `Let` that will wrap the
+        expression that defines the value of the function in `Fcn`.
         *)
         (List.concat bounds, List.concat letin)
     end

--- a/src/expr/e_parser.ml
+++ b/src/expr/e_parser.ml
@@ -449,12 +449,12 @@ and atomic_expr b = lazy begin
                     [<<x, y>> \in S,  r, w \in Q |-> x + y - r - w]
 
                     is represented with `bs` containing the declarations
-                    `fcnbnd#xy \in S`, `r \in Q`, `w \in Ditto`, and
+                    `fcnbnd#x \in S`, `r \in Q`, `w \in Ditto`, and
                     `e` the expression
 
                         LET
-                            x == fcnbnd#xy[1]
-                            y == fcnbnd#xy[2]
+                            x == fcnbnd#x[1]
+                            y == fcnbnd#x[2]
                         IN
                             x + y - r - w
                     *)
@@ -712,21 +712,21 @@ and func_boundeds b = lazy begin
         Each bounded tuple (like `<<x, y>>` above) is replaced by a fresh
         identifier of the form:
 
-            fcnbnd#concatenated_names
+            fcnbnd#first_name
 
-        where "concatenated_names" results from concatenating the identifiers
-        that occur within the tuple. For example, `<<x, y>>` is replaced by
+        where "first_name" results from using the first identifier
+        that occurs within the tuple. For example, `<<x, y>>` is replaced by
 
-            fcnbnd#xy
+            fcnbnd#x
 
         The fresh identifier is used inside the `LET...IN` for defining each
         of the identifiers that occurred within the tuple. For example,
         `[<<x, y>> \in S |-> ...]` becomes:
 
-            [fcnbnd#xy \in S:
+            [fcnbnd#x \in S:
                 LET
-                    x == fcnbnd#xy[1]
-                    y == fcnbnd#xy[2]
+                    x == fcnbnd#x[1]
+                    y == fcnbnd#x[2]
                 IN
                     ...]
 
@@ -736,8 +736,8 @@ and func_boundeds b = lazy begin
         not available while parsing). The syntax of TLA+ ensures this,
         because no identifier in TLA+ source can contain a hashmark.
 
-        In each function constructor, the concatenation of identifiers
-        (like "xy" above) is unique, because the TLA+ syntax ensures that
+        In each function constructor, the first identifier from the tuple
+        (like "x" above) is unique, because the TLA+ syntax ensures that
         each identifier is unique within its context. Therefore, each bounded
         tuple within a function constructor will be replaced by a unique
         fresh identifier (unique within that context and that context's
@@ -748,20 +748,18 @@ and func_boundeds b = lazy begin
             <$> begin
                 fun (vs, dom) ->
                     (* bounds *)
-                    (* names of identifiers that appear within the tuple,
-                    for example "x", "y" from the tuple `<x, y>`
+                    (* name of first identifier that appears within the tuple,
+                    for example "x" from the tuple `<x, y>`.
+                    This name is to be used as suffix of the fresh identifier
+                    that will represent the tuple.
                     *)
-                    let nms = List.map (fun h -> h.core) vs in
-                    (* suffix of fresh identifier that will represent the tuple,
-                    for example "xy" from the tuple `<x, y>`
-                    *)
-                    let name = String.concat "" nms in
+                    let name = (List.hd vs).core in
                     (* fresh identifier that will represent the tuple,
-                    for example "fcnbnd#xy" from the tuple `<x, y>`
+                    for example "fcnbnd#x" from the tuple `<x, y>`
                     *)
                     let v = noprops ("fcnbnd#" ^ name) in
                     (* bounded constant declaration for the fresh identifier,
-                    for example `fcnbnd#xy \in S` from `<x, y> \in S`
+                    for example `fcnbnd#x \in S` from `<x, y> \in S`
                     *)
                     let hd = (v, Constant, Domain dom) in
                     (* a list with a single element, in preparation for
@@ -778,8 +776,8 @@ and func_boundeds b = lazy begin
                     For example, the tuple declaration `<<x, y>> \in S`
                     would here result in the creation of two definitions:
 
-                        x == fcnbnd#xy[1]
-                        y == fcnbnd#xy[2]
+                        x == fcnbnd#x[1]
+                        y == fcnbnd#x[2]
                     *)
                     let letin =
                         (* create one definition for each identifier that
@@ -791,7 +789,7 @@ and func_boundeds b = lazy begin
                             - `op` is the tuple element (an identifier)
                             *)
                             let e =
-                                (* tuple identifier, for example "fcnbnd#xy" *)
+                                (* tuple identifier, for example "fcnbnd#x" *)
                                 let f = noprops (Opaque v.core) in
                                 (* 1-based index numeral *)
                                 let idx =
@@ -799,13 +797,13 @@ and func_boundeds b = lazy begin
                                     let num = Num (i_str, "") in
                                     noprops num in
                                 (* function application on the index,
-                                for example:  fcnbnd#xy[1]
+                                for example:  fcnbnd#x[1]
                                 *)
                                 let e_ = FcnApp (f, [idx]) in
                                 noprops e_ in
                             (* definition for `op`, for example:
 
-                            x == fcnbnd#xy[1]
+                            x == fcnbnd#x[1]
 
                             The result is of type `defn`.
                             *)

--- a/src/expr/e_t.ml
+++ b/src/expr/e_t.ml
@@ -80,6 +80,7 @@ and expr_ =
   | Fcn of bounds * expr
     (* `f[x]` *)
   | FcnApp of expr * expr list
+    (* Set of functions `[A -> B]` *)
   | Arrow of expr * expr
   (* [h: S, ...] *)
   | Rect of (string * expr) list

--- a/test/fast/language/parse_function_comma_args.tla
+++ b/test/fast/language/parse_function_comma_args.tla
@@ -1,0 +1,19 @@
+------------------------- MODULE parse_function_comma_args ---------------------
+
+(* only for parsing, backends cannot yet handle this function *)
+p1 == [m, n \in {1}, r \in {2} |-> m]
+
+(* only for parsing, backends cannot yet handle this function *)
+p2 == [<<m, n>> \in {1} \X {2}, r \in {3} |-> m]
+
+(* only for parsing, backends cannot yet handle this function *)
+f == [1 EXCEPT ![1, 2] = 1]
+
+
+k == [<<m, n>> \in {1} \X {2} |-> m]
+
+
+THEOREM k[1, 2] = 1
+BY DEF k
+
+================================================================================

--- a/test/fast/language/parse_function_comma_args.tla
+++ b/test/fast/language/parse_function_comma_args.tla
@@ -16,4 +16,13 @@ k == [<<m, n>> \in {1} \X {2} |-> m]
 THEOREM k[1, 2] = 1
 BY DEF k
 
+
+g == [<<ab>> \in {<<1>>}, <<a, b>> \in {2} \X {3} |-> ab]
+
+
+(* backends do not not support this expression yet *)
+(*
+THEOREM g[<<1>>, <<2, 3>>] = 1
+BY DEF g
+*)
 ================================================================================


### PR DESCRIPTION
These changes extend the parser to:
- recognize tuples in declarations within function constructors, for example `[<<m, n>> \in A \X B |-> m]`
- recognize comma-separated arguments in `EXCEPT` assignments, for example `[1 EXCEPT ![1, 2] = 1]`