### PR TITLE
fixed bogus proof in setEuclid_test.tla

### DIFF
--- a/test/fast/regression/setEuclid_test.tla
+++ b/test/fast/regression/setEuclid_test.tla
@@ -320,7 +320,7 @@ THEOREM Inv /\ Next => Inv'
              /\ IsFiniteSet(S))'
         <4>1. (S \subseteq Nat \ {0})'
           BY \A i, j \in S : j > i => j - i \in Nat \ {0},
-             <1>1, Zenon DEF Inv, TypeOK, lbl
+             <1>1 DEF Inv, TypeOK, lbl
         <4>2. (S # {})'
           BY <1>1, InputAssump, GCD1, GCD2, GCD3, CardThm, FiniteSetThm, Z3
           DEF Inv, TypeOK, CorrectTermination, lbl
@@ -360,14 +360,12 @@ THEOREM Inv /\ Next => Inv'
 (*|*) <3>3. QED
 (*|*)   BY <3>1, <3>2
     <2>3. CorrectTermination'
-      <3>1. ASSUME Cardinality(S) = 1
-            PROVE  GCD (S) = CHOOSE t \in S : TRUE
-        <4>1. PICK t \in S : S = {t}
-          BY <3>1, CardThm DEF Inv, TypeOK
-        <4>. QED  
-          BY <4>1, GCD2, Zenon DEF Inv, TypeOK
+      <3>1. Cardinality (S) = 1 => S = {CHOOSE t \in S : TRUE}
+        BY CardThm DEF Inv, TypeOK
+      <3>2. Cardinality (S) = 1 => GCD (S) = CHOOSE t \in S : TRUE
+        BY <3>1, GCD2 DEF Inv, TypeOK
       <3> QED
-        BY <1>1, <3>1, InputAssump, GCD1, GCD2, GCD3, CardThm, FiniteSetThm, Z3
+        BY <1>1, <3>2, InputAssump, GCD1, GCD2, GCD3, CardThm, FiniteSetThm, Z3
         DEF Inv, TypeOK, CorrectTermination, lbl
     <2>4. QED
       BY <2>1, <2>2, <2>3 DEF Inv

--- a/test/fast/regression/setEuclid_test.tla
+++ b/test/fast/regression/setEuclid_test.tla
@@ -320,7 +320,7 @@ THEOREM Inv /\ Next => Inv'
              /\ IsFiniteSet(S))'
         <4>1. (S \subseteq Nat \ {0})'
           BY \A i, j \in S : j > i => j - i \in Nat \ {0},
-             <1>1 DEF Inv, TypeOK, lbl
+             <1>1, Zenon DEF Inv, TypeOK, lbl
         <4>2. (S # {})'
           BY <1>1, InputAssump, GCD1, GCD2, GCD3, CardThm, FiniteSetThm, Z3
           DEF Inv, TypeOK, CorrectTermination, lbl
@@ -360,12 +360,14 @@ THEOREM Inv /\ Next => Inv'
 (*|*) <3>3. QED
 (*|*)   BY <3>1, <3>2
     <2>3. CorrectTermination'
-      <3>1. Cardinality (S) = 1 => S = {CHOOSE t \in S : TRUE}
-        BY CardThm DEF Inv, TypeOK
-      <3>2. Cardinality (S) = 1 => GCD (S) = CHOOSE t \in S : TRUE
-        BY <3>1, GCD2 DEF Inv, TypeOK
+      <3>1. ASSUME Cardinality(S) = 1
+            PROVE  GCD (S) = CHOOSE t \in S : TRUE
+        <4>1. PICK t \in S : S = {t}
+          BY <3>1, CardThm DEF Inv, TypeOK
+        <4>. QED  
+          BY <4>1, GCD2, Zenon DEF Inv, TypeOK
       <3> QED
-        BY <1>1, <3>2, InputAssump, GCD1, GCD2, GCD3, CardThm, FiniteSetThm, Z3
+        BY <1>1, <3>1, InputAssump, GCD1, GCD2, GCD3, CardThm, FiniteSetThm, Z3
         DEF Inv, TypeOK, CorrectTermination, lbl
     <2>4. QED
       BY <2>1, <2>2, <2>3 DEF Inv

--- a/test/fast/regression/setEuclid_test.tla
+++ b/test/fast/regression/setEuclid_test.tla
@@ -361,7 +361,10 @@ THEOREM Inv /\ Next => Inv'
 (*|*)   BY <3>1, <3>2
     <2>3. CorrectTermination'
       <3>1. Cardinality (S) = 1 => S = {CHOOSE t \in S : TRUE}
-        BY CardThm DEF Inv, TypeOK
+        <4> Cardinality (S) = 1 => \E x \in S : S = {x}
+          BY CardThm DEF Inv, TypeOK
+        <4> QED
+          BY Zenon
       <3>2. Cardinality (S) = 1 => GCD (S) = CHOOSE t \in S : TRUE
         BY <3>1, GCD2 DEF Inv, TypeOK
       <3> QED


### PR DESCRIPTION
I investigated in more detail the issue with the failed regression test. The failing obligation was

```Cardinality (S) = 1 => S = {CHOOSE t \in S : TRUE}```

During pre-processing, the old SMT backend simplified the right-hand side of this implication to

```\A x : x \in S <=> (S # {} => x \in S)```

which, together with the hypothesis ```S # {}``` available from the context, made the proof trivial.
In fact, the same step was proved even without appealing to CardThm, and without the assumption
of the left-hand side of the implication. This is clearly unsound.

This small PR contains a fixed proof of this test case.

NB: Running tlapm with the option `--debug tempfiles` still produces the input files for Isabelle
and Zenon, but no longer for SMT. More precisely, the files are created but are empty. Is this a
known issue?