### PR TITLE
Encode TLAPM build dependencies in shell.nix file

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,39 @@
+let pkgs = import <nixpkgs> {};
+in pkgs.mkShell {
+  packages = with pkgs; [
+    # Fundamental dependencies
+    bash
+    ocaml                       # OCaml compiler & interpreter
+    dune_3                      # OCaml build system
+    gnumake                     # Called by Dune to build non-OCaml code
+    ocamlPackages.findlib       # OCaml library manager
+
+    # CLI tools necessary to build & test project
+    gawk
+    gnupatch
+    time
+    zlib
+
+    # OCaml packages necessary to build & test project
+    ocamlPackages.camlzip         # Library for handling zip & gzip files
+    ocamlPackages.cmdliner        # Enables declarative CLI definitions
+    ocamlPackages.eio_main        # Parallel IO library
+    ocamlPackages.dune-build-info # Embed build information inside executables
+    ocamlPackages.dune-site       # Embed location information inside executables
+    ocamlPackages.lsp             # LSP protocol library for building LSP servers
+    ocamlPackages.odoc            # Documentation generator
+    ocamlPackages.ounit2          # Unit testing framework for OCaml
+    ocamlPackages.ppx_assert      # Macro library for assertions with useful errors
+    ocamlPackages.ppx_deriving    # Macro library for auto-displaying datatypes
+    ocamlPackages.ppx_inline_test # Macro library for writing in-line tests
+    ocamlPackages.re2             # Regular expression library
+    ocamlPackages.sexplib         # Library for building & parsing S-expression
+
+    # Optional packages to assist OCaml development
+    ocamlPackages.earlybird       # DAP server for OCaml debugging
+    ocamlPackages.ocaml-lsp       # LSP server for OCaml coding
+    ocamlPackages.ocamlformat     # OCaml code formatter
+    ocamlPackages.utop            # Nice OCaml REPL
+  ];
+}
+


### PR DESCRIPTION
Got about as far as my nix knowledge allows (which is not too far!) in building tlapm from NixOS. @calvin-l have any idea how to make progress beyond this? When running `nix-shell shell.nix` and then `make`, it gets pretty far then:
```
make[2]: Leaving directory '/mnt/data/ahelwer/src/tlaplus/proofs/_build/default/deps/isabelle/Isabelle/src/TLA+'
cd Isabelle/ \
        && ./bin/isabelle build -o system_heaps -o document=false -b -v -d src/Pure Pure \
        && ./bin/isabelle build -o system_heaps -o document=false -b -c -v -d src/TLA+ TLA+ \
        && rm -rf ./heaps/polyml-*/log/*
make[1]: Leaving directory '/mnt/data/ahelwer/src/tlaplus/proofs/_build/default/deps/isabelle'
Could not start dynamically linked executable: /mnt/data/ahelwer/src/tlaplus/proofs/_build/default/deps/isabelle/Isabelle/contrib/jdk-21.0.3/x86_64-linux/bin/java
NixOS cannot run dynamically linked executables intended for generic
linux environments out of the box. For more information, see:
https://nix.dev/permalink/stub-ld
make[1]: *** [dune.mk:84: Isabelle/src/TLA+] Error 127
make: *** [Makefile:34: build] Error 1 
```
So it seems like it's invoking a general-release build of Java for the Isabelle build process.