### PR TITLE
Add license field to opam package definition file

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -10,6 +10,8 @@
 
 (source (github tlaplus/tlapm))
 
+(license BSD-2-Clause)
+
 (package
  (name tlapm)
  (synopsis "TLA+ Proof Manager")

--- a/tlapm.opam
+++ b/tlapm.opam
@@ -22,6 +22,7 @@ authors: [
   "Jean-Baptiste Tristan"
   "Hernan Vanzetto"
 ]
+license: "BSD-2-Clause"
 homepage: "https://github.com/tlaplus/tlapm"
 bug-reports: "https://github.com/tlaplus/tlapm/issues"
 depends: [


### PR DESCRIPTION
Without this field, newer versions of `opam` will print out the following warning when running `make opam-deps`:
>[WARNING] Failed checks on tlapm package definition from source at
          git+file:///mnt/data/ahelwer/src/tlaplus/proofs#main:
  warning 68: Missing field 'license'

This tiny change fixes that warning by adding the [SPDX short form](https://spdx.org/licenses/BSD-2-Clause.html) of the repo's license to the `tlapm.opam` file.