### PR TITLE
change magic number for fingerprint files

### DIFF
--- a/src/backend/fpfile.ml
+++ b/src/backend/fpfile.ml
@@ -153,8 +153,8 @@ open V13
 
 let fptbl = ref (Hashtbl.create 500 : V13.tbl)
 
-let old_magic_number = 20101013
-let magic_number = 20210223
+let old_magic_numbers = [20101013; 20210223]
+let magic_number = 20241112
 
 let write_fp_table oc =
   output_value oc magic_number;
@@ -568,7 +568,7 @@ let load_fingerprints_aux file =
   if Sys.file_exists file then begin
     let ic = open_in_bin file in
     let magic = Marshal.from_channel ic in
-    if magic = old_magic_number then
+    if List.mem magic old_magic_numbers then
         raise(FpFileOlderMagicNumber);
     if magic <> magic_number then raise(FpFileCorrupted);
     let v = Marshal.from_channel ic in

--- a/src/backend/fpfile.ml
+++ b/src/backend/fpfile.ml
@@ -126,7 +126,7 @@ module V13 = struct
   (* The key is the MD5 converted to hex. *)
 
   (* File format:
-     - magic number as a marshalled integer = 20101013
+     - magic number as a marshalled integer = 20241112
      - Fpver13 of tbl
      - any number of (Digest.t, sti list) pairs
   *)


### PR DESCRIPTION
Change the magic number for fingerprint files, because the file format has changed.