### PR TITLE
Emit bytecode in dune build for debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "TLAPM Debug",
+            "type": "ocaml.earlybird",
+            "request": "launch",
+            "program": "${workspaceFolder}/src/tlapm.bc",
+            "stopOnEntry": true,
+            "env": {
+                "CAML_LD_LIBRARY_PATH": "${workspaceFolder}/_build/default/src:${env:CAML_LD_LIBRARY_PATH}"
+            }
+        }
+    ]
+}

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ opam-deps:
 	opam install ./ --deps-only --yes --working-dir
 
 opam-deps-dev:
-	opam install ocamlformat ocaml-lsp-server
+	opam install ocamlformat ocaml-lsp-server earlybird
 
 build:
 	dune build

--- a/src/dune
+++ b/src/dune
@@ -4,6 +4,7 @@
 
 (executable
   (name tlapm)
+  (modes byte exe)
   (public_name tlapm)
   (modules tlapm)
   (libraries tlapm_lib)
@@ -26,4 +27,3 @@
  (sites tlapm))
 
 (include_subdirs unqualified)
-


### PR DESCRIPTION
This will generate a `tlapm.bc` OCaml bytecode file in `_build/default/src` which can be loaded by `ocamldebug`. Dune 2.0+ requires this to be explicitly specified ([docs](https://dune.readthedocs.io/en/stable/reference/dune/executable.html)):

>Given an executable stanza with (name \<name\>), Dune will know how to build \<name\>.exe. If requested, it will also know how to build \<name\>.bc and \<name\>.bc.js (Dune 2.0 and up also need specific configuration (see the modes optional field below)).

`ocamldebug` also requires everything to be built with the `-g` flag, which is the case by default with Dune; see output of `dune printenv .`.

Ref https://github.com/tlaplus/tlapm/discussions/143

I also added a debug launch profile for VS Code, and added the [earlybird](https://github.com/hackwaly/ocamlearlybird) DAP server to the `opam-deps-dev` make target.