### PR TITLE
Make SimpleEventually proof a bit less simple.

### DIFF
--- a/examples/SimpleEventually.tla
+++ b/examples/SimpleEventually.tla
@@ -42,17 +42,11 @@ LEMMA TypeCorrect == System => []TypeOK
 
 -------------------------------------------------------------------------------
 
-\* The PM needs this hint for the liveness proof to be accepted.
-LEMMA Equiv == ~(x = TRUE) <=> (x = FALSE) OBVIOUS
-USE Equiv
-
--------------------------------------------------------------------------------
-
 (* Proof of liveness property. *)
 THEOREM System => Prop
-<1>1. SUFFICES (System /\ [](x = FALSE)) => FALSE 
+<1>1. SUFFICES (System /\ []~(x = TRUE)) => FALSE 
     BY <1>1, PTL DEF Prop
-<1>3. ASSUME TypeOK /\ (x = FALSE)
+<1>3. ASSUME TypeOK /\ ~(x = TRUE)
       PROVE ENABLED <<A>>_vars
     BY <1>3, ExpandENABLED DEF Next, vars, A, B
 <1>4. ASSUME <<A>>_vars

--- a/examples/SimpleEventually.tla
+++ b/examples/SimpleEventually.tla
@@ -3,33 +3,62 @@
 EXTENDS TLAPS
 
 
-VARIABLE x
+VARIABLE x, y
+vars == <<x, y>>
 
+TypeOK ==
+    /\ x \in BOOLEAN
+    /\ y \in BOOLEAN
 
-Init == x = FALSE
-Next == x = FALSE /\ x' = TRUE
-System == Init /\ [][Next]_x /\ WF_x(Next)
+Init ==
+    /\ x = FALSE
+    /\ y = FALSE
 
+A ==
+    /\ x = FALSE
+    /\ x' = TRUE
+    /\ UNCHANGED y
 
-THEOREM System => <>(x = TRUE)
-<1>1. SUFFICES (System /\ []~(x = TRUE)) => FALSE
-    BY <1>1, PTL
-<1> DEFINE TypeOK == x \in BOOLEAN
-<1> HIDE DEF TypeOK
-<1>2. (Init /\ [][Next]_x) => []TypeOK
-    <2>1. Init => TypeOK
-        BY DEF Init, TypeOK
-    <2>2. ASSUME TypeOK /\ [Next]_x
-          PROVE TypeOK'
-        BY <2>2 DEF TypeOK, Next
-    <2> QED
-        BY <2>1, <2>2, PTL
-<1>3. ASSUME TypeOK /\ ~(x = TRUE)
-      PROVE ENABLED <<Next>>_x
-    BY <1>3, ExpandENABLED DEF Next
-<1>4. ASSUME <<Next>>_x
+B ==
+    /\ y = FALSE
+    /\ y' = TRUE
+    /\ UNCHANGED x
+
+Next ==
+    A \/ B
+
+System ==
+    Init /\ [][Next]_vars /\ WF_vars(Next)
+
+Prop ==
+    <>(x = TRUE)
+
+-------------------------------------------------------------------------------
+(* Ordinary safety proof. *)
+LEMMA TypeCorrect == System => []TypeOK
+<1>1. Init => TypeOK BY DEF Init, TypeOK
+<1>2. TypeOK /\ [Next]_vars => TypeOK' BY DEF TypeOK, Next, vars, A, B
+<1>. QED BY <1>1, <1>2, PTL DEF System, TypeOK, Init, Next, A, B
+
+-------------------------------------------------------------------------------
+
+\* The PM needs this hint for the liveness proof to be accepted.
+LEMMA Equiv == ~(x = TRUE) <=> (x = FALSE) OBVIOUS
+USE Equiv
+
+-------------------------------------------------------------------------------
+
+(* Proof of liveness property. *)
+THEOREM System => Prop
+<1>1. SUFFICES (System /\ [](x = FALSE)) => FALSE 
+    BY <1>1, PTL DEF Prop
+<1>3. ASSUME TypeOK /\ (x = FALSE)
+      PROVE ENABLED <<A>>_vars
+    BY <1>3, ExpandENABLED DEF Next, vars, A, B
+<1>4. ASSUME <<A>>_vars
       PROVE (x = TRUE)'
-    BY <1>4 DEF Next
+    BY <1>4 DEF Next, vars, A, B
 <1> QED
-    BY <1>2, <1>3, <1>4, PTL DEF System, Init
+    BY TypeCorrect, <1>3, <1>4, PTL DEF System, Init, Prop
+
 ================================================================================

--- a/examples/SimpleEventually.tla
+++ b/examples/SimpleEventually.tla
@@ -20,7 +20,7 @@ A ==
     /\ UNCHANGED y
 
 B ==
-    /\ y = FALSE
+\*    /\ y = FALSE \* WF_vars(Next) suffices hinges on the fact that a B step disables B (s.t. it leaves the vars unchanged). 
     /\ y' = TRUE
     /\ UNCHANGED x
 

--- a/examples/SimpleEventually.tla
+++ b/examples/SimpleEventually.tla
@@ -28,7 +28,7 @@ Next ==
     A \/ B
 
 System ==
-    Init /\ [][Next]_vars /\ WF_vars(A)
+    Init /\ [][Next]_vars /\ WF_vars(Next)
 
 Prop ==
     <>(x = TRUE)
@@ -42,17 +42,23 @@ LEMMA TypeCorrect == System => []TypeOK
 
 -------------------------------------------------------------------------------
 
-(* Proof of liveness property. *)
+(* 
+    Proof of liveness property. Informally:
+    <1>1 proves that x can become true because Next is enabled.
+    <1>2 proves that x becomes true by taking a Next step if y is already true.
+    <1>3 proves that y will become true eventually.
+    <1>4 proves that action B will be disable. Thus, []<>ENABLED <<Next>>_vars... effectively becomes []<>ENABLED <<A>>_vars...
+*)
 THEOREM System => Prop
-<1>1. SUFFICES (System /\ []~(x = TRUE)) => FALSE 
-    BY <1>1, PTL DEF Prop
-<1>3. ASSUME TypeOK /\ ~(x = TRUE)
-      PROVE ENABLED <<A>>_vars
-    BY <1>3, ExpandENABLED DEF Next, vars, A, B
-<1>4. ASSUME <<A>>_vars
-      PROVE (x = TRUE)'
-    BY <1>4 DEF Next, vars, A, B
+<1>1. TypeOK /\ ~(x = TRUE) => ENABLED <<Next>>_vars
+  BY ExpandENABLED DEF TypeOK, Next, A, B, vars
+<1>2. TypeOK /\ ~(x = TRUE) /\ (y = TRUE) /\ <<Next>>_vars => (x = TRUE)'
+  BY DEF TypeOK, Next, A, B, vars
+<1>3. TypeOK /\ ~(x = TRUE) /\ ~(y = TRUE) /\ ~(x = TRUE)' /\ <<Next>>_vars => (y = TRUE)'
+  BY DEF TypeOK, Next, A, B, vars
+<1>4. TypeOK /\ (y = TRUE) /\ [Next]_vars => (y = TRUE)' \* Could replace [Next]_vars with UNCHANGED vars.
+  BY DEF TypeOK, Next, A, B, vars
 <1> QED
-    BY TypeCorrect, <1>3, <1>4, PTL DEF System, Init, Prop
+  BY TypeCorrect, <1>1, <1>2, <1>3, <1>4, PTL DEF System, Prop
 
 ================================================================================

--- a/examples/SimpleEventually.tla
+++ b/examples/SimpleEventually.tla
@@ -28,7 +28,7 @@ Next ==
     A \/ B
 
 System ==
-    Init /\ [][Next]_vars /\ WF_vars(Next)
+    Init /\ [][Next]_vars /\ WF_vars(A)
 
 Prop ==
     <>(x = TRUE)


### PR DESCRIPTION
Two actions, `A` and `B`, allow for the discussion of the non-distributiveness of (weak) fairness.

Happy to remove `Equiv` again.