### PR TITLE
Fix instantiation of a module containing USE.

### DIFF
--- a/src/module/m_visit.ml
+++ b/src/module/m_visit.ml
@@ -165,6 +165,7 @@ class map =
     method mutate cx change usable =
         let mu = Mutate (
             change, usable) in
+        let cx = update_cx cx mu in
         (cx, mu)
 
     method submod cx tla_module =

--- a/test/bugs/instance_mutate.tla
+++ b/test/bugs/instance_mutate.tla
@@ -1,0 +1,5 @@
+---- MODULE instance_mutate ----
+Op(x) == TRUE
+USE TRUE
+OpAll == \A x : Op(x)
+====

--- a/test/bugs/instance_mutate_test.tla
+++ b/test/bugs/instance_mutate_test.tla
@@ -1,0 +1,7 @@
+---- MODULE instance_mutate_test ----
+(*
+Instantiation was failing on use of an operator if there was
+a Mutation (USE) involved in the instantiated module.
+*)
+INSTANCE instance_mutate
+====


### PR DESCRIPTION
It was failing before with `tlapm ending abnormally with Failure("unknown bound variable")`.

This fixes a case mentioned in https://github.com/tlaplus/tlapm/issues/151#issuecomment-2365142957