### PR TITLE
CI: Use macos-latest instead of versions 13 & 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,7 @@ jobs:
           matrix:
             os:
               - ubuntu-latest
-              - macos-13
-              - macos-14
+              - macos-latest
             ocaml-compiler:
               - '4.14.1'
               - '5.1.0'


### PR DESCRIPTION
@kape1395 is there a reason we run the CI on both macOS 13 and 14? Version 13 machines are very slow, taking about twice as long to complete as the rest. This PR just changes it to use macos-latest.