### PR TITLE
Rewrite Nat to {x ∈ Int : 0 ≤ x} instead of n ∈ Nat to (n ∈ Int ∧ 0 ≤ n).

### DIFF
--- a/deps/isabelle/.gitignore
+++ b/deps/isabelle/.gitignore
@@ -1,3 +1,3 @@
 /Isabelle.exec-files
-/Isabelle.no-links
 /Isabelle/
+/Isabelle-test/

--- a/deps/isabelle/Makefile
+++ b/deps/isabelle/Makefile
@@ -64,7 +64,8 @@ $(ISABELLE_DIR)/src/TLA+: $(ISABELLE_DIR)
 		&& echo "ISABELLE_OUTPUT=$$HEAPS_PATH" >> etc/settings
 	mkdir -p $(ISABELLE_DIR)/src/TLA+ \
 		&& cp -a ../../isabelle/* $(ISABELLE_DIR)/src/TLA+/ \
-		&& chmod -R u+w $(ISABELLE_DIR)/src/TLA+/
+		&& chmod -R u+w $(ISABELLE_DIR)/src/TLA+/ \
+		&& make -C $(ISABELLE_DIR)/src/TLA+/ clean
 	cd $(ISABELLE_DIR)/ \
 		&& ./bin/isabelle build -o system_heaps -o document=false -b -v -d src/Pure Pure \
 		&& ./bin/isabelle build -o system_heaps -o document=false -b -c -v -d src/TLA+ TLA+ \

--- a/deps/isabelle/Makefile
+++ b/deps/isabelle/Makefile
@@ -44,19 +44,23 @@ $(ISABELLE_ARCHIVE): $(CACHE_DIR)/$(ISABELLE_ARCHIVE)
 	ln -s $< $@
 
 # Extract the isabelle archive.
+# $(ISABELLE_DIR) is for the release and
+# $(ISABELLE_DIR)-test is for running the isabelle TLA+ tests.
 $(ISABELLE_DIR): $(ISABELLE_ARCHIVE)
+	rm -rf $(ISABELLE_DIR) $(ISABELLE_DIR)-test
 ifeq ($(ISABELLE_ARCHIVE_TYPE),tgz)
-	rm -rf $(ISABELLE_DIR)
 	tar -xzf $<
 	mv $(ISABELLE_ARCHIVE_DIR) $(ISABELLE_DIR)
 endif
+	cp -r $(ISABELLE_DIR) $(ISABELLE_DIR)-test
 
 # Build the TLA+ theory.
 .PRECIOUS: $(ISABELLE_DIR)/src/TLA+
 $(ISABELLE_DIR)/src/TLA+: $(ISABELLE_DIR)
 	cd $(ISABELLE_DIR) \
 		&& rm -rf contrib/ProofGeneral* doc heaps/*/HOL contrib/vscodium* contrib/vscode* \
-		&& sed -i -e 's@^\(contrib/vscode_extension\|contrib/vscodium\|src/Tools/Demo\)@#rm at TLA# \1@' etc/components
+		&& sed -i -e 's@^\(contrib/vscode_extension\|contrib/vscodium\|src/Tools/Demo\)@#rm at TLA# \1@' etc/components \
+		&& echo 'src/TLA+' >> etc/components
 	cd $(ISABELLE_DIR) \
 		&& HEAPS_PATH=$(shell pwd)/$(ISABELLE_DIR)/heaps \
 		&& if [ "$(HOST_CPU)" = "x86_64" ] ; then sed -i -e 's/^ML_PLATFORM=.*$$/ML_PLATFORM="$${ISABELLE_PLATFORM64:-$$ISABELLE_PLATFORM}"/' etc/settings ; fi \

--- a/deps/isabelle/dune
+++ b/deps/isabelle/dune
@@ -3,8 +3,7 @@
 ; The generated heaps (Pure and TLA+) are in Isabelle/heaps/polyml-*/.
 (rule
  (alias default)
- (mode (promote (until-clean)))
- (deps "Makefile" (source_tree ../../isabelle))
+ (deps "Makefile" (source_tree ../../isabelle) (sandbox none))
  (targets (dir Isabelle) "Isabelle.no-links" "Isabelle.exec-files")
  (action (run "make" "-C" "." "Isabelle.no-links" "Isabelle.exec-files")))
 

--- a/deps/isabelle/dune
+++ b/deps/isabelle/dune
@@ -3,9 +3,15 @@
 ; The generated heaps (Pure and TLA+) are in Isabelle/heaps/polyml-*/.
 (rule
  (alias default)
- (deps "Makefile" (source_tree ../../isabelle) (sandbox none))
- (targets (dir Isabelle) "Isabelle.no-links" "Isabelle.exec-files")
- (action (run "make" "-C" "." "Isabelle.no-links" "Isabelle.exec-files")))
+ (deps
+  "dune.mk"
+  (source_tree ../../isabelle)
+  (sandbox none))
+ (targets
+  (dir "Isabelle")
+  (dir "Isabelle-test")
+  "Isabelle.exec-files")
+ (action (run "make" "-f" "dune.mk")))
 
 (install
  (section (site (tlapm backends)))

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.12)
+(lang dune 3.15)
 
 (using dune_site 0.1)
 

--- a/isabelle/CaseExpressions.thy
+++ b/isabelle/CaseExpressions.thy
@@ -1,8 +1,8 @@
 (*  Title:      TLA+/CaseExpressions.thy
     Author:     Stephan Merz, Inria Nancy
-    Copyright (C) 2009-2022  INRIA and Microsoft Corporation
+    Copyright (C) 2009-2024  INRIA and Microsoft Corporation
     License:    BSD
-    Version:    Isabelle2021-1
+    Version:    Isabelle2024
 *)
 
 section \<open> Case expressions \<close>

--- a/isabelle/Constant.thy
+++ b/isabelle/Constant.thy
@@ -1,8 +1,8 @@
 (*  Title:      TLA+/Constant.thy
     Author:     Stephan Merz, LORIA
-    Copyright (C) 2008-2022  INRIA and Microsoft Corporation
+    Copyright (C) 2008-2024  INRIA and Microsoft Corporation
     License:    BSD
-    Version:    Isabelle2021-1
+    Version:    Isabelle2024
 *)
 
 section \<open> Main theory for constant-level Isabelle/\tlaplus{} \<close>

--- a/isabelle/FixedPoints.thy
+++ b/isabelle/FixedPoints.thy
@@ -1,8 +1,8 @@
 (*  Title:      TLA+/FixedPoints.thy
-    Author:     Stephan Merz, LORIA
-    Copyright (C) 2008-2021  INRIA and Microsoft Corporation
+    Author:     Stephan Merz, Inria Nancy
+    Copyright (C) 2008-2024  INRIA and Microsoft Corporation
     License:    BSD
-    Version:    Isabelle2020
+    Version:    Isabelle2024
 *)
 
 section \<open>Fixed points for set-theoretical constructions\<close>

--- a/isabelle/Functions.thy
+++ b/isabelle/Functions.thy
@@ -1,8 +1,8 @@
 (*  Title:      TLA+/Functions.thy
-    Author:     Stephan Merz, LORIA
-    Copyright (C) 2008-2021  INRIA and Microsoft Corporation
+    Author:     Stephan Merz, Inria Nancy
+    Copyright (C) 2008-2024  INRIA and Microsoft Corporation
     License:    BSD
-    Version:    Isabelle2020
+    Version:    Isabelle2024
 *)
 
 section \<open> \tlaplus{} Functions \<close>

--- a/isabelle/IntegerArithmetic.thy
+++ b/isabelle/IntegerArithmetic.thy
@@ -833,7 +833,7 @@ lemma nat_iff_int_geq0' (*[simp]*) : "n \<in> Nat = (n \<in> Int \<and> 0 \<le> 
   by (auto simp: int_leq_def)
 
 text \<open>
-We will use \<open>nat_iff_int_geq0\<close> for simplification instead
+We will use \<open>nat_is_int_geq0\<close> for simplification instead
 of \<open>nat_iff_int_geq0'\<close> for rewriting \<open>Nat\<close> to \<open>Int\<close> to
 handle also the cases where no \<open>Nat\<close> is used without
 the \<open>\<in>\<close> operator, e.g. in function sets.

--- a/isabelle/IntegerArithmetic.thy
+++ b/isabelle/IntegerArithmetic.thy
@@ -816,8 +816,24 @@ text \<open>
   From now on, we reduce the set @{text "Nat"} to the set of
   non-negative integers.
 \<close>
-lemma nat_iff_int_geq0 [simp]: "n \<in> Nat = (n \<in> Int \<and> 0 \<le> n)"
+lemma nat_iff_int_geq0' (*[simp]*) : "n \<in> Nat = (n \<in> Int \<and> 0 \<le> n)"
   by (auto simp: int_leq_def)
+
+text \<open>
+We will use \<open>nat_iff_int_geq0\<close> for simplification instead
+of \<open>nat_iff_int_geq0'\<close> for rewriting \<open>Nat\<close> to \<open>Int\<close> to
+handle also the cases where no \<open>Nat\<close> is used without
+the \<open>\<in>\<close> operator, e.g. in function sets.
+\<close>
+lemma nat_iff_int_geq0 [simp] : "Nat = {x \<in> Int : 0 \<le> x}"
+proof
+  show "\<And>x. x \<in> Nat \<Longrightarrow> x \<in> {x \<in> Int : 0 \<le> x}"
+    using nat_iff_int_geq0' by auto
+next
+  show "\<And>x. x \<in> {x \<in> Int : 0 \<le> x} \<Longrightarrow> x \<in> Nat"
+    using nat_iff_int_geq0' by auto
+qed
+
 
 declare natIsInt [simp del]
 declare succInNat [simp del]
@@ -1696,12 +1712,12 @@ lemma trans_leq_diff_nat2 [simp]:
 lemma int_leq_iff_add:
   assumes "i \<in> Int" and "j \<in> Int"
   shows "(i \<le> j) = (\<exists>k \<in> Nat: j = i + k)" (is "?lhs = ?rhs")
-  using assms by (auto intro: int_leq_imp_add)
+  using assms by (auto intro: int_leq_imp_add simp del: nat_iff_int_geq0 simp add: nat_iff_int_geq0')
 
 lemma int_less_iff_succ_add:
   assumes "i \<in> Int" and "j \<in> Int"
   shows "(i < j) = (\<exists>k \<in> Nat: j = succ[i + k])" (is "?lhs = ?rhs")
-  using assms by (auto intro: int_less_imp_succ_add)
+  using assms by (auto intro: int_less_imp_succ_add simp del: nat_iff_int_geq0 simp add: nat_iff_int_geq0')
 
 lemma leq_add_self1 [simp]:
   assumes "i \<in> Int" and "j \<in> Int"

--- a/isabelle/IntegerArithmetic.thy
+++ b/isabelle/IntegerArithmetic.thy
@@ -1,8 +1,8 @@
 (*  Title:      TLA+/IntegerArithmetic.thy
     Author:     Stephan Merz, Inria Nancy
-    Copyright (C) 2009-2022  INRIA and Microsoft Corporation
+    Copyright (C) 2009-2024  INRIA and Microsoft Corporation
     License:    BSD
-    Version:    Isabelle2021-1
+    Version:    Isabelle2024
 *)
 
 section \<open> Arithmetic (except division) for the integers \<close>
@@ -719,18 +719,31 @@ by simp
 lemma less_not_refl: "a < b \<Longrightarrow> a \<noteq> b"
 by auto
 
-lemma neq_leq_trans [trans]: "a \<noteq> b \<Longrightarrow> a \<le> b \<Longrightarrow> a < b"
+lemma neq_leq_trans [trans,intro]: "a \<noteq> b \<Longrightarrow> a \<le> b \<Longrightarrow> a < b"
 by (simp add: less_def)
 
-declare neq_leq_trans[simplified,trans]
+declare neq_leq_trans[simplified,trans,intro]
+
+lemma neq_leq_trans_sym [trans,intro]: "b \<noteq> a \<Longrightarrow> a \<le> b \<Longrightarrow> a < b"
+by (simp add: less_def)
+
+declare neq_leq_trans_sym[simplified,trans,intro]
 
 lemma leq_neq_trans [trans,elim!]: "a \<le> b \<Longrightarrow> a \<noteq> b \<Longrightarrow> a < b"
 by (simp add: less_def)
 
-declare leq_neq_trans[simplified,trans]
+declare leq_neq_trans[simplified,trans,elim!]
+
+lemma leq_neq_trans_sym [trans,elim!]: "a \<le> b \<Longrightarrow> b \<noteq> a \<Longrightarrow> a < b"
+by (simp add: less_def)
+
+declare leq_neq_trans_sym[simplified,trans,elim!]
 
 (* Don't add to [simp]: will be tried on all disequalities! *)
 lemma leq_neq_iff_less: "a \<le> b \<Longrightarrow> (a \<noteq> b) = (a < b)"
+by auto
+
+lemma leq_neq_iff_less_sym: "a \<le> b \<Longrightarrow> (b \<noteq> a) = (a < b)"
 by auto
 
 subsection \<open> Facts about @{text "\<le>"} over @{text Int} \<close>
@@ -825,7 +838,7 @@ of \<open>nat_iff_int_geq0'\<close> for rewriting \<open>Nat\<close> to \<open>I
 handle also the cases where no \<open>Nat\<close> is used without
 the \<open>\<in>\<close> operator, e.g. in function sets.
 \<close>
-lemma nat_iff_int_geq0 [simp] : "Nat = {x \<in> Int : 0 \<le> x}"
+lemma nat_is_int_geq0 [simp] : "Nat = {x \<in> Int : 0 \<le> x}"
 proof
   show "\<And>x. x \<in> Nat \<Longrightarrow> x \<in> {x \<in> Int : 0 \<le> x}"
     using nat_iff_int_geq0' by auto
@@ -1087,14 +1100,7 @@ lemma nat_leq_induct:  \<comment> \<open>sometimes called ``complete induction''
   shows "\<forall>n\<in>Nat : P(n)"
 proof -
   have "\<forall>n\<in>Nat : \<forall>m\<in>Nat : m \<le> n \<Rightarrow> P(m)"
-  proof (rule natInduct)
-    from base show "\<forall>m \<in> Nat : m \<le> 0 \<Rightarrow> P(m)" by auto
-  next
-    fix n
-    assume "n \<in> Nat" "\<forall>m \<in> Nat : m \<le> n \<Rightarrow> P(m)"
-    with step show "\<forall>m \<in> Nat : m \<le> succ[n] \<Rightarrow> P(m)" 
-      by (auto simp del: nat_iff_int_geq0)
-  qed
+    using assms by (intro natInduct) auto
   thus ?thesis by auto
 qed
 
@@ -1179,12 +1185,12 @@ lemma int_lessE:
   by (simp add: int_less_iff_zero_less_diff[of "a" "b"])
 
 lemma int_leq_not_less:
-  assumes "a \<in> Int" and "b \<in> Int" and "a \<le> b"
+  assumes "a \<le> b" and "a \<in> Int" and "b \<in> Int"
   shows "(b < a) = FALSE"
   using assms by (auto simp: less_def dest: int_leq_antisym)
 
 lemma int_less_not_leq:
-  assumes "a \<in> Int" and "b \<in> Int" and "a < b"
+  assumes "a < b" and "a \<in> Int" and "b \<in> Int"
   shows "(b \<le> a) = FALSE"
   using assms by (auto simp: less_def dest: int_leq_antisym)
 
@@ -1429,7 +1435,7 @@ proof (rule int_leq_lessE[OF ij])
   thus ?thesis by auto
 next
   assume "i = j"
-  with i f show ?thesis by (auto simp del: nat_iff_int_geq0)
+  with i f show ?thesis by auto
 qed (auto simp: i[simplified] j[simplified])
 
 lemma int_succ_lessI:
@@ -1629,12 +1635,12 @@ lemma leq_add_nat2 [iff]:
   shows "b \<le> a + b"
   using assms add_leq_right_mono [of 0 a b] by simp
 
-lemma trans_leq_add_nat1 [simp] (* was [elim]*):
+lemma trans_leq_add_nat1 [simp,intro]:
   assumes "a \<le> b" and "a \<in> Int" and "b \<in> Int" and "m \<in> Int" and "0 \<le> m"
   shows "a \<le> b+m"
   using assms by (simp add: int_leq_trans[of "a" "b" "b+m"])
 
-lemma trans_leq_add_nat2 [simp] (* was [elim] *):
+lemma trans_leq_add_nat2 [simp,intro]:
   assumes "a \<le> b" and "a \<in> Int" and "b \<in> Int" and "m \<in> Int" and "0 \<le> m"
   shows "a \<le> m+b"
   using assms by (simp add: int_leq_trans[of "a" "b" "m+b"])
@@ -1712,12 +1718,12 @@ lemma trans_leq_diff_nat2 [simp]:
 lemma int_leq_iff_add:
   assumes "i \<in> Int" and "j \<in> Int"
   shows "(i \<le> j) = (\<exists>k \<in> Nat: j = i + k)" (is "?lhs = ?rhs")
-  using assms by (auto intro: int_leq_imp_add simp del: nat_iff_int_geq0 simp add: nat_iff_int_geq0')
+  using assms by (auto intro: int_leq_imp_add simp del: nat_is_int_geq0 simp add: nat_iff_int_geq0')
 
 lemma int_less_iff_succ_add:
   assumes "i \<in> Int" and "j \<in> Int"
   shows "(i < j) = (\<exists>k \<in> Nat: j = succ[i + k])" (is "?lhs = ?rhs")
-  using assms by (auto intro: int_less_imp_succ_add simp del: nat_iff_int_geq0 simp add: nat_iff_int_geq0')
+  using assms by (auto intro: int_less_imp_succ_add simp del: nat_is_int_geq0 simp add: nat_iff_int_geq0')
 
 lemma leq_add_self1 [simp]:
   assumes "i \<in> Int" and "j \<in> Int"
@@ -1734,15 +1740,25 @@ lemma leq_add_self2 [simp]:
   shows "(j + i \<le> i) = (j \<le> 0)"
   using assms by (simp add: add_commute)
 
-lemma trans_less_add_nat1 [simp]:
+lemma trans_less_add_nat1 [simp,intro]:
   assumes "i < j" and "i \<in> Int" and "j \<in> Int" and "m \<in> Int" and "0 \<le> m"
   shows "i < j + m"
   using assms by (simp add: int_less_leq_trans[of "i" "j" "j+m"])
 
-lemma trans_less_add_nat2 [simp]:
+lemma trans_less_add_nat2 [simp,intro]:
   assumes "i < j" and "i \<in> Int" and "j \<in> Int" and "m \<in> Int" and "0 \<le> m"
   shows "i < m + j"
   using assms by (simp add: int_less_leq_trans[of "i" "j" "m+j"])
+
+lemma trans_leq_less_add_nat1 [simp,intro]:
+  assumes "i \<le> j" and "i \<in> Int" and "j \<in> Int" and "m \<in> Int" and "0 < m"
+  shows "i < j + m"
+  using assms add_leq_less_mono[of "i" "j" "0" "m"] by simp
+
+lemma trans_leq_less_add_nat2 [simp,intro]:
+  assumes "i \<le> j" and "i \<in> Int" and "j \<in> Int" and "m \<in> Int" and "0 < m"
+  shows "i < m + j"
+  using assms add_leq_less_mono[of "i" "j" "0" "m"] by (simp add: add_commute)
 
 lemma trans_less_diff_nat1:
   assumes "i < j" and "i \<in> Int" and "j \<in> Int" and "m \<in> Int" and "0 \<le> m"

--- a/isabelle/IntegerDivision.thy
+++ b/isabelle/IntegerDivision.thy
@@ -1,8 +1,8 @@
 (*  Title:      TLA+/IntegerDivision.thy
     Author:     Stephan Merz, Inria Nancy
-    Copyright (C) 2009-2022  INRIA and Microsoft Corporation
+    Copyright (C) 2009-2024  INRIA and Microsoft Corporation
     License:    BSD
-    Version:    Isabelle2021-1
+    Version:    Isabelle2024
 *)
 
 section \<open> The division operators div and mod on the integers \<close>

--- a/isabelle/Integers.thy
+++ b/isabelle/Integers.thy
@@ -1,8 +1,8 @@
 (*  Title:      TLA+/Integers.thy
-    Author:     Stephan Merz, LORIA
-    Copyright (C) 2008-2021  INRIA and Microsoft Corporation
+    Author:     Stephan Merz, Inria Nancy
+    Copyright (C) 2008-2024  INRIA and Microsoft Corporation
     License:    BSD
-    Version:    Isabelle2021-1
+    Version:    Isabelle2024
 *)
 
 section \<open> The set of integer numbers \<close>

--- a/isabelle/Makefile
+++ b/isabelle/Makefile
@@ -18,7 +18,7 @@ heap-only:
 # This is invoked from the dune file to run the tests.
 # The tex files might be readonly in the sandbox and Isabelle copies
 # them several times, and thus fails by overwriting a readonly file.
-dune-runtest:
+dune-runtest: clean
 	chmod 644 examples/document/root.tex document/root.tex
 	$(SRC_ROOT)/deps/isabelle/Isabelle/bin/isabelle build -o document=false -o browser_info=false -c -v -D .
 

--- a/isabelle/Makefile
+++ b/isabelle/Makefile
@@ -1,5 +1,4 @@
 ISABELLE=isabelle
-SRC_ROOT=$(if $(DUNE_SOURCEROOT),$(DUNE_SOURCEROOT),..)
 
 .PHONY: rebuild heap-only dune-runtest clean
 
@@ -15,12 +14,9 @@ rebuild:
 heap-only:
 	$(ISABELLE) build -o document=false -o browser_info=false -b -c -v -D .
 
-# This is invoked from the dune file to run the tests.
-# The tex files might be readonly in the sandbox and Isabelle copies
-# them several times, and thus fails by overwriting a readonly file.
-dune-runtest: clean
-	chmod 644 examples/document/root.tex document/root.tex
-	$(SRC_ROOT)/deps/isabelle/Isabelle/bin/isabelle build -o document=false -o browser_info=false -c -v -D .
+# Launch Isabelle / Jedit to edit the theory, examples, tests.
+jedit:
+	$(ISABELLE) jedit -d . Constant.thy
 
 clean:
 	rm -rf output/ examples/output/

--- a/isabelle/PredicateLogic.thy
+++ b/isabelle/PredicateLogic.thy
@@ -1,8 +1,8 @@
 (*  Title:      TLA+/PredicateLogic.thy
-    Author:     Stephan Merz, LORIA
-    Copyright (C) 2008-2021  INRIA and Microsoft Corporation
+    Author:     Stephan Merz, Inria Nancy
+    Copyright (C) 2008-2024  INRIA and Microsoft Corporation
     License:    BSD
-    Version:    Isabelle2020
+    Version:    Isabelle2024
 *)
 
 section \<open>First-Order Logic for TLA+\<close>

--- a/isabelle/ROOT
+++ b/isabelle/ROOT
@@ -10,7 +10,7 @@ session "TLA+" = "Pure" +
 
   document_files
     "root.tex"
-(*
+
 session "TLA+Tests" in tests = "TLA+" +
   options [document=false]
   theories
@@ -21,8 +21,7 @@ session "TLA+Examples" in examples = "TLA+" +
 
   theories
     Allocator
-    (* AtomicBakeryG  TODO: Restore it here, when examples are fixed. *)
+    AtomicBakeryG
 
   document_files
     "root.tex"
-*)

--- a/isabelle/ROOT
+++ b/isabelle/ROOT
@@ -10,7 +10,7 @@ session "TLA+" = "Pure" +
 
   document_files
     "root.tex"
-
+(*
 session "TLA+Tests" in tests = "TLA+" +
   options [document=false]
   theories
@@ -25,3 +25,4 @@ session "TLA+Examples" in examples = "TLA+" +
 
   document_files
     "root.tex"
+*)

--- a/isabelle/SetTheory.thy
+++ b/isabelle/SetTheory.thy
@@ -1,8 +1,8 @@
 (*  Title:      TLA+/SetTheory.thy
-    Author:     Stephan Merz, LORIA
-    Copyright (C) 2008-2021  INRIA and Microsoft Corporation
+    Author:     Stephan Merz, Inria Nancy
+    Copyright (C) 2008-2024  INRIA and Microsoft Corporation
     License:    BSD
-    Version:    Isabelle2020
+    Version:    Isabelle2024
 *)
 
 section \<open>\tlaplus{} Set Theory\<close>
@@ -378,20 +378,22 @@ lemma bspec:
   shows "P(x)"
 using assms unfolding bAll_def by blast
 
+setup \<open>
+  map_theory_claset (fn ctxt =>
+    ctxt addbefore ("bspec", fn ctxt' => dresolve_tac ctxt' @{thms bspec} THEN' assume_tac ctxt'))
+\<close>
+
+(**
 text \<open>The following rule intentionally has single assumption (non-conditional),
 because otherwise it interferes with how \<open>Nat\<close> is reduced to \<open>Int\<close>.\<close>
 lemma bspec' [dest]:
   assumes "\<forall>x\<in>A : P(x)"
   shows "\<forall>x : (x\<in>A) \<Rightarrow> P(x)"
   using assms unfolding bAll_def by blast
+**)
 
 lemma bAll_unb [simp] : "\<And>T P. (\<forall>e : e \<in> T \<Rightarrow> P(e)) \<Longrightarrow> (\<forall>e \<in> T : P(e))"
   using bAll_def by simp
-
-setup \<open>
-  map_theory_claset (fn ctxt =>
-    ctxt addbefore ("bspec", fn ctxt' => dresolve_tac ctxt' @{thms bspec} THEN' assume_tac ctxt'))
-\<close>
 
 lemma bAllE [elim]:
   assumes "\<forall>x\<in>A : P(x)" and "x \<notin> A \<Longrightarrow> Q" and "P(x) \<Longrightarrow> Q"

--- a/isabelle/Strings.thy
+++ b/isabelle/Strings.thy
@@ -1,8 +1,8 @@
 (*  Title:      TLA+/Strings.thy
-    Author:     Stephan Merz, LORIA
-    Copyright (C) 2009-2021  INRIA and Microsoft Corporation
+    Author:     Stephan Merz, Inria Nancy
+    Copyright (C) 2009-2024  INRIA and Microsoft Corporation
     License:    BSD
-    Version:    Isabelle2020
+    Version:    Isabelle2024
 *)
 
 section \<open> Characters and strings \<close>

--- a/isabelle/Tuples.thy
+++ b/isabelle/Tuples.thy
@@ -129,7 +129,7 @@ lemma SeqI [intro]:
   shows "s \<in> Seq(S)"
 proof -
   from assms have "s \<in> [1 .. Len(s) \<rightarrow> S]" by auto
-  with s show ?thesis unfolding Seq_def by (auto simp del: nat_iff_int_geq0)
+  with s show ?thesis unfolding Seq_def by (auto simp del: nat_is_int_geq0)
 qed
 
 lemma SeqI':  \<comment> \<open> closer to the definition but probably less useful \<close>

--- a/isabelle/Tuples.thy
+++ b/isabelle/Tuples.thy
@@ -129,7 +129,7 @@ lemma SeqI [intro]:
   shows "s \<in> Seq(S)"
 proof -
   from assms have "s \<in> [1 .. Len(s) \<rightarrow> S]" by auto
-  with s show ?thesis unfolding Seq_def by auto
+  with s show ?thesis unfolding Seq_def by (auto simp del: nat_iff_int_geq0)
 qed
 
 lemma SeqI':  \<comment> \<open> closer to the definition but probably less useful \<close>

--- a/isabelle/Tuples.thy
+++ b/isabelle/Tuples.thy
@@ -1,8 +1,8 @@
 (*  Title:      TLA+/Tuples.thy
     Author:     Stephan Merz, Inria Nancy
-    Copyright (C) 2008-2022 Inria and Microsoft Corporation
+    Copyright (C) 2008-2024 Inria and Microsoft Corporation
     License:    BSD
-    Version:    Isabelle2021-1
+    Version:    Isabelle2024
 *)
 
 section \<open> Tuples and Relations in \tlaplus{} \<close>

--- a/isabelle/Zenon.thy
+++ b/isabelle/Zenon.thy
@@ -1,7 +1,7 @@
 (* Zenon.thy --- Support lemmas for Zenon proofs
  * Author: Damien Doligez <damien.doligez@inria.fr>
- * Copyright (C) 2008-2022  INRIA and Microsoft Corporation
- * Version:    Isabelle2021-1
+ * Copyright (C) 2008-2024  INRIA and Microsoft Corporation
+ * Version:    Isabelle2024
  *)
 
 (* isabelle usedir -b Pure TLA+ *)

--- a/isabelle/dune
+++ b/isabelle/dune
@@ -5,9 +5,9 @@
 (rule
  (alias runtest)
  (deps
-  ; (alias_rec ../deps/isabelle/default) -- We don't use it here, because otherwise the isabelle is always rebuilt.
-  (source_tree "."))
+  (source_tree ".")
+  (sandbox none))
  (action
-  (run make dune-runtest)))
+  (run make -f dune.mk runtest)))
 
 (data_only_dirs document examples tests)

--- a/isabelle/dune.mk
+++ b/isabelle/dune.mk
@@ -4,7 +4,9 @@
 ## find a rule for building $(ISABELLE). It is already built.
 ##
 
-ISABELLE=../deps/isabelle/Isabelle-test/bin/isabelle
+ISABELLE_TEST=../deps/isabelle/Isabelle-test
+ISABELLE=$(ISABELLE_TEST)/bin/isabelle
 
 runtest:
+	chmod -R ug+rw . $(ISABELLE_TEST)/lib/texinputs/ # Fighting the dune sandboxing...
 	$(ISABELLE) build -o document=false -o browser_info=false -c -v -D .

--- a/isabelle/dune.mk
+++ b/isabelle/dune.mk
@@ -1,0 +1,10 @@
+##
+## This Makefile is called from the dune script.
+## We call the Isabelle via make to avoid dune attempts to
+## find a rule for building $(ISABELLE). It is already built.
+##
+
+ISABELLE=../deps/isabelle/Isabelle-test/bin/isabelle
+
+runtest:
+	$(ISABELLE) build -o document=false -o browser_info=false -c -v -D .

--- a/isabelle/examples/Allocator.thy
+++ b/isabelle/examples/Allocator.thy
@@ -8,7 +8,7 @@
 section \<open>A Simple Resource Allocator\<close>
 
 theory Allocator
-imports "../Constant"
+imports Constant
 begin
 
 text \<open>

--- a/isabelle/examples/Allocator.thy
+++ b/isabelle/examples/Allocator.thy
@@ -2,13 +2,13 @@
     Author:     Stephan Merz, Inria Nancy
     Copyright (C) 2009-2022  INRIA and Microsoft Corporation
     License:    BSD
-    Version:    Isabelle2021-1
+    Version:    Isabelle2024
 *)
 
 section \<open>A Simple Resource Allocator\<close>
 
 theory Allocator
-imports Constant
+imports "../Constant"
 begin
 
 text \<open>

--- a/isabelle/examples/AtomicBakeryG.thy
+++ b/isabelle/examples/AtomicBakeryG.thy
@@ -8,7 +8,7 @@
 section \<open>Safety Proof of the Atomic Version of the Bakery Algorithm\<close>
 
 theory AtomicBakeryG
-imports "../Constant"
+imports Constant
 begin
 
 text \<open>

--- a/isabelle/examples/AtomicBakeryG.thy
+++ b/isabelle/examples/AtomicBakeryG.thy
@@ -434,7 +434,7 @@ proof auto
                pc[k] = ''p3'' \<and> num[i] \<le> max[k] \<or>
                (pc[k] = ''p4'' \<or> pc[k] = ''p5'' \<or> pc[k] = ''p6'') \<and>
                GG(i, k, num) \<and> (pc[k] = ''p5'' \<or> pc[k] = ''p6'' \<Rightarrow> i \<in> unread[k])"
-    from iinv i have iinvi: "IInv(i, unread, max, flag, pc, num, nxt)" ..
+    from iinv i have iinvi: "IInv(i, unread, max, flag, pc, num, nxt)" by auto
 
     \<comment> \<open> iinv3 and iinv5: particular parts of the invariant, 
          taken to the meta-level for then being instantiated with the proper variables, 
@@ -447,7 +447,7 @@ proof auto
       fix i j
       assume pci: "pc[i] \<in> {''p5'', ''p6''}" 
         and i: "i \<in> ProcSet" and j:"j \<in> ProcSet \<setminus> unread[i] \<setminus> {i}"
-      from iinv i have iinvi: "IInv(i, unread, max, flag, pc, num, nxt)" ..
+      from iinv i have iinvi: "IInv(i, unread, max, flag, pc, num, nxt)" by auto
       hence "pc[i] \<in> {''p5'', ''p6''} \<Rightarrow>
         (\<forall>j \<in> ProcSet \<setminus> unread[i] \<setminus> {i} :
         After(j, i, unread, max, flag, pc, num, nxt))"
@@ -465,7 +465,7 @@ proof auto
       fix i j
       assume pci: "pc[i] \<in> {''p7'', ''p8''}" 
         and i: "i \<in> ProcSet" and j:"j \<in> ProcSet \\ {i}"
-      from iinv i have iinvi: "IInv(i, unread, max, flag, pc, num, nxt)" ..
+      from iinv i have iinvi: "IInv(i, unread, max, flag, pc, num, nxt)" by auto
       hence "pc[i] \<in> {''p7'', ''p8''} \<Rightarrow>
         (\<forall>j \<in> ProcSet \<setminus> {i} :
         After(j, i, unread, max, flag, pc, num, nxt))"
@@ -568,7 +568,7 @@ proof auto
             fix j
             assume pc': "pc'[i] \<in> {''p5'',''p6''}" and j: "j \<in> (ProcSet \<setminus> unread'[i]) \<setminus> {i}"
             from unch pc' i j iinvi have after: "After(j,i,unread,max,flag,pc,num,nxt)"
-              unfolding IInv_def by auto
+              unfolding IInv_def using After_def by auto
             show "After(j,i,unread',max',flag',pc',num',nxt')"
             proof (cases "self = j")
               case True
@@ -602,7 +602,7 @@ proof auto
             fix j
             assume pc': "pc'[i] \<in> {''p7'',''p8''}" and j: "j \<in> ProcSet \<setminus> {i}"
             from unch pc' i j iinvi have after: "After(j,i,unread,max,flag,pc,num,nxt)"
-              unfolding IInv_def by auto
+              unfolding IInv_def using After_def by auto
             show "After(j,i,unread',max',flag',pc',num',nxt')"
             proof (cases "self = j")
               case True

--- a/isabelle/tests/Tests.thy
+++ b/isabelle/tests/Tests.thy
@@ -59,7 +59,7 @@ lemma \<comment> \<open>Works with abstract types, by auto.\<close>
 text \<open>
 The following only started to work after changing the \<open>Nat\<close> to \<open>Int\<close>
 rewrite from \<open>n \<in> Nat = (n \<in> Int \<and> 0 \<le> n)\<close> to \<open>Nat = {x \<in> Int : 0 \<le> x}\<close>
-see \<open>nat_iff_int_geq0\<close>.
+see \<open>nat_is_int_geq0\<close>.
 \<close>
 lemma
   fixes p :: "c" and f and i

--- a/isabelle/tests/Tests.thy
+++ b/isabelle/tests/Tests.thy
@@ -48,4 +48,24 @@ lemma
   by auto
 
 
+section \<open>Nat vs Functions\<close>
+
+lemma \<comment> \<open>Works with abstract types, by auto.\<close>
+  fixes p :: "c" and f and i
+  assumes "f \<in> [p \<rightarrow> a]" and "i \<in> p"
+  shows "f[i] \<in> a"
+  using assms by auto
+
+text \<open>
+The following only started to work after changing the \<open>Nat\<close> to \<open>Int\<close>
+rewrite from \<open>n \<in> Nat = (n \<in> Int \<and> 0 \<le> n)\<close> to \<open>Nat = {x \<in> Int : 0 \<le> x}\<close>
+see \<open>nat_iff_int_geq0\<close>.
+\<close>
+lemma
+  fixes p :: "c" and f and i
+  assumes "f \<in> [p \<rightarrow> Nat]" and "i \<in> p"
+  shows "f[i] \<in> Nat"
+  using assms by auto
+
+
 end

--- a/test/TOOLS/do_one_test
+++ b/test/TOOLS/do_one_test
@@ -119,7 +119,7 @@ phase == 1 && FILENAME ~ /.*\/separator$/ {
     result = system (check_command);
     if (result != 0){ fail("explicit check failed"); }
   }else if (!command_done){
-    run_command("${TLAPM} --toolbox 0 0 --nofp ${FILE} --stretch ${STRETCH}");
+    run_command("${TLAPM} --toolbox 0 0 --nofp ${FILE} --stretch ${STRETCH} --debug=tempfiles ");
   }
   if (result_code != expected_result){
     fail("wrong result code");

--- a/test/dune
+++ b/test/dune
@@ -4,7 +4,8 @@
   (alias_rec ../deps/all)
   (alias_rec ../src/all)
   (glob_files_rec "*.tla")
-  (source_tree "TOOLS"))
+  (source_tree "TOOLS")
+  (sandbox none))
  (action
   (setenv USE_TLAPM %{exe:../src/tlapm.exe}
   (setenv USE_LIB ../library

--- a/tlapm.opam
+++ b/tlapm.opam
@@ -25,7 +25,7 @@ authors: [
 homepage: "https://github.com/tlaplus/tlapm"
 bug-reports: "https://github.com/tlaplus/tlapm/issues"
 depends: [
-  "dune" {>= "3.12"}
+  "dune" {>= "3.15"}
   "ocaml"
   "dune-site"
   "dune-build-info"


### PR DESCRIPTION
This PR tries to address https://github.com/tlaplus/tlapm/issues/133.

The idea is to rewrite `Nat` as a value instead of its use in expressions like `n ∈ Nat`. So expressions like `[P -> Nat]` are also rewritten. E.g. the following lemma was failing before this change (while the same with `a` instead of `Nat` was passing):
```
lemma
  fixes p :: "c" and f and i
  assumes "f ∈ [p → Nat]" and "i ∈ p"
  shows "f[i] ∈ Nat"
  using assms by auto
```

All the tests are still passing (tests, community modules, examples repo).
The `isabelle/examples/AtomicBakeryG.thy` example still fails, but now the first error is at line `535` instead of `325`.