### PR TITLE
Use HTTPS to download the Isabelle.

### DIFF
--- a/deps/isabelle/Makefile
+++ b/deps/isabelle/Makefile
@@ -19,7 +19,7 @@ ifeq ($(OS_TYPE),Cygwin)
 	FIND_EXEC=-executable
 endif
 
-ISABELLE_URL=http://isabelle.in.tum.de/website-$(ISABELLE_VSN)/dist/$(ISABELLE_ARCHIVE)
+ISABELLE_URL=https://isabelle.in.tum.de/website-$(ISABELLE_VSN)/dist/$(ISABELLE_ARCHIVE)
 ISABELLE_DIR=Isabelle
 
 # Some defaults, for the case if makefile is called not by the dune build system.


### PR DESCRIPTION
HTTP endpoints used to download the Isabelle/HOL during the build no longer work.