### PR TITLE
fix install location for ptl_to_trp

### DIFF
--- a/translate/dune
+++ b/translate/dune
@@ -8,8 +8,8 @@
  (modules_without_implementation fotypes))
 
 (install ; It has to be installed under 2 names for some reason.
- (section bin)
- (files (main.exe as ptl_to_trp)))
+ (section (site (tlapm backends)))
+ (files (main.exe as bin/ptl_to_trp)))
 
 (ocamllex folex)
 (ocamlyacc foyacc)


### PR DESCRIPTION
`ptl_to_trp` is installed in `.../bin` but `tlapm` expects to find it in `.../lib/tlapm/backends/bin`.
