### PR TITLE
Exposed parse method in TLAPM API

### DIFF
--- a/lsp/lib/parser/parser.ml
+++ b/lsp/lib/parser/parser.ml
@@ -1,3 +1,3 @@
 let module_of_string ~content ~filename ~loader_paths =
-  Tlapm_lib.module_of_string ~content ~filename ~loader_paths
+  Tlapm_lib.transitive_parse_module_of_string ~content ~filename ~loader_paths
     ~prefer_stdlib:true

--- a/src/tlapm_lib.ml
+++ b/src/tlapm_lib.ml
@@ -615,7 +615,7 @@ let init () =
        exit 3
 
 (* Access to this function has to be synchronized. *)
-let module_of_string ~(content : string) ~(filename : string) ~loader_paths ~prefer_stdlib : (Module.T.mule, (string option* string)) result =
+let transitive_parse_module_of_string ~(content : string) ~(filename : string) ~loader_paths ~prefer_stdlib : (Module.T.mule, (string option* string)) result =
     let parse_it () =
         Errors.reset ();
         Params.prefer_stdlib := prefer_stdlib;
@@ -651,3 +651,8 @@ let module_of_string ~(content : string) ~(filename : string) ~loader_paths ~pre
          | None, None -> Error (None, Printexc.to_string e))
 
 let stdlib_search_paths = Params.stdlib_search_paths
+
+let parse_module_of_string module_str =
+    let hparse = Tla_parser.P.use M_parser.parse in
+    let (flex, _) = Alexer.lex_string module_str in
+    Tla_parser.P.run hparse ~init:Tla_parser.init ~source:flex

--- a/src/tlapm_lib.ml
+++ b/src/tlapm_lib.ml
@@ -656,8 +656,3 @@ let module_of_string module_str =
     Tla_parser.P.run hparse ~init:Tla_parser.init ~source:flex
 
 let stdlib_search_paths = Params.stdlib_search_paths
-
-let parse_module_of_string module_str =
-    let hparse = Tla_parser.P.use M_parser.parse in
-    let (flex, _) = Alexer.lex_string module_str in
-    Tla_parser.P.run hparse ~init:Tla_parser.init ~source:flex

--- a/src/tlapm_lib.mli
+++ b/src/tlapm_lib.mli
@@ -14,13 +14,16 @@ module Backend = Backend
 val main : string list -> unit
 val init : unit -> unit
 
-val module_of_string :
+val transitive_parse_module_of_string :
   content:string ->
   filename:string ->
   loader_paths:string list ->
   prefer_stdlib:bool ->
   (Module.T.mule, string option * string) result
 (** Parse module from a specified string, assume it is located in the specified path. *)
+
+val parse_module_of_string: string -> M_t.mule option
+(** Parse module from given string without pulling in dependencies. *)
 
 val stdlib_search_paths : string list
 (** A list of paths to look for stdlib modules. *)

--- a/src/tlapm_lib.mli
+++ b/src/tlapm_lib.mli
@@ -28,8 +28,5 @@ val module_of_string : string -> M_t.mule option
 (** Parse the specified string as a module. No dependencies
     are considered, nor proof obligations are elaborated. *)
 
-val parse_module_of_string: string -> M_t.mule option
-(** Parse module from given string without pulling in dependencies. *)
-
 val stdlib_search_paths : string list
 (** A list of paths to look for stdlib modules. *)


### PR DESCRIPTION
This adds a simple string -> parse tree method in TLAPM's public API, so it can be hit by non-inline unit tests.