### PR TITLE
API: represent tuply declarations in the syntax tree

### DIFF
--- a/src/backend/fingerprints.ml
+++ b/src/backend/fingerprints.ml
@@ -405,6 +405,11 @@ let rec fp_expr counthyp countvar stack buf e =
         fp_expr counthyp countvar stack buf e
     | Bang _ ->
         Errors.bug ~at:e "Expr.Fingerprint: Bang"
+    | QuantTuply _
+    | ChooseTuply _
+    | SetStTuply _
+    | SetOfTuply _
+    | FcnTuply _ -> assert false
 
 
 and fp_sequent stack buf sq =
@@ -503,6 +508,8 @@ and fp_sequent stack buf sq =
               *)
               bprintf buf "$Fact(%a,%s)" (fp_expr counthyp countvar stack) e
                       (time_to_string tm)
+          | FreshTuply _ ->
+             assert false  (* unexpected case *)
   in
   spin stack sq.context
 

--- a/src/backend/isabelle.ml
+++ b/src/backend/isabelle.ml
@@ -459,6 +459,11 @@ and fmt_expr sd cx e = match e.core with
       Errors.bug ~at:e "Backend.Isabelle: @"
   | Parens (e, _) ->
       fmt_expr sd cx e
+  | QuantTuply _
+  | ChooseTuply _
+  | SetStTuply _
+  | SetOfTuply _
+  | FcnTuply _ -> assert false
 
 and extend_bound cx (v, kn, dom) =
   let (cx, v) = adj cx v in
@@ -537,6 +542,7 @@ and pp_print_sequent_outer cx ff sq = match Deque.front sq.context with
                *     failwith "Backend.Isabelle.pp_print_sequent"
                *)
         | Defn ({ core = Bpragma _ } , _, _, _) -> cx
+        | FreshTuply _ -> assert false  (* unexpected case *)
     end
 
 and pp_print_sequent_inner cx ff sq = match Deque.front sq.context with
@@ -575,6 +581,7 @@ and pp_print_sequent_inner cx ff sq = match Deque.front sq.context with
             let ncx = Ctx.bump cx in
             pp_print_sequent_inner ncx ff { sq with context = hs }
         | Defn (df, _, _, _) -> raise (Unsupported "Inner definition")
+        | FreshTuply _ -> assert false  (* unexpected case *)
     end
 
 type obx = obligation * string list * int * int

--- a/src/backend/ls4.ml
+++ b/src/backend/ls4.ml
@@ -490,6 +490,8 @@ let visitor = object (self : 'self)
             fprintf ff  "%s" (if (not is_first) then " & " else "");
             self#expr scxp e;
             true
+        | FreshTuply _ ->
+            assert false  (* unexpected case *)
       in
       (ret, Expr.Visit.adj scxp h)
   method myhyps ((ff,scx) as scxp) hs had_first = match Deque.front hs with
@@ -519,6 +521,7 @@ let visitor = object (self : 'self)
               self#expr scxp { e with core = Opaque name.core }
           | Some({core=Defn ({core=Operator (name, _)}, _, _, _)}) ->
                 self#expr scxp (Opaque name.core @@ name)
+          | Some {core=FreshTuply _}
           | Some({core=Fact _}) -> assert false
                 (* super#expr *)
           | Some({core=Defn _}) -> assert false

--- a/src/backend/zenon.ml
+++ b/src/backend/zenon.ml
@@ -437,6 +437,11 @@ and fmt_expr sd cx e =
         Errors.bug ~at:e "Backend.Zenon.fmt_exp: encountered @"
     | Parens (e, _) ->
         fmt_expr sd cx e
+    | QuantTuply _
+    | ChooseTuply _
+    | SetStTuply _
+    | SetOfTuply _
+    | FcnTuply _ -> assert false
 
 and pp_print_boundvar cx ff (v, _, _) = pp_print_string ff v
 
@@ -488,6 +493,9 @@ and pp_print_sequent cx ff sq =
   | Some ({core = Fact (_, Hidden, _)}, hs) ->
      let ncx = bump cx in
      pp_print_sequent ncx ff {sq with context = hs}
+  | Some ({core=FreshTuply _}, _) ->
+      assert false  (* unexpected case *)
+
 
 let pp_print_obligation ff ob =
   fprintf ff ";; obligation #%d@\n" (Option.get ob.id);

--- a/src/expr.mli
+++ b/src/expr.mli
@@ -48,14 +48,22 @@ module T: sig
     | List of bullet * expr list
     | Let of defn list * expr
     | Quant of quantifier * bounds * expr
+    | QuantTuply of
+          quantifier * tuply_bounds * expr
     | Tquant of quantifier * hints * expr
     | Choose of hint * expr option * expr
+    | ChooseTuply of
+          hints * expr option * expr
     | SetSt of hint * expr * expr
+    | SetStTuply of
+          hints * expr * expr
     | SetOf of expr * bounds
+    | SetOfTuply of expr * tuply_bounds
     | SetEnum of expr list
     | Product of expr list
     | Tuple of expr list
     | Fcn of bounds * expr
+    | FcnTuply of tuply_bounds * expr
     | FcnApp of expr * expr list
     | Arrow of expr * expr
     | Rect of (string * expr) list
@@ -100,6 +108,13 @@ module T: sig
   and bounds = bound list
   and bound =
       hint * kind * bound_domain
+  (* tuply bounds *)
+  and tuply_bounds = tuply_bound list
+  and tuply_bound =
+      tuply_name * bound_domain
+  and tuply_name =
+    | Bound_name of hint
+    | Bound_names of hints
   and bound_domain =
     | No_domain
     | Domain of expr
@@ -154,6 +169,7 @@ module T: sig
   and hyp = hyp_ wrapped
   and hyp_ =
     | Fresh of hint * shape * kind * hdom
+    | FreshTuply of hints * hdom
     | Flex of hint
     | Defn of defn * wheredef * visibility * export
     | Fact of expr * visibility * time
@@ -169,7 +185,9 @@ module T: sig
   and time = Now | Always | NotSet
 
   val unditto: bounds -> bounds
+  val unditto_tuply: tuply_bounds -> tuply_bounds
 
+  val name_of_tuply: tuply_name -> hint
   val name_of_bound: bound -> hint
   val names_of_bounds: bounds -> hints
   val string_of_bound: bound -> string
@@ -233,6 +251,12 @@ module T: sig
           bounds -> expr -> expr
       val make_forall:
           bounds -> expr -> expr
+      val make_tuply_exists:
+          tuply_bounds -> expr ->
+          expr
+      val make_tuply_forall:
+          tuply_bounds -> expr ->
+          expr
       val make_temporal_exists:
           t list -> expr -> expr
       val make_temporal_forall:
@@ -241,10 +265,21 @@ module T: sig
           t -> expr -> expr
       val make_bounded_choose:
           t -> expr -> expr -> expr
+      val make_tuply_choose:
+          t list -> expr -> expr
+      val make_bounded_tuply_choose:
+          t list -> expr ->
+          expr -> expr
       val make_setst:
           t -> expr -> expr -> expr
+      val make_tuply_setst:
+          t list -> expr ->
+          expr -> expr
       val make_setof:
           expr -> bounds -> expr
+      val make_tuply_setof:
+          expr -> tuply_bounds ->
+          expr
       val make_setenum:
           expr list -> expr
       val make_product:
@@ -253,6 +288,9 @@ module T: sig
           expr list -> expr
       val make_fcn:
           bounds -> expr -> expr
+      val make_tuply_fcn:
+          tuply_bounds -> expr ->
+          expr
       val make_fcn_domain:
           expr -> expr
       val make_fcn_app:
@@ -310,12 +348,25 @@ module T: sig
       val make_bounded:
           t -> kind ->
           expr -> bound
+      val make_unbounded_name_decl:
+          t -> tuply_bound
+      val make_bounded_name_decl:
+          t -> expr -> tuply_bound
+      val make_tuply_decl:
+          t list -> tuply_bound
+      val make_bounded_tuply_decl:
+          t list -> expr ->
+          tuply_bound
       val make_fresh:
           t -> kind -> hyp
       val make_bounded_fresh:
           t -> expr -> hyp
       val make_fresh_with_arity:
           t -> kind -> int -> hyp
+      val make_tuply_fresh:
+          t list -> hyp
+      val make_bounded_tuply_fresh:
+          t list -> expr -> hyp
   end
 
 
@@ -570,6 +621,21 @@ module Visit: sig
     method instance : 's scx -> instance -> unit
     method hyp      : 's scx -> hyp -> 's scx
     method hyps     : 's scx -> hyp Deque.dq -> 's scx
+  end
+  class virtual ['s] map_concrete: object
+      inherit ['s] map
+      method tuply_bounds:
+          's scx -> tuply_bounds ->
+          's scx * tuply_bounds
+      method tuply_bound:
+          's scx -> tuply_bound -> tuply_bound
+  end
+  class virtual ['s] iter_concrete: object
+      inherit ['s] iter
+      method tuply_bounds:
+          's scx -> tuply_bounds -> 's scx
+      method tuply_bound:
+          's scx -> tuply_bound -> unit
   end
   class virtual ['s] map_visible_hyp : ['s] map
   class virtual ['s] iter_visible_hyp : ['s] iter

--- a/src/expr/e_action.ml
+++ b/src/expr/e_action.ml
@@ -371,6 +371,7 @@ class auto_expansion_of_defs =
                     begin
                     assert (e_level <= 2);
                     match hyp.core with
+                        | FreshTuply _
                         | Fact _ -> assert false
                         | Flex _  -> assert (e.core = Ix n); e
                         | Fresh (op_name, shape, kind, _) ->

--- a/src/expr/e_anon.ml
+++ b/src/expr/e_anon.ml
@@ -27,6 +27,8 @@ let hyp_is_named what h = match h.core with
             _, _, _) ->
         nm.core = what
     | Fact (_, _, _) -> false
+    | FreshTuply _ -> assert false  (* unexpected
+        case *)
 
 
 let anon_apply index op args =
@@ -221,8 +223,9 @@ class anon_sg = object (self: 'self)
                         let index = depth + 1 in
                         let op = e $$ decl in
                         Ix index @@ op
-                    (* fact: unexpected *)
-                    | Some (_, {core=Fact _}) -> assert false
+                    (* unexpected cases *)
+                    | Some (_, {core=Fact _ | FreshTuply _}) ->
+                        assert false
                     | None ->
                          (* TODO? allow builtin operators here ?
                          possibly passing a context with builtin operators

--- a/src/expr/e_constness.ml
+++ b/src/expr/e_constness.ml
@@ -54,6 +54,12 @@ class virtual const_visitor = object (self : 'self)
             end
         in
         assign e isconst (sq_const sq.context)
+    | QuantTuply _
+    | ChooseTuply _
+    | SetStTuply _
+    | SetOfTuply _
+    | FcnTuply _ ->
+        assert false
     | _ ->
         let e = super#expr scx e in
         let cx = snd scx in
@@ -178,6 +184,12 @@ class virtual const_visitor = object (self : 'self)
                   | None -> true
                   | Some e -> is_const e
               end
+          | QuantTuply _
+          | ChooseTuply _
+          | SetStTuply _
+          | SetOfTuply _
+          | FcnTuply _ ->
+              assert false  (* not implemented *)
         in
         assign e isconst const
 

--- a/src/expr/e_fmt.ml
+++ b/src/expr/e_fmt.ml
@@ -349,6 +349,11 @@ let rec fmt_expr ?(temp=false) cx ew = match ew.core with
       fmt_expr ~temp:temp cx (Parens (e, Nlabel (l, xs) @@ e) @@ e)
   | Parens (e, {core = Syntax}) ->
       fmt_expr ~temp:temp cx e
+  | QuantTuply _
+  | ChooseTuply _
+  | SetStTuply _
+  | SetOfTuply _
+  | FcnTuply _ -> assert false
 
 and pp_print_bang ff () =
   if Params.debugging "garish" then
@@ -642,6 +647,8 @@ and pp_print_sequent  ?(temp=false) cx ff sq = match Deque.null sq.context with
                   fst (adj cx nm)
               | Fact (_, _,_) ->
                   bump cx
+              | FreshTuply _ ->
+                  assert false  (* not implemented *)
             in (cx, ch :: chs)
         end (cx, []) sq.context in
       let chs = List.filter (fun (cx, h) -> not (elide h)) (List.rev chs) in
@@ -679,6 +686,7 @@ and pp_print_hyp ?(temp=false) cx ff h =
            | Bounded (_, Hidden) -> ()
            | Bounded (b, _) -> fprintf ff " \\in %a" (pp_print_expr ~temp:temp cx) b) ;
         ncx
+    | FreshTuply _ -> assert false  (* not implemented *)
     | Flex nm ->
         let (ncx, nm) = adj cx nm in
         fprintf ff "NEW VARIABLE %s" nm ;

--- a/src/expr/e_level_comparison.ml
+++ b/src/expr/e_level_comparison.ml
@@ -484,6 +484,13 @@ class level_comparison = object (self : 'self)
             && j = l
         | At b,
           At c -> b = c
+        | (QuantTuply _ | ChooseTuply _ |
+           SetStTuply _ | SetOfTuply _ |
+           FcnTuply _), _
+        | _, (QuantTuply _ | ChooseTuply _ |
+              SetStTuply _ | SetOfTuply _ |
+              FcnTuply _) ->
+            assert false
         | _, _ -> false
 
     method exprs cx1 cx2 es fs = match es, fs with

--- a/src/expr/e_levels.ml
+++ b/src/expr/e_levels.ml
@@ -262,6 +262,8 @@ class virtual ['s] level_computation = object (self : 'self)
                     let hyp_scx = E_t.scx_front scx n in
                     let (_, e_) = self#hyp hyp_scx hyp in
                     get_level_info e_
+                | FreshTuply _ ->
+                    assert false  (* not implemented *)
                 | Fact (e_, _, _) ->
                     (*
                     E_t.print_cx cx;
@@ -908,6 +910,12 @@ class virtual ['s] level_computation = object (self : 'self)
             let new_parens = Parens (e_, pf_) in
             let new_e = new_parens @@ e in
             assign new_e exprlevel e_level_info
+        | QuantTuply _
+        | ChooseTuply _
+        | SetStTuply _
+        | SetOfTuply _
+        | FcnTuply _ ->
+            assert false  (* not implemented *)
         in
         e_
         end
@@ -986,6 +994,8 @@ class virtual ['s] level_computation = object (self : 'self)
                 let level_args = StringSet.singleton name.core in
                 LevelInfo (level, weights, level_args)
                 end
+            | FreshTuply _ ->
+                assert false  (* not implemented *)
             (* defined operator of any arity *)
             | Defn (df, _, _, _) ->
                 let df_ = self#defn scx df in
@@ -1013,6 +1023,8 @@ class virtual ['s] level_computation = object (self : 'self)
                 in
                 let h = Fresh (nm, shp, lc, dom) @@ h in
                 (adj scx h, h)
+            | FreshTuply _ ->
+                assert false  (* not implemented *)
             | Flex s ->
                 let h = Flex s @@ h in
                 (adj scx h, h)

--- a/src/expr/e_subst.ml
+++ b/src/expr/e_subst.ml
@@ -93,6 +93,11 @@ let rec app_expr s oe = match oe.core with
       Case (List.map (fun (e, f) -> (app_expr s e, app_expr s f)) arms,
             Option.map (app_expr s) oth) @@ oe
   | Parens (e, rig) -> Parens (app_expr s e, rig) @@ oe
+  | QuantTuply _
+  | ChooseTuply _
+  | SetStTuply _
+  | SetOfTuply _
+  | FcnTuply _ -> assert false
 
 and app_exprs s es =
   List.map (fun e -> app_expr s e) es
@@ -196,6 +201,7 @@ and app_hyps s cs = match Deque.front cs with
 
 and app_hyp s h = match h.core with
   | Fresh (x, shp, lv, b) -> Fresh (x, shp, lv, app_dom s b) @@ h
+  | FreshTuply _ -> assert false  (* not implemented *)
   | Flex v -> Flex v @@ h
   | Defn (d, wd, us, ex) -> Defn (app_defn s d, wd, us, ex) @@ h
   | Fact (e, us,tm) -> Fact (app_expr s e, us,tm) @@ h
@@ -346,6 +352,11 @@ class map = object (self : 'self)
         At b @@ oe
     | Parens (e, pf) ->
         Parens (self#expr s e, self#pform s pf) @@ oe
+    | QuantTuply _
+    | ChooseTuply _
+    | SetStTuply _
+    | SetOfTuply _
+    | FcnTuply _ -> assert false  (* not implemented *)
 
   method exprs s es = List.map (self#expr s) es
 
@@ -421,6 +432,7 @@ class map = object (self : 'self)
           | Bounded (r, rvis) -> Bounded (self#expr s r, rvis)
         in
         Fresh (nm, shp, lc, dom) @@ h
+    | FreshTuply _ -> assert false  (* not implemented *)
     | Flex v -> Flex v @@ h
     | Defn (df, wd, vis, ex) ->
         let (s, df) = self#defn s df in
@@ -472,6 +484,7 @@ class map_visible_hyp = object (self: 'self)
     method hyp s h =
       begin match h.core with
       | Fresh _ | Flex _ -> super#hyp s h
+      | FreshTuply _ -> assert false  (* not implemented *)
       | Defn (_, _, Hidden, _)
       | Fact (_, Hidden, _) -> (bump s, h)
       | Defn _ | Fact _ -> super#hyp s h

--- a/src/expr/e_t.mli
+++ b/src/expr/e_t.mli
@@ -59,16 +59,24 @@ and expr_ =
   | List of bullet * expr list
   | Let of defn list * expr
   | Quant of quantifier * bounds * expr
+  | QuantTuply of
+        quantifier * tuply_bounds * expr
   | Tquant of
         quantifier * hints * expr
   | Choose of
         hint * expr option * expr
+  | ChooseTuply of
+        hints * expr option * expr
   | SetSt of hint * expr * expr
+  | SetStTuply of
+        hints * expr * expr
   | SetOf of expr * bounds
+  | SetOfTuply of expr * tuply_bounds
   | SetEnum of expr list
   | Product of expr list
   | Tuple of expr list
   | Fcn of bounds * expr
+  | FcnTuply of tuply_bounds * expr
   | FcnApp of expr * expr list
   | Arrow of expr * expr
   | Rect of (string * expr) list
@@ -117,6 +125,13 @@ and expoint =
 and bounds = bound list
 and bound =
     hint * kind * bound_domain
+(* tuply bounds *)
+and tuply_bounds = tuply_bound list
+and tuply_bound =
+    tuply_name * bound_domain
+and tuply_name =
+  | Bound_name of hint
+  | Bound_names of hints
 and bound_domain =
   | No_domain
   | Domain of expr
@@ -175,6 +190,7 @@ and hyp = hyp_ wrapped
 and hyp_ =
   | Fresh of
         hint * shape * kind * hdom
+  | FreshTuply of hints * hdom
   | Flex of hint
   | Defn of defn * wheredef *
             visibility * export
@@ -194,6 +210,11 @@ and time = Now | Always | NotSet
 
 val unditto:
     bounds -> bounds
+val unditto_tuply:
+    tuply_bounds -> tuply_bounds
+
+val name_of_tuply:
+    tuply_name -> hint
 val name_of_bound:
     bound -> hint
 val names_of_bounds:
@@ -260,6 +281,12 @@ sig
         bounds -> expr -> expr
     val make_forall:
         bounds -> expr -> expr
+    val make_tuply_exists:
+        tuply_bounds -> expr ->
+        expr
+    val make_tuply_forall:
+        tuply_bounds -> expr ->
+        expr
     val make_temporal_exists:
         t list -> expr -> expr
     val make_temporal_forall:
@@ -268,10 +295,21 @@ sig
         t -> expr -> expr
     val make_bounded_choose:
         t -> expr -> expr -> expr
+    val make_tuply_choose:
+        t list -> expr -> expr
+    val make_bounded_tuply_choose:
+        t list -> expr ->
+        expr -> expr
     val make_setst:
         t -> expr -> expr -> expr
+    val make_tuply_setst:
+        t list -> expr ->
+        expr -> expr
     val make_setof:
         expr -> bounds -> expr
+    val make_tuply_setof:
+        expr -> tuply_bounds ->
+        expr
     val make_setenum:
         expr list -> expr
     val make_product:
@@ -280,6 +318,9 @@ sig
         expr list -> expr
     val make_fcn:
         bounds -> expr -> expr
+    val make_tuply_fcn:
+        tuply_bounds -> expr ->
+        expr
     val make_fcn_domain:
         expr -> expr
     val make_fcn_app:
@@ -337,12 +378,25 @@ sig
     val make_bounded:
         t -> kind ->
         expr -> bound
+    val make_unbounded_name_decl:
+        t -> tuply_bound
+    val make_bounded_name_decl:
+        t -> expr -> tuply_bound
+    val make_tuply_decl:
+        t list -> tuply_bound
+    val make_bounded_tuply_decl:
+        t list -> expr ->
+        tuply_bound
     val make_fresh:
         t -> kind -> hyp
     val make_bounded_fresh:
         t -> expr -> hyp
     val make_fresh_with_arity:
         t -> kind -> int -> hyp
+    val make_tuply_fresh:
+        t list -> hyp
+    val make_bounded_tuply_fresh:
+        t list -> expr -> hyp
 end
 
 

--- a/src/expr/e_visit.mli
+++ b/src/expr/e_visit.mli
@@ -56,6 +56,23 @@ class virtual ['s] iter : object
   method hyps     : 's scx -> hyp Deque.dq -> 's scx
 end
 
+class virtual ['s] map_concrete: object
+    inherit ['s] map
+    method tuply_bounds:
+        's scx -> tuply_bounds ->
+        's scx * tuply_bounds
+    method tuply_bound:
+        's scx -> tuply_bound -> tuply_bound
+end
+
+class virtual ['s] iter_concrete: object
+    inherit ['s] iter
+    method tuply_bounds:
+        's scx -> tuply_bounds -> 's scx
+    method tuply_bound:
+        's scx -> tuply_bound -> unit
+end
+
 class virtual ['s] map_visible_hyp : ['s] map
 class virtual ['s] iter_visible_hyp : ['s] iter
 

--- a/src/frontend/coalesce.ml
+++ b/src/frontend/coalesce.ml
@@ -171,8 +171,9 @@ let rename_with_loc cx e =
                 *)
                 let h = Defn (df, wd, vis, ex) @@ hyp in
                 (h, name)
+            | FreshTuply _
             | Fact _ ->
-                assert false
+                assert false  (* unexpected cases *)
     end in
     visitor#expr ((), cx) e
 
@@ -364,7 +365,9 @@ let coalesce_modal_visitor = object (self)
                     let op_ = (Operator (coalesced_op, expr)) @@ index in
                     coalesce_operator cx op_ args
                 end
-            | Fact _ -> (* unexpected `Fact` *)  assert false
+            | FreshTuply _
+            | Fact _ ->
+                assert false  (* unexpected cases *)
             | Defn ({core=Recursive _}, _, _, _) ->
                 (* not implemented case *)  assert false
             | Defn ({core=Instance _}, _, _, _) ->

--- a/src/proof.mli
+++ b/src/proof.mli
@@ -23,9 +23,11 @@ module T : sig
     | Suffices of sequent * proof
     | Pcase    of expr * proof
     | Pick     of bound list * expr * proof
+    | PickTuply of tuply_bounds * expr * proof
     | Use      of usable * bool
     | Have     of expr
     | Take     of bound list
+    | TakeTuply of tuply_bounds
     | Witness  of expr list
     | Forget   of int
   and qed_step = qed_step_ wrapped

--- a/src/proof/p_fmt.ml
+++ b/src/proof/p_fmt.ml
@@ -291,6 +291,9 @@ and pp_print_step cx ff stp =
         let cx = bump cx in
         (* conjunction of nondom facts in the SUFFICES *)
         bump cx
+    | TakeTuply _
+    | PickTuply _ ->
+        assert false
   in cx
 
 and pp_print_qed_step cx ff q =

--- a/src/proof/p_gen.ml
+++ b/src/proof/p_gen.ml
@@ -352,6 +352,9 @@ and gen_step (sq, inits, time_flag) stp =
     | Witness _
     | Pick _ ->
         Errors.bug ~at:stp "Proof.Gen.gen_step"
+    | TakeTuply _
+    | PickTuply _ ->
+        assert false
 
 (* FIXME this function must split the list of facts into
    its elements and pass them one by one to gen_step *)

--- a/src/proof/p_simplify.ml
+++ b/src/proof/p_simplify.ml
@@ -273,6 +273,9 @@ and simplify_step cx goal st time_flag =
                         (Quant (Forall, gbs, ge) @@ goal, shf + 1)
                   in
                   strip shf aux goal bs
+              | {core=QuantTuply (Forall, _, _)} ->
+                  assert false  (* tuple declarations
+                      have been translated earlier *)
               | _ ->
                   let msg =
                     Util.sprintf "@.@[<v2>@[<b0>%s@ %s@]@,%a@]@."
@@ -355,6 +358,9 @@ and simplify_step cx goal st time_flag =
                   let e = Apply (Internal Builtin.Unprimable @@ e, [e]) @@ e in
                   let goal = app_expr (scons e (shift 0)) goal in
                   instantiate aux err goal es
+              | {core = QuantTuply (Exists, _, _)} ->
+                  assert false  (* tuple declarations
+                      have been translated earlier *)
               | goal ->
                   let msg =
                     Util.sprintf "@.@[<v2>@[<b0>%s@ %s@]@,%a@]@."
@@ -447,6 +453,9 @@ and simplify_step cx goal st time_flag =
           | _ -> Errors.bug ~at:st "Proof.Simplify.simplify_step/PICK"
         in
         (cx, goal, nsts, time_flag)
+    | TakeTuply _
+    | PickTuply _ ->
+        assert false
   in
   Util.eprintf ~debug:"simpl" ~at:st
     "simplify_step (result)@\n@[<hv2>%t@ --> %t@]@.@."

--- a/src/proof/p_subst.ml
+++ b/src/proof/p_subst.ml
@@ -74,6 +74,9 @@ and app_step s stp = match stp.core with
   | Witness es ->
       let es = List.map (app_expr s) es in
       (s, Witness es @@ stp)
+  | TakeTuply _
+  | PickTuply _ ->
+      assert false
 
 and app_usable s us =
   let app_def dw =

--- a/src/proof/p_t.ml
+++ b/src/proof/p_t.ml
@@ -49,9 +49,11 @@ and step_ =
     | Suffices of sequent * proof
     | Pcase of expr * proof
     | Pick of bound list * expr * proof
+    | PickTuply of tuply_bounds * expr * proof
     | Use of usable * bool
     | Have of expr
     | Take of bound list
+    | TakeTuply of tuply_bounds
     | Witness of expr list
     | Forget of int
 (** Terminal proof-step **)

--- a/src/proof/p_t.mli
+++ b/src/proof/p_t.mli
@@ -26,9 +26,11 @@ and step_ =
     | Suffices of sequent * proof
     | Pcase of expr * proof
     | Pick of bound list * expr * proof
+    | PickTuply of tuply_bounds * expr * proof
     | Use of usable * bool
     | Have of expr
     | Take of bound list
+    | TakeTuply of tuply_bounds
     | Witness of expr list
     | Forget of int
 (** Terminal proof-step **)

--- a/src/proof/p_visit.mli
+++ b/src/proof/p_visit.mli
@@ -26,3 +26,13 @@ class virtual ['s] iter: object
   method step: 's scx -> step -> 's scx
   method usable: 's scx -> usable -> unit
 end
+
+class virtual ['s] map_concrete: object
+    inherit ['s] map
+    inherit ['s] Expr.Visit.map_concrete
+end
+
+class virtual ['s] iter_concrete: object
+    inherit ['s] iter
+    inherit ['s] Expr.Visit.iter_concrete
+end

--- a/src/smt/ectx.ml
+++ b/src/smt/ectx.ml
@@ -49,6 +49,7 @@ let update_hyp_name id h =
   | Fact _ ->
       (* Errors.bug "Backend.SMT.Ectx.adj: Fact not expected" *)
       h
+  | FreshTuply _ -> assert false  (* unexpected case *)
 
 let adj (dx,cx) h =
   let id = hyp_name h in
@@ -128,4 +129,5 @@ let rec from_hyps (ecx:t) (hs:hyp Deque.dq) : t =
           from_hyps ecx hs
       | Fact _ ->
           from_hyps (bump ecx) hs
+      | FreshTuply _ -> assert false  (* unexpected case *)
       end

--- a/src/smt/smtcommons.ml
+++ b/src/smt/smtcommons.ml
@@ -831,6 +831,8 @@ let allids cx =
               _, _, _)
         -> SSet.add nm.core r
       | Fact (_, _, _) -> r
+      | FreshTuply _ ->
+        assert false  (* unexpected case *)
     end SSet.empty cx
 
 let subtract xs x = fold_left (fun r a -> if x = a then r else r @ [a]) [] xs
@@ -972,6 +974,12 @@ and fv_expr scx e : string list =
         @ (match oth with Some e -> fv_expr scx e | None -> [])
   | Parens (e, pf) ->
       fv_expr scx e
+  | QuantTuply _
+  | ChooseTuply _
+  | SetStTuply _
+  | SetOfTuply _
+  | FcnTuply _ ->
+      assert false
   | _ -> []
 and fv_sel scx = function
   | Sel_inst args ->

--- a/src/typesystem/typ_e.ml
+++ b/src/typesystem/typ_e.ml
@@ -32,6 +32,8 @@ let hyp_optype h =
         optype nm
     | Fact (_, _, _) ->
         None
+    | FreshTuply _ ->
+        assert false  (* unexpected case *)
 
 
 (* Equivalence classes of type variables *)
@@ -783,6 +785,12 @@ let rec fmt_expr (cx: Expr.Fmt.ctx) ew = match ew.core with
       fmt_expr cx (Parens (e, Nlabel (l, xs) @@ e) @@ e)
   | Parens (e, {core=Syntax}) ->
       fmt_expr cx e
+  | QuantTuply _
+  | ChooseTuply _
+  | SetStTuply _
+  | SetOfTuply _
+  | FcnTuply _ ->
+      assert false
 
 and pp_print_bang ff () =
   if Params.debugging "garish" then
@@ -1083,6 +1091,8 @@ and pp_print_sequent cx ff sq = match Deque.null sq.context with
                   fst (Expr.Fmt.adj cx nm)
               | Fact (_, _, _) ->
                   Expr.Fmt.bump cx
+              | FreshTuply _ ->
+                  assert false  (* not implemented *)
             in (cx, ch :: chs)
         end (cx, []) sq.context in
       let chs = List.filter
@@ -1121,6 +1131,7 @@ and pp_print_hyp cx ff h =
               fprintf ff
               " \\in %a" (pp_print_expr cx) b);
         ncx
+    | FreshTuply _ -> assert false  (* not implemented *)
     | Flex nm ->
         let t = optype nm in
         let (ncx, nm) = Expr.Fmt.adj cx nm in


### PR DESCRIPTION
- extend the syntax-tree to represent tuply declarations
- add traversals for concrete syntax trees (trees that have tuply declarations) to the modules:
  - `E_visit`
  - `P_visit`
- add functions for creating syntax-tree nodes relevant to tuply declarations