### PR TITLE
Fixed SMT soundness bug involving tuples and EXCEPT

### DIFF
--- a/src/encode/n_axioms.ml
+++ b/src/encode/n_axioms.ml
@@ -2814,10 +2814,10 @@ let tupexcept_def ~disable_arithmetic n i =
       (ixi ~shift:1 n) %% []
     ; begin
       if disable_arithmetic then
-        apps (T.IntLit (i + 1)) [] %% []
+        apps (T.IntLit i) [] %% []
       else
         apps (T.Cast t_int)
-        [ apps (T.TIntLit (i + 1)) [] %% []
+        [ apps (T.TIntLit i) [] %% []
         ] %% []
       end
     ; Ix 1 %% []
@@ -2829,10 +2829,10 @@ let tupexcept_def ~disable_arithmetic n i =
         (ixi ~shift:1 n) %% []
       ; begin
         if disable_arithmetic then
-          apps (T.IntLit (i + 1)) [] %% []
+          apps (T.IntLit i) [] %% []
         else
           apps (T.Cast t_int)
-          [ apps (T.TIntLit (i + 1)) [] %% []
+          [ apps (T.TIntLit i) [] %% []
           ] %% []
         end
       ; Ix 1 %% []


### PR DESCRIPTION
The bug originated from axiom "TupExcept" which specifies the replacement of a element in a tuple using EXCEPT.  For instance, the axiom could be used to generate the equality `[ <<a, b, c>> EXCEPT ![2] = d ] = <<a, d, c>>`.

The index of the element to change was not set correctly.  Also, the axiom is only put in the result if both a tuple and the EXCEPT operator appear in the obligation, making this bug harder to detect.

This closes #201 