### PR TITLE
Memoize level computation to avoid exponential behavior

### DIFF
--- a/src/expr.mli
+++ b/src/expr.mli
@@ -875,8 +875,6 @@ module Levels: sig
     val kind_to_level:
         kind -> int
 
-    class virtual ['s] level_computation:
-        ['s] Visit.map
     class virtual ['s] _rm_expr_level:
         ['s] Visit.map
 
@@ -884,6 +882,9 @@ module Levels: sig
         ctx -> expr -> expr
     val rm_expr_level:
         ctx -> expr -> expr
+
+    val newcache:
+        expr -> expr
 end
 
 

--- a/src/expr/e_anon.ml
+++ b/src/expr/e_anon.ml
@@ -304,7 +304,8 @@ end
 
 class anon = object (self : 'self)
   inherit anon_sg as super
-  method expr scx e = Elab.desugar self#expr super#expr scx e
+  method expr scx e =
+    E_levels.newcache (Elab.desugar self#expr super#expr scx e)
 end
 
 

--- a/src/expr/e_levels.mli
+++ b/src/expr/e_levels.mli
@@ -22,8 +22,9 @@ val assert_has_correct_level: expr -> unit
 val kind_to_level: kind -> int
 
 
-class virtual ['s] level_computation : ['s] E_visit.map
 class virtual ['s] _rm_expr_level : ['s] E_visit.map_visible_hyp
 
 val compute_level: ctx -> expr -> expr
 val rm_expr_level: ctx -> expr -> expr
+
+val newcache: expr -> expr

--- a/src/expr/e_tla_norm.ml
+++ b/src/expr/e_tla_norm.ml
@@ -10,6 +10,8 @@ open Property
 open E_t
 module B = Builtin
 
+let ( @@ ) core e = E_levels.newcache (core @@ e)
+
 let rec tuple_flatten e = match e.core with
   | Tuple es ->
       List.concat (List.map tuple_flatten es)

--- a/src/util/deque.ml
+++ b/src/util/deque.ml
@@ -206,3 +206,20 @@ let alter ?(backwards=false) q n alt_fn =
         end
   in
   spin 0 q
+
+(* Compare deques `q1` and `q2`, using `cmp` to compare their elements. *)
+let equal cmp q1 q2 =
+  let rec diff l1 l2 =
+    match l1, l2 with
+    | x1 :: ll1, x2 :: ll2 when cmp x1 x2 -> diff ll1 ll2
+    | [], _ -> Some l2
+    | _, [] -> Some l1
+    | _ -> None
+  in
+  q1.flen + q1.rlen = q2.flen + q2.rlen && begin
+    let f = diff q1.front q2.front in
+    let r = diff q1.rear q2.rear in
+    match f, r with
+    | Some lf, Some lr -> List.for_all2 cmp lf (List.rev lr)
+    | _, _ -> false
+  end

--- a/src/util/deque.mli
+++ b/src/util/deque.mli
@@ -33,3 +33,5 @@ val prepend_list : 'a list -> 'a dq -> 'a dq
 
 val of_list : 'a list -> 'a dq
 val to_list : 'a dq -> 'a list
+
+val equal : ('a -> 'a -> bool) -> 'a dq -> 'a dq -> bool


### PR DESCRIPTION
Follow-up to https://github.com/tlaplus/tlapm/pull/148#issuecomment-2595420647
Should make #186 unnecessary.

cc @kape1395 