### PR TITLE
Upload rolling pre-releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
               run: |
                 sudo apt-get update
                 sudo apt-get install --yes time
-            - uses: ocaml/setup-ocaml@v2
+            - uses: ocaml/setup-ocaml@v3
               with:
                 ocaml-compiler: ${{ matrix.ocaml-compiler }}
             - uses: actions/cache@v4
@@ -53,7 +53,7 @@ jobs:
                 # Workaround for https://github.com/tlaplus/tlapm/issues/88
                 set +e
                 for ((attempt = 1; attempt <= 5; attempt++)); do
-                  rm -rf _build
+                  make clean
                   make
                   if [ $? -eq 0 ]; then
                     make release
@@ -81,10 +81,10 @@ jobs:
             - name: Check proofs in TLA+ examples
               run: |
                 mkdir -p "$DEPS_DIR"
-                cp ./_build/tlaps*.tar.gz "$DEPS_DIR/tlaps.tar.gz"
-                tar -xzf "$DEPS_DIR/tlaps.tar.gz" -C "$DEPS_DIR"
-                rm "$DEPS_DIR/tlaps.tar.gz"
-                mv $DEPS_DIR/tlaps* "$DEPS_DIR/tlapm-install"
+                cp ./_build/tlapm*.tar.gz "$DEPS_DIR/tlapm.tar.gz"
+                tar -xzf "$DEPS_DIR/tlapm.tar.gz" -C "$DEPS_DIR"
+                rm "$DEPS_DIR/tlapm.tar.gz"
+                mv $DEPS_DIR/tlapm* "$DEPS_DIR/tlapm-install"
                 SKIP=(
                   # General proof failure
                   "specifications/Bakery-Boulangerie/Bakery.tla"

--- a/.github/workflows/rolling-prerelease.yml
+++ b/.github/workflows/rolling-prerelease.yml
@@ -1,0 +1,70 @@
+name: Rolling Pre-release
+on:
+  push:
+    branches: [main]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+env:
+  DUNE_BUILD_DIR: "_build"
+  OCAML_VERSION: "5.1.0"
+jobs:
+  publish:
+    environment: release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+    - name: Clone repo
+      uses: actions/checkout@v4
+    - name: Install deps on Ubuntu
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo apt-get install --yes time
+    - uses: ocaml/setup-ocaml@v3
+      with:
+        ocaml-compiler: ${{ env.OCAML_VERSION }}
+    - uses: actions/cache@v4
+      id: cache
+      with:
+        path: _build_cache
+        key: ${{ runner.os }}_build_cache
+    - name: Build TLAPM
+      run: |
+        eval $(opam env)
+        make opam-deps
+        make opam-deps-opt
+        # Workaround for https://github.com/tlaplus/tlapm/issues/88
+        set +e
+        for ((attempt = 1; attempt <= 5; attempt++)); do
+          make clean
+          make
+          if [ $? -eq 0 ]; then
+            make release RELEASE_VERSION=${{ vars.ROLLING_PRERELEASE_VERSION }}
+            exit $?
+          fi
+        done
+        exit 1
+    - name: "Upload release"
+      run: |
+        kernel=$(uname -s)
+        if [ "$kernel" == "Linux" ]; then
+          OS_TYPE=linux-gnu
+        elif [ "$kernel" == "Darwin" ]; then
+          OS_TYPE=darwin
+        else
+          echo "Unknown OS: $kernel"
+          exit 1
+        fi
+        HOST_CPU=$(uname -m)
+        TLAPM_ZIP=tlapm-${{ vars.ROLLING_PRERELEASE_VERSION }}-$HOST_CPU-$OS_TYPE.tar.gz
+        echo $TLAPM_ZIP
+        ls -lh ${{ env.DUNE_BUILD_DIR }}
+        cat ${{ env.DUNE_BUILD_DIR }}/tlapm-release-version
+        ## Adapted from https://github.com/tlaplus/tlaplus repository
+        ## Crawl release id
+        DRAFT_RELEASE=$(curl -sS -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/releases --header "Content-Type: application/json" | jq '.[]| select(.name=="${{ vars.ROLLING_PRERELEASE_GITHUB_NAME }}") | .id')
+        ## Delete old assets and upload replacement assets (if delete fails we still try to upload the new asset)
+        ID=$(curl -sS -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/releases/$DRAFT_RELEASE/assets --header "Content-Type: application/json"  | jq '.[]| select(.name == "$TLAPM_ZIP") | .id')
+        curl -sS -X DELETE -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/releases/assets/$ID
+        curl -s -X POST -H "Content-Type: application/zip" -H "Authorization: token ${{secrets.GITHUB_TOKEN}}" https://uploads.github.com/repos/${{ github.repository }}/releases/$DRAFT_RELEASE/assets?name=$TLAPM_ZIP --upload-file ${{ env.DUNE_BUILD_DIR }}/$TLAPM_ZIP

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -7,10 +7,8 @@ It uses the [Dune](https://dune.build/) build system for OCaml, with [Make](http
 
 Release Channels
 ----------------
-You can find official versioned releases on the [GitHub Releases page](https://github.com/tlaplus/tlapm/releases).
-
-Official releases lag the current development frontier by quite some time; thus, you might prefer to clone & build TLAPM yourself, as described below.
-Plans exist to make rolling pre-releases available in the near future.
+Past versioned releases can be downloaded from the [GitHub Releases page](https://github.com/tlaplus/tlapm/releases).
+For the latest development version, download the builds attached to the [1.6.0 rolling pre-release](https://github.com/tlapm/tlapm/releases/tag/1.6.0-pre) or follow the instructions below to build TLAPM from source.
 
 Dependencies
 ------------

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ For information on TLA⁺ generally, see http://tlapl.us.
 
 Installation & Use
 ------------------
-Versioned releases can be downloaded from the [GitHub Releases page](https://github.com/tlaplus/tlapm/releases).
-If you instead prefer to use the latest development version, follow the instructions in [`DEVELOPING.md`](DEVELOPING.md) to build & install TLAPM.
+Past versioned releases can be downloaded from the [GitHub Releases page](https://github.com/tlaplus/tlapm/releases).
+For the latest development version, download the builds attached to the [1.6.0 rolling pre-release](https://github.com/tlapm/tlapm/releases/tag/1.6.0-pre) or follow the instructions in [`DEVELOPING.md`](DEVELOPING.md) to build TLAPM from source.
 
 Once TLAPM is installed, run `tlapm --help` to see documentation of the various command-line parameters.
 Check the proofs in a simple example spec in this repo by running:


### PR DESCRIPTION
Finally got around to this. This sets up rolling pre-release publishing similar to what exists for the TLA+ tools, where the head of the main branch is built and uploaded to a github release for ease of consumption.

This work requires some changes to the repository settings:
1. Create a `release` environment and constrain it to only be accessible from the `main` branch
2. Create a new pre-release titled (for example) `Version 1.6.0 rolling pre-release` or similar
3. Create a fine-grained personal access token with read/write access to releases in the tlaplus/tlapm repo
4. Store the access token in the `release` environment secrets as `TLAPM_RELEASES_AT`
5. Define the `ROLLING_PRERELEASE_VERSION` environment variable in the `release` environment to be `1.6.0-pre` or similar
6. Define the `ROLLING_PRERELEASE_GITHUB_NAME` environment variable in the `release` environment to be whatever you called the release in step (2)

If you give me more permissions on this repo I'll do all of that or whoever is reviewing this can do it themselves. I've tested this on my own fork of the TLAPM repo; you can see what the release with uploaded artifacts looks like here: https://github.com/ahelwer/tlapm/releases/tag/1.6.0-pre

This is a good first step to get this working and then later we can add the following features:
1. Update the tag associated with the release to track the head of the main branch
2. Do macOS code signing (ref #46)
3. Upload the releases to the Inria server as well

Ref #92