### PR TITLE
Isabelle2025

### DIFF
--- a/deps/isabelle/dune.mk
+++ b/deps/isabelle/dune.mk
@@ -4,17 +4,17 @@
 OS_TYPE=$(patsubst CYGWIN%,Cygwin,$(shell uname))
 HOST_CPU=$(shell uname -m)
 
-ISABELLE_VSN=Isabelle2024
+ISABELLE_VSN=Isabelle2025
 
 ifeq ($(OS_TYPE),Linux)
-	ISABELLE_SHA256=603aaaf8abea36597af3b0651d2c162a86c0a0dd4420766f47e5724039639267
+	ISABELLE_SHA256=3d1d66de371823fe31aa8ae66638f73575bac244f00b31aee1dcb62f38147c56
 	ISABELLE_ARCHIVE=$(ISABELLE_VSN)_linux.tar.gz
 	ISABELLE_ARCHIVE_TYPE=tgz
 	ISABELLE_ARCHIVE_DIR=$(ISABELLE_VSN)
 	FIND_EXEC=-executable
 endif
 ifeq ($(OS_TYPE),Darwin)
-	ISABELLE_SHA256=22035f996f71ea1f03063f6f144195eb6a04974d4d916ed0772cd79569a28bc7
+	ISABELLE_SHA256=ea5754c228857f5d9d3ae254ec9814797f2453ea290df20b2f6dcb2ef0e2e7f8
 	ISABELLE_ARCHIVE=$(ISABELLE_VSN)_macos.tar.gz
 	ISABELLE_ARCHIVE_TYPE=tgz
 	ISABELLE_ARCHIVE_DIR=$(ISABELLE_VSN).app
@@ -64,12 +64,12 @@ ifeq ($(ISABELLE_ARCHIVE_TYPE),tgz)
 	tar -xzf $<
 	mv $(ISABELLE_ARCHIVE_DIR) $(ISABELLE_DIR)
 endif
-	cd $(ISABELLE_DIR) && rm -rf ./contrib/e-3.0.03-1/src/lib/
+	cd $(ISABELLE_DIR) && rm -rf ./contrib/e-3.1-1/src/lib/
 ifeq ($(OS_TYPE),Darwin)
-	cd $(ISABELLE_DIR) && cd contrib/jdk-21.0.3/arm64-darwin/ \
+	cd $(ISABELLE_DIR) && cd contrib/jdk-21.0.6/arm64-darwin/ \
 		&& (find . -type link | xargs rm) \
 		&& mv zulu-21.jdk/Contents/Home/* ./
-	cd $(ISABELLE_DIR) && cd contrib/jdk-21.0.3/x86_64-darwin/ \
+	cd $(ISABELLE_DIR) && cd contrib/jdk-21.0.6/x86_64-darwin/ \
 		&& (find . -type link | xargs rm) \
 		&& mv zulu-21.jdk/Contents/Home/* ./
 endif

--- a/isabelle/Constant.thy
+++ b/isabelle/Constant.thy
@@ -1,8 +1,8 @@
 (*  Title:      TLA+/Constant.thy
     Author:     Stephan Merz, LORIA
-    Copyright (C) 2008-2024  INRIA and Microsoft Corporation
+    Copyright (C) 2008-2025  INRIA and Microsoft Corporation
     License:    BSD
-    Version:    Isabelle2024
+    Version:    Isabelle2025
 *)
 
 section \<open> Main theory for constant-level Isabelle/\tlaplus{} \<close>

--- a/isabelle/FixedPoints.thy
+++ b/isabelle/FixedPoints.thy
@@ -1,8 +1,8 @@
 (*  Title:      TLA+/FixedPoints.thy
     Author:     Stephan Merz, Inria Nancy
-    Copyright (C) 2008-2024  INRIA and Microsoft Corporation
+    Copyright (C) 2008-2025  INRIA and Microsoft Corporation
     License:    BSD
-    Version:    Isabelle2024
+    Version:    Isabelle2025
 *)
 
 section \<open>Fixed points for set-theoretical constructions\<close>

--- a/isabelle/Functions.thy
+++ b/isabelle/Functions.thy
@@ -1,8 +1,8 @@
 (*  Title:      TLA+/Functions.thy
     Author:     Stephan Merz, Inria Nancy
-    Copyright (C) 2008-2024  INRIA and Microsoft Corporation
+    Copyright (C) 2008-2025  INRIA and Microsoft Corporation
     License:    BSD
-    Version:    Isabelle2024
+    Version:    Isabelle2025
 *)
 
 section \<open> \tlaplus{} Functions \<close>

--- a/isabelle/IntegerArithmetic.thy
+++ b/isabelle/IntegerArithmetic.thy
@@ -1,8 +1,8 @@
 (*  Title:      TLA+/IntegerArithmetic.thy
     Author:     Stephan Merz, Inria Nancy
-    Copyright (C) 2009-2024  INRIA and Microsoft Corporation
+    Copyright (C) 2009-2025  INRIA and Microsoft Corporation
     License:    BSD
-    Version:    Isabelle2024
+    Version:    Isabelle2025
 *)
 
 section \<open> Arithmetic (except division) for the integers \<close>
@@ -829,23 +829,8 @@ text \<open>
   From now on, we reduce the set @{text "Nat"} to the set of
   non-negative integers.
 \<close>
-lemma nat_iff_int_geq0' (*[simp]*) : "n \<in> Nat = (n \<in> Int \<and> 0 \<le> n)"
-  by (auto simp: int_leq_def)
-
-text \<open>
-We will use \<open>nat_is_int_geq0\<close> for simplification instead
-of \<open>nat_iff_int_geq0'\<close> for rewriting \<open>Nat\<close> to \<open>Int\<close> to
-handle also the cases where no \<open>Nat\<close> is used without
-the \<open>\<in>\<close> operator, e.g. in function sets.
-\<close>
 lemma nat_is_int_geq0 [simp] : "Nat = {x \<in> Int : 0 \<le> x}"
-proof
-  show "\<And>x. x \<in> Nat \<Longrightarrow> x \<in> {x \<in> Int : 0 \<le> x}"
-    using nat_iff_int_geq0' by auto
-next
-  show "\<And>x. x \<in> {x \<in> Int : 0 \<le> x} \<Longrightarrow> x \<in> Nat"
-    using nat_iff_int_geq0' by auto
-qed
+  by (auto simp: int_leq_def)
 
 
 declare natIsInt [simp del]
@@ -1717,13 +1702,26 @@ lemma trans_leq_diff_nat2 [simp]:
 
 lemma int_leq_iff_add:
   assumes "i \<in> Int" and "j \<in> Int"
-  shows "(i \<le> j) = (\<exists>k \<in> Nat: j = i + k)" (is "?lhs = ?rhs")
-  using assms by (auto intro: int_leq_imp_add simp del: nat_is_int_geq0 simp add: nat_iff_int_geq0')
+  shows "(i \<le> j) = (\<exists>k \<in> Nat: j = i + k)"
+  using assms by (auto intro: int_leq_imp_add simp: nat_zero_leq simp del: nat_is_int_geq0)
 
 lemma int_less_iff_succ_add:
   assumes "i \<in> Int" and "j \<in> Int"
   shows "(i < j) = (\<exists>k \<in> Nat: j = succ[i + k])" (is "?lhs = ?rhs")
-  using assms by (auto intro: int_less_imp_succ_add simp del: nat_is_int_geq0 simp add: nat_iff_int_geq0')
+proof -
+  {
+    assume ?lhs then have ?rhs
+      using assms by (blast dest: int_less_imp_succ_add)
+  }
+  moreover
+  {
+    assume ?rhs
+    then obtain k where k: "k \<in> Int" "0 \<le> k" "j = succ[i+k]" by auto
+    with assms have ?lhs by auto
+  }
+  ultimately 
+  show ?thesis by blast
+qed
 
 lemma leq_add_self1 [simp]:
   assumes "i \<in> Int" and "j \<in> Int"

--- a/isabelle/IntegerDivision.thy
+++ b/isabelle/IntegerDivision.thy
@@ -1,8 +1,8 @@
 (*  Title:      TLA+/IntegerDivision.thy
     Author:     Stephan Merz, Inria Nancy
-    Copyright (C) 2009-2024  INRIA and Microsoft Corporation
+    Copyright (C) 2009-2025  INRIA and Microsoft Corporation
     License:    BSD
-    Version:    Isabelle2024
+    Version:    Isabelle2025
 *)
 
 section \<open> The division operators div and mod on the integers \<close>

--- a/isabelle/Integers.thy
+++ b/isabelle/Integers.thy
@@ -1,8 +1,8 @@
 (*  Title:      TLA+/Integers.thy
     Author:     Stephan Merz, Inria Nancy
-    Copyright (C) 2008-2024  INRIA and Microsoft Corporation
+    Copyright (C) 2008-2025  INRIA and Microsoft Corporation
     License:    BSD
-    Version:    Isabelle2024
+    Version:    Isabelle2025
 *)
 
 section \<open> The set of integer numbers \<close>

--- a/isabelle/SMT.thy
+++ b/isabelle/SMT.thy
@@ -1,3 +1,5 @@
+(* This material is now obsolete but included because it may still become relevant. *)
+
 header {* Normalization rules used in the SMT backend  *}
 
 theory SMT

--- a/isabelle/SetTheory.thy
+++ b/isabelle/SetTheory.thy
@@ -1,8 +1,8 @@
 (*  Title:      TLA+/SetTheory.thy
     Author:     Stephan Merz, Inria Nancy
-    Copyright (C) 2008-2024  INRIA and Microsoft Corporation
+    Copyright (C) 2008-2025  INRIA and Microsoft Corporation
     License:    BSD
-    Version:    Isabelle2024
+    Version:    Isabelle2025
 *)
 
 section \<open>\tlaplus{} Set Theory\<close>
@@ -168,38 +168,38 @@ translations
 
 print_translation \<open>
   let
-      fun bEx_tr' [S, Abs(x, T, P as (Const (@{const_syntax "bEx"},_) $ S' $ Q))] =
+      fun bEx_tr' ctxt [S, Abs(x, T, P as (Const (@{const_syntax "bEx"},_) $ S' $ Q))] =
           (* bEx(S, bEx(S', Q)) => \\E x,y \\in S : Q if S = S' *)
-          let val (y,Q') = Syntax_Trans.atomic_abs_tr' (x,T,Q)
-              val (_ $ xs $ set $ Q'') = bEx_tr' [S', Q']
+          let val (y,Q') = Syntax_Trans.atomic_abs_tr' ctxt (x,T,Q)
+              val (_ $ xs $ set $ Q'') = bEx_tr' ctxt [S', Q']
 	  in  if S = S'
 	      then Syntax.const "@bEx" $ (Syntax.const "@cidts" $ y $ xs)
 				       $ set $ Q''
 	      else Syntax.const "@bEx" $ y $ S $
 		       (Syntax.const "@bEx" $ xs $ set $ Q'')
 	  end
-	| bEx_tr' [S, Abs(x, T, P)] =
-	    let val (x',P') = Syntax_Trans.atomic_abs_tr' (x,T,P)
+	| bEx_tr' ctxt [S, Abs(x, T, P)] =
+	    let val (x',P') = Syntax_Trans.atomic_abs_tr' ctxt (x,T,P)
 	    in  (Syntax.const "@bEx") $ x' $ S $ P'
 	    end
-	| bEx_tr' _ = raise Match;
-      fun bAll_tr' [S, Abs(x, T, P as (Const (@{const_syntax "bAll"},_) $ S' $ Q))] =
+	| bEx_tr' _ _ = raise Match;
+      fun bAll_tr' ctxt [S, Abs(x, T, P as (Const (@{const_syntax "bAll"},_) $ S' $ Q))] =
           (* bAll(S, bAll(S', Q)) => \\A x,y \\in S : Q if S = S' *)
-          let val (y,Q') = Syntax_Trans.atomic_abs_tr' (x,T,Q)
-              val (_ $ xs $ set $ Q'') = bAll_tr' [S', Q']
+          let val (y,Q') = Syntax_Trans.atomic_abs_tr' ctxt (x,T,Q)
+              val (_ $ xs $ set $ Q'') = bAll_tr' ctxt [S', Q']
 	  in  if S = S'
 	      then Syntax.const "@bAll" $ (Syntax.const "@cidts" $ y $ xs)
 				        $ set $ Q''
 	      else Syntax.const "@bAll" $ y $ S $
 		       (Syntax.const "@bAll" $ xs $ set $ Q'')
 	  end
-	| bAll_tr' [S, Abs(x, T, P)] =
-	    let val (x',P') = Syntax_Trans.atomic_abs_tr' (x,T,P)
+	| bAll_tr' ctxt [S, Abs(x, T, P)] =
+	    let val (x',P') = Syntax_Trans.atomic_abs_tr' ctxt (x,T,P)
 	    in  (Syntax.const "@bAll") $ x' $ S $ P'
 	    end
-	| bAll_tr' _ = raise Match;
-  in  [(@{const_syntax "bEx"}, (fn _ => bEx_tr')),
-       (@{const_syntax "bAll"}, (fn _ => bAll_tr'))]
+	| bAll_tr' _ _ = raise Match;
+  in  [(@{const_syntax "bEx"}, bEx_tr'),
+       (@{const_syntax "bAll"}, bAll_tr')]
   end
 \<close>
 

--- a/isabelle/Strings.thy
+++ b/isabelle/Strings.thy
@@ -1,8 +1,8 @@
 (*  Title:      TLA+/Strings.thy
     Author:     Stephan Merz, Inria Nancy
-    Copyright (C) 2009-2024  INRIA and Microsoft Corporation
+    Copyright (C) 2009-2025  INRIA and Microsoft Corporation
     License:    BSD
-    Version:    Isabelle2024
+    Version:    Isabelle2025
 *)
 
 section \<open> Characters and strings \<close>

--- a/isabelle/Tuples.thy
+++ b/isabelle/Tuples.thy
@@ -1,8 +1,8 @@
 (*  Title:      TLA+/Tuples.thy
     Author:     Stephan Merz, Inria Nancy
-    Copyright (C) 2008-2024 Inria and Microsoft Corporation
+    Copyright (C) 2008-2025 Inria and Microsoft Corporation
     License:    BSD
-    Version:    Isabelle2024
+    Version:    Isabelle2025
 *)
 
 section \<open> Tuples and Relations in \tlaplus{} \<close>
@@ -193,7 +193,7 @@ lemmas emptySeqIsAFcn [iff] = emptySeqIsASeq[THEN SeqIsAFcn]
 lemma lenEmptySeq [iff]: "Len(\<langle>\<rangle>) = 0"
 by (auto simp: emptySeq_def)
 
-lemma emptySeqInSeq (*[simp,intro!]*): "\<langle>\<rangle> \<in> Seq(S)"
+lemma emptySeqInSeq [simp,intro!]: "\<langle>\<rangle> \<in> Seq(S)"
 by auto
 
 lemma SeqNotEmpty [simp]:

--- a/isabelle/Zenon.thy
+++ b/isabelle/Zenon.thy
@@ -1,7 +1,7 @@
 (* Zenon.thy --- Support lemmas for Zenon proofs
  * Author: Damien Doligez <damien.doligez@inria.fr>
- * Copyright (C) 2008-2024  INRIA and Microsoft Corporation
- * Version:    Isabelle2024
+ * Copyright (C) 2008-2025  INRIA and Microsoft Corporation
+ * Version:    Isabelle2025
  *)
 
 (* isabelle usedir -b Pure TLA+ *)

--- a/isabelle/examples/Allocator.thy
+++ b/isabelle/examples/Allocator.thy
@@ -1,8 +1,8 @@
 (*  Title:      TLA+/Allocator.thy
     Author:     Stephan Merz, Inria Nancy
-    Copyright (C) 2009-2022  INRIA and Microsoft Corporation
+    Copyright (C) 2009-2025  INRIA and Microsoft Corporation
     License:    BSD
-    Version:    Isabelle2024
+    Version:    Isabelle2025
 *)
 
 section \<open>A Simple Resource Allocator\<close>

--- a/isabelle/examples/AtomicBakeryG.thy
+++ b/isabelle/examples/AtomicBakeryG.thy
@@ -1,8 +1,8 @@
 (*  Title:      TLA+/AtomicBakery.thy
     Author:     Hernan Vanzetto, LORIA
-    Copyright (C) 2009-2022  INRIA and Microsoft Corporation
+    Copyright (C) 2009-2025  INRIA and Microsoft Corporation
     License:    BSD
-    Version:    Isabelle2024
+    Version:    Isabelle2025
 *)
 
 section \<open>Safety Proof of the Atomic Version of the Bakery Algorithm\<close>

--- a/library/BagsTheorems_proofs.tla
+++ b/library/BagsTheorems_proofs.tla
@@ -38,14 +38,17 @@ SeqToBag(seq) == [ x \in Range(seq) |-> Cardinality({i \in DOMAIN seq: seq[i]=x}
 
 
 (***************************************************************************)
-(* Equality of bags via DOMAIN and CopiesIn.                               *)
+(* Two bags are equal if they agree on all numbers of copies.              *)
 (***************************************************************************)
 THEOREM BagEquality ==
   ASSUME NEW B1, NEW B2, IsABag(B1), IsABag(B2),
-         DOMAIN B1 = DOMAIN B2,
          \A e : CopiesIn(e, B1) = CopiesIn(e, B2)
   PROVE  B1 = B2
-BY DEF IsABag, CopiesIn, BagIn, BagToSet
+<1>1. \A e : e \in DOMAIN B1 <=> e \in DOMAIN B2
+  BY DEF IsABag, CopiesIn, BagIn, BagToSet
+<1>2. DOMAIN B1 = DOMAIN B2
+  BY <1>1
+<1>. QED  BY <1>2 DEF IsABag, CopiesIn, BagIn, BagToSet
  
 (***************************************************************************)
 (* \sqsubseteq is a PARTIAL ORDER relattion                                *)

--- a/library/FiniteSetTheorems_proofs.tla
+++ b/library/FiniteSetTheorems_proofs.tla
@@ -18,7 +18,8 @@ EXTENDS
 (***************************************************************************)
 LEMMA TwoExpLemma ==
   ASSUME NEW n \in Nat
-  PROVE  2^(n+1) = 2^n + 2^n
+  PROVE  /\ 2^0 = 1
+         /\ 2^(n+1) = 2^n + 2^n
 PROOF OMITTED
 
 
@@ -44,7 +45,9 @@ LEMMA FS_NatSurjection ==
   <2> QED BY <2>2 DEF ExistsSurjection
 
 <1>2. ASSUME NEW n \in Nat, ExistsSurjection(1..n,S)  PROVE  IsFiniteSet(S)
-  BY <1>2, Z3 DEF IsFiniteSet, ExistsSurjection, Surjection
+  <2>1. PICK M \in [1..n -> S] : \A t \in S : \E s \in 1..n : M[s] = t
+    BY <1>2 DEF ExistsSurjection, Surjection
+  <2>. QED  BY <2>1 DEF IsFiniteSet
 
 <1> QED BY <1>1, <1>2
 
@@ -121,7 +124,7 @@ PROOF
               OBVIOUS
         <4>2. Size(T) = 0  BY <4>1, Fun_NatBijSame
         <4>3. T = {}  BY <4>1, Fun_NatBijEmpty
-        <4>4. SZ[T] = 0  BY <4>2  DEF SZ
+        <4>4. SZ[T] = 0  BY <4>2, Zenon  DEF SZ
         <4>5. fn(SZ,T) = 0  BY <4>3  DEF fn
         <4> QED BY <4>4, <4>5
 
@@ -142,7 +145,7 @@ PROOF
         <4>7. SZ[U] = i  BY <4>5, Fun_NatBijSame DEF SZ
         <4>8. fn(SZ,T) = 1 + SZ[U]  BY <4>2, <4>4 DEF fn
         <4>9. fn(SZ,T) = i+1  BY <4>7, <4>8
-        <4>10. SZ[T] = i+1  BY <4>3  DEF SZ
+        <4>10. SZ[T] = i+1  BY <4>3, Zenon  DEF SZ
         <4>. QED  BY <4>9, <4>10
       <3> HIDE DEF Prop
       <3> QED BY Isa, <3>1, <3>2, NatInduction
@@ -192,8 +195,8 @@ PROOF
         <4>. DEFINE U == T \ {t}
         <4>9. ExistsBijection(1..i,U)  BY Fun_NatBijSubElem, Z3
         <4>10. CS1[U] = CS2[U]  BY <4>9, <3>2
-        <4>11. CS1[T] = 1 + CS1[U]  BY <4>6, <4>7, <1>2  DEF fn
-        <4>12. CS2[T] = 1 + CS2[U]  BY <4>6, <4>7, <1>2  DEF fn
+        <4>11. CS1[T] = 1 + CS1[U]  BY <4>6, <4>7, <1>2, Zenon  DEF fn
+        <4>12. CS2[T] = 1 + CS2[U]  BY <4>6, <4>7, <1>2, Zenon  DEF fn
         <4> QED BY <4>10, <4>11, <4>12
 
       <3> HIDE DEF Prop
@@ -212,8 +215,8 @@ PROOF
   <1>4. CS = SZ  BY <1>1, <1>2, <1>3, Zenon
 
 
-  <1>5. Cardinality(S) = CS[S]  BY DEF Cardinality, CS, fn
-  <1>7. SZ[S] = Size(S)  BY DEF SZ
+  <1>5. Cardinality(S) = CS[S]  BY Zenon DEF Cardinality, CS, fn
+  <1>7. SZ[S] = Size(S)  BY Zenon DEF SZ
   <1>8. Size(S) = n  BY Fun_NatBijSame
   <1> QED BY <1>4, <1>5, <1>7, <1>8
 
@@ -279,7 +282,7 @@ THEOREM FS_SurjSameCardinalityImpliesInj ==
   PROVE  f \in Injection(S,T)
 <1>1. SUFFICES ASSUME NEW a \in S, NEW b \in S, a # b, f[a] = f[b]
       PROVE FALSE
-  BY DEF Injection, Surjection
+  BY DEF Injection, Surjection, IsInjective
 <1>. DEFINE n == Cardinality(S)
 <1>. n \in Nat  BY FS_CardinalityType
 <1>. PICK g \in Bijection(1..n, S) : TRUE
@@ -300,7 +303,21 @@ THEOREM FS_SurjSameCardinalityImpliesInj ==
   <2>2. ASSUME NEW t \in T  PROVE \E k \in 1..n-1 : h[k] = t
     <3>1. PICK s \in S : f[s] = t  BY DEF Surjection
     <3>2. PICK l \in 1..n : g[l] = s  BY DEF Bijection, Surjection
-    <3>. QED  BY <1>1, <1>2, <3>1, <3>2
+    <3>. HIDE DEF n
+    <3>3. CASE l = j
+      <4>. /\ i \in 1 .. n-1
+           /\ i # j
+           /\ h[i] = t
+        BY <1>1, <1>2, <3>1, <3>2, <3>3
+      <4>. QED  OBVIOUS
+    <3>4. CASE l # j /\ l = n
+      <4>. /\ j \in 1 .. n-1
+           /\ h[j] = t
+        BY <3>1, <3>2, <3>4
+      <4>. QED  OBVIOUS
+    <3>5. CASE l # j /\ l # n
+      BY <3>1, <3>2, <3>5
+    <3>. QED  BY <3>3, <3>4, <3>5
   <2>. QED  BY <2>1, <2>2 DEF Surjection
 <1>4. Cardinality(T) <= n-1  BY <1>3, FS_SurjCardinalityBound DEF ExistsSurjection
 <1>. QED  BY <1>4
@@ -370,7 +387,7 @@ THEOREM FS_Singleton ==
   <2>1. /\ IsFiniteSet({} \cup {x})
         /\ Cardinality({} \cup {x}) = 0 + 1
     BY FS_EmptySet, FS_AddElement, Zenon
-  <2>. QED  BY <2>1
+  <2>. QED  BY <2>1, Isa
 <1>2. ASSUME NEW S, IsFiniteSet(S), Cardinality(S) = 1
       PROVE  \E x : S = {x}
   BY <1>2, FS_CardinalityType, Fun_NatBijSingleton, Zenon
@@ -507,7 +524,7 @@ THEOREM FS_PigeonHole ==
   PROVE  \E x,y \in S : x # y /\ f[x] = f[y]
 <1>. SUFFICES ASSUME f \in Injection(S,T)
               PROVE  FALSE
-  BY DEF Injection
+  BY DEF Injection, IsInjective
 <1>. QED  BY FS_Injection, FS_CardinalityType
 
 
@@ -535,8 +552,7 @@ THEOREM FS_BoundedSetOfNaturals ==
   PROVE  /\ IsFiniteSet(S)
          /\ Cardinality(S) \leq n+1
 <1>1. S \subseteq 0 .. n
-  \* FIXME: auxiliary assertion required due to current encoding for SMT backend
-  BY \A x : x \in S => x \in Nat, Z3
+  OBVIOUS
 <1>2. IsFiniteSet(0..n) /\ Cardinality(0..n) = n+1  BY FS_Interval
 <1>. QED  BY <1>1, <1>2, FS_Subset, Zenon
 
@@ -605,7 +621,7 @@ THEOREM FS_StrictSubsetOrderingWellFounded ==
   BY FS_CardinalityType, FS_Subset DEF FiniteSubsetsOf
 <1>2. IsWellFoundedOn(PreImage(Cardinality, FiniteSubsetsOf(S), OpToRel(<,Nat)),
                        FiniteSubsetsOf(S))
-  BY <1>1, PreImageWellFounded, NatLessThanWellFounded, Isa
+  BY <1>1, PreImageWellFounded, NatLessThanWellFounded, IsaM("blast")
 <1>3. StrictSubsetOrdering(S) \cap (FiniteSubsetsOf(S) \X FiniteSubsetsOf(S))
        \subseteq PreImage(Cardinality, FiniteSubsetsOf(S), OpToRel(<, Nat))
   BY FS_Subset, <1>1
@@ -825,7 +841,8 @@ THEOREM FS_Product ==
     BY <1>2, Isa
   <2>3. ExistsBijection(S, SX)
     <3>. DEFINE f  == [s \in S |-> <<s,x>>]
-    <3>. f \in Bijection(S, SX)  BY Zenon DEF Bijection, Injection, Surjection
+    <3>. f \in Bijection(S, SX)
+      BY Zenon DEF Bijection, Injection, IsInjective, Surjection
     <3>. QED  BY DEF ExistsBijection
   <2>4. /\ IsFiniteSet(SX)
         /\ Cardinality(SX) = Cardinality(S)
@@ -859,11 +876,10 @@ THEOREM FS_SUBSET ==
 <1>. DEFINE P(A) == /\ IsFiniteSet(SUBSET A)
                     /\ Cardinality(SUBSET A) = 2^Cardinality(A)
 <1>1. P({})
-  <2>1. /\ IsFiniteSet({{}})
-        /\ Cardinality({{}}) = 1
+  <2>. /\ IsFiniteSet({{}})
+       /\ Cardinality({{}}) = 1
     BY FS_Singleton, Zenon
-  <2>2. 1 = 2^0  OBVIOUS
-  <2>. QED  BY <2>1, <2>2, FS_EmptySet, Zenon
+  <2>. QED  BY FS_EmptySet, TwoExpLemma, Zenon
 <1>2. ASSUME NEW A, NEW x, IsFiniteSet(A), x \notin A, P(A)
       PROVE  P(A \cup {x})
   <2>. DEFINE Ax == {B \cup {x} : B \in SUBSET A}
@@ -901,7 +917,7 @@ THEOREM FS_SUBSET ==
 
 =============================================================================
 \* Modification History
-\* Last modified Wed Jan 08 17:42:32 CET 2020 by merz
+\* Last modified Fri Jun 13 19:01:57 CEST 2025 by merz
 \* Last modified Thu Jul 04 15:15:07 CEST 2013 by bhargav
 \* Last modified Tue Jun 04 11:44:51 CEST 2013 by bhargav
 \* Last modified Fri May 03 12:02:51 PDT 2013 by tomr

--- a/library/FunctionTheorems_proofs.tla
+++ b/library/FunctionTheorems_proofs.tla
@@ -468,21 +468,18 @@ THEOREM Fun_CantorBernsteinSchroeder_Lemma ==
       f0       == Y
       Def(v,i) == {F[s] : s \in v}
       f        == CHOOSE f : f = [i \in Nat |-> IF i = 0 THEN f0 ELSE Def(f[i-1],i)]
-  <2> SUFFICES \A i \in Nat : f[i] = IF i = 0 THEN f0 ELSE Def(f[i-1],i)  BY DEF Ci
+  <2> SUFFICES \A i \in Nat : f[i] = IF i = 0 THEN f0 ELSE Def(f[i-1],i)  BY Zenon DEF Ci
   <2> HIDE DEF f0, Def, f
   <2> SUFFICES NatInductiveDefConclusion(f,f0,Def)  BY DEF NatInductiveDefConclusion
-  <2> SUFFICES NatInductiveDefHypothesis(f,f0,Def)  BY NatInductiveDef
-  <2> QED BY DEF NatInductiveDefHypothesis, f
+  <2> SUFFICES NatInductiveDefHypothesis(f,f0,Def)  BY NatInductiveDef, Zenon
+  <2> QED BY Zenon DEF NatInductiveDefHypothesis, f
 
 (*************************************************************************)
 (* Applying F to an element of Ci[i] produces an element of Ci[i+1].     *)
 (*************************************************************************)
 <1>4. ASSUME NEW i \in Nat, NEW s \in Ci[i]
       PROVE F[s] \in Ci[i+1]
-   (* old proof fails:
-      BY <1>3, SMT
-   *)
-   BY <1>3, i+1 \in Nat \ {0}, (i+1)-1 = i, Zenon
+   BY <1>3
 
 (*************************************************************************)
 (* Each element of Ci[i+1] is the application of F to some element in    *)
@@ -490,9 +487,6 @@ THEOREM Fun_CantorBernsteinSchroeder_Lemma ==
 (*************************************************************************)
 <1>5. ASSUME NEW i \in Nat, NEW t \in Ci[i+1]
       PROVE \E s \in Ci[i] : F[s] = t
-   (* old proof fails:
-      BY <1>3, SMT
-   *)
    <2>1. Ci[i+1] = {F[s] : s \in Ci[i]}
      BY <1>3, i+1 \in Nat \ {0}, (i+1)-1 = i, Zenon
    <2>. QED  BY <2>1
@@ -532,11 +526,8 @@ THEOREM Fun_CantorBernsteinSchroeder_Lemma ==
     <3>1. PICK i \in Nat : c \in Ci[i]  BY <1>7
     <3>2. CASE i = 0  BY <3>1, <3>2, <1>3, Zenon
     <3>3. CASE i # 0
-      (* old proof fails:
-      <4>1. PICK s \in Ci[i-1] : F[s] = c  BY <3>1, <3>3, <1>5, SMT
-      *)
       <4>0. PICK j \in Nat : i = j+1
-        BY <3>3
+        BY <3>3, Isa
       <4>1. PICK s \in Ci[j] : F[s] = c
         BY <4>0, <3>1, <1>5, Zenon
       <4>2. s \in C  BY <3>3, <1>7
@@ -710,15 +701,12 @@ THEOREM Fun_ExistsBijInterval ==
 <1>. DEFINE f == [i \in 1 .. b-a+1 |-> i+a-1]
 <1>1. f \in [1 .. b-a+1 -> a .. b]  BY SMT
 <1>2. f \in Injection(1 .. b-a+1, a .. b) BY DEF Injection, IsInjective
-(** old proof fails:
-<1>3. f \in Surjection(1 .. b-a+1, a .. b) BY Z3 DEF Surjection
-**)
 <1>3. \A t \in a..b :
          /\ t-a+1 \in 1 .. (b-a+1)
          /\ f[t-a+1] = t
   OBVIOUS
 <1>4. f \in Surjection(1 .. b-a+1, a .. b)
-  BY <1>3, <1>1, Zenon DEF Surjection
+  BY <1>1, <1>3 DEF Surjection
 <1>. QED  BY <1>1, <1>2, <1>4 DEF ExistsBijection, Bijection
 
 
@@ -812,7 +800,13 @@ THEOREM Fun_NatSurjImpliesNatBij ==
     <3>1. g \in [1..m-1 -> S]  BY <2>1
     <3>2. ASSUME NEW s \in S  PROVE \E k \in 1..m-1 : g[k] = s
       <4>. PICK l \in 1..m : f[l] = s  BY <1>3 DEF Surjection
-      <4>. QED  BY <2>2
+      <4>1. CASE l = j
+        BY <2>2, <4>1, i \in 1 .. m-1
+      <4>2. CASE l # j /\ l = m
+        BY <4>2, j \in 1 .. m-1
+      <4>3. CASE l # j /\ l # m
+        BY <4>3
+      <4>. QED  BY <4>1, <4>2, <4>3
     <3>. QED  BY <3>1, <3>2, Zenon DEF Surjection
   <2>. QED  BY SMT, <2>3, <2>4, <1>1 DEF ExistsSurjection
 
@@ -862,7 +856,7 @@ THEOREM Fun_NatBijEmpty ==
   <2>. ExistsInjection(S, 1..0)  BY <1>1, Fun_ExistsBijEquiv
   <2>. QED  BY <1>1 DEF ExistsInjection, Injection
 <1>2. ASSUME S = {}  PROVE ExistsBijection(1..0, S)
-  BY <1>2, Fun_ExistsBijReflexive
+  BY <1>2, Fun_ExistsBijReflexive, Isa
 <1>3. QED  BY <1>1, <1>2
 
 
@@ -877,7 +871,7 @@ THEOREM Fun_NatBijSingleton ==
   ASSUME NEW S
   PROVE  ExistsBijection(1..1,S) <=> \E s : S = {s}
 <1>1. ASSUME NEW f \in Bijection(1..1, S)  PROVE \E s : S = {s}
-  BY DEF Bijection, Injection, Surjection
+  BY 1..1 = {1}, SMTT(10) DEF Bijection, Injection, Surjection
 <1>2. ASSUME NEW s, S = {s}  PROVE [i \in 1..1 |-> s] \in Bijection(1..1, S)
   BY <1>2 DEF Bijection, Injection, IsInjective, Surjection
 <1>. QED  BY <1>1, <1>2 DEF ExistsBijection
@@ -964,7 +958,7 @@ THEOREM Fun_NatBijSubElem ==
 
 =============================================================================
 \* Modification History
-\* Last modified Wed Dec 30 08:28:26 CET 2020 by merz
+\* Last modified Fri Jun 13 14:51:49 CEST 2025 by merz
 \* Last modified Tue Jun 11 12:30:05 CEST 2013 by bhargav
 \* Last modified Fri May 31 15:27:41 CEST 2013 by bhargav
 \* Last modified Fri May 03 12:55:32 PDT 2013 by tomr

--- a/library/NaturalsInduction_proofs.tla
+++ b/library/NaturalsInduction_proofs.tla
@@ -40,7 +40,7 @@ THEOREM DownwardNatInduction ==
 <1>1. Q(0)  OBVIOUS
 <1>2. ASSUME NEW n \in Nat, Q(n)
       PROVE  Q(n+1)
-  BY <1>2
+  BY <1>2, n+1 <= m => m-n \in 1 .. m
 <1>3. \A n \in Nat : Q(n)  BY <1>1, <1>2, NatInduction, Isa
 <1>. QED  BY <1>3, Isa
 
@@ -125,7 +125,7 @@ THEOREM RecursiveFcnOfNat ==
     <3>. SUFFICES \A k \in Nat : Q(k)  BY Zenon
     <3>1. Q(0)
       <4>. DEFINE g0 == [n \in {0} |-> [i \in {} |-> {}]]
-      <4>1. P(g0, 0)  OBVIOUS
+      <4>1. P(g0, 0)  BY Isa
       <4>. QED  BY <4>1, Zenon
     <3>2. ASSUME NEW k \in Nat, Q(k)
           PROVE  Q(k+1)
@@ -159,7 +159,7 @@ THEOREM RecursiveFcnOfNat ==
     <3>1. ASSUME NEW k \in Nat, Q(k)
           PROVE  Q(k+1)
       <4>. HIDE DEF P
-      <4>. SUFFICES ASSUME NEW l \in 0 .. k+1, NEW i \in 0 .. l-1, NEW g, NEW h,
+      <4>. SUFFICES ASSUME NEW l \in 1 .. k+1, NEW i \in 0 .. l-1, NEW g, NEW h,
                            P(g,k+1), P(h,l)
                     PROVE  g[l][i] = h[l][i]
         OBVIOUS
@@ -186,9 +186,10 @@ THEOREM RecursiveFcnOfNat ==
             BY nn-1 \in 0 .. l-1, nn-1 \in 0 .. l, Zenon DEF P
           <6>. QED  BY <6>1, <6>2
         <5>. QED  BY <5>1, Zenon DEF P
-      <4>4. \A m \in 0 .. i-1 : gg[l-1][m] = hh[l-1][m]
+      <4>4. ASSUME NEW m \in 0 .. i-1
+            PROVE  gg[l-1][m] = hh[l-1][m]
         <5>. HIDE DEF gg, hh
-        <5>. QED  BY <3>1, <4>2, <4>3
+        <5>. QED  BY <3>1, <4>2, <4>3, l-1 \in 0 .. k, m \in 0 .. l-2
       <4>5. \A m \in 0 .. i-1 : g[l-1][m] = gg[l-1][m]   BY <2>0
       <4>6. \A m \in 0 .. i-1 : h[l-1][m] = hh[l-1][m]   BY <2>0
       <4>7. \A m \in 0 .. i-1 : g[l-1][m] = h[l-1][m]    BY <4>4, <4>5, <4>6, Zenon
@@ -202,9 +203,9 @@ THEOREM RecursiveFcnOfNat ==
                   PROVE  FF[k][i] = Def(FF[k-1], i)
       BY Zenon
     <3>1. FF[k][i] = G(k)[k][i]  OBVIOUS
-    <3>2. G(k)[k][i] = Def(G(k)[k-1], i)  BY <2>2, CVC4
+    <3>2. G(k)[k][i] = Def(G(k)[k-1], i)  BY <2>2
     <3>. HIDE DEF P
-    <3>3. \A j \in 0 .. i-1 : G(k)[k-1][j] = FF[k-1][j]  BY <2>2, <2>3, CVC4
+    <3>3. \A j \in 0 .. i-1 : G(k)[k-1][j] = FF[k-1][j]  BY <2>2, <2>3 DEF G
     <3>. HIDE DEF FF
     <3>4. Def(G(k)[k-1], i) = Def(FF[k-1], i)  BY <3>3
     <3>. QED  BY <3>1, <3>2, <3>4
@@ -283,7 +284,7 @@ THEOREM NatInductiveDef ==
 <1>. HIDE DEF PRDef
 <1>2. ff = [n \in Nat |-> PRDef(ff,n)]  BY <1>1, RecursiveFcnOfNat, Isa
 <1>. USE DEF PRDef
-<1>3. ff = f  BY DEF NatInductiveDefHypothesis
+<1>3. ff = f  BY DEF NatInductiveDefHypothesis, Zenon
 <1>. HIDE DEF ff
 <1>. QED  BY <1>2, <1>3 DEF NatInductiveDefConclusion
 
@@ -433,9 +434,9 @@ factorial[n \in Nat] == IF n = 0 THEN 1 ELSE n * factorial[n-1]
 
 THEOREM FactorialDefConclusion == NatInductiveDefConclusion(factorial, 1, LAMBDA v,n : n*v)
 <1>1. NatInductiveDefHypothesis(factorial, 1, LAMBDA v,n : n*v)
-  BY DEF NatInductiveDefHypothesis, factorial
+  BY Zenon DEF NatInductiveDefHypothesis, factorial
 <1>2. QED
-  BY <1>1, NatInductiveDef
+  BY <1>1, NatInductiveDef, Zenon
 
 THEOREM FactorialDef == \A n \in Nat : factorial[n] = IF n = 0 THEN 1 ELSE n * factorial[n-1]
 BY FactorialDefConclusion DEF NatInductiveDefConclusion
@@ -447,7 +448,7 @@ THEOREM FactorialType == factorial \in [Nat -> Nat]
   BY <1>1, NatInductiveDefType, FactorialDefConclusion, Isa
 
 \* Modification History
-\* Last modified Tue Jan 21 11:44:24 CET 2020 by merz
+\* Last modified Fri Jun 13 13:59:36 CEST 2025 by merz
 \* Last modified Tue Oct 15 12:06:48 CEST 2013 by shaolin
 \* Last modified Sat Nov 26 08:49:59 CET 2011 by merz
 \* Last modified Mon Nov 07 08:58:05 PST 2011 by lamport

--- a/library/SequenceTheorems_proofs.tla
+++ b/library/SequenceTheorems_proofs.tla
@@ -128,7 +128,7 @@ THEOREM ConcatSimplifications ==
 
 THEOREM SubSeqProperties ==
   ASSUME NEW S, NEW s \in Seq(S), NEW m \in Int, NEW n \in Int,
-         1 <= m, m <= n, n <= Len(s),
+         m > n \/ (1 <= m /\ n <= Len(s)),
          \A i \in m .. n : s[i] \in S
    PROVE /\ SubSeq(s,m,n) \in Seq(S)
          /\ Len(SubSeq(s,m,n)) = IF m<=n THEN n-m+1 ELSE 0
@@ -136,7 +136,7 @@ THEOREM SubSeqProperties ==
 OBVIOUS
 
 THEOREM SubSeqEmpty ==
-  ASSUME NEW s, NEW m \in Int, NEW n \in Int, n < m
+  ASSUME NEW S, NEW s \in Seq(S), NEW m \in Int, NEW n \in Int, n < m
   PROVE  SubSeq(s,m,n) = << >>
 OBVIOUS
 
@@ -240,7 +240,7 @@ THEOREM HeadTailAppend ==
   ASSUME NEW S, NEW seq \in Seq(S), NEW elt
   PROVE  /\ Head(Append(seq, elt)) = IF seq = <<>> THEN elt ELSE Head(seq)
          /\ Tail(Append(seq, elt)) = IF seq = <<>> THEN <<>> ELSE Append(Tail(seq), elt)
-OBVIOUS
+BY seq \in Seq(S \union {elt})
 
 THEOREM AppendInjective ==
   ASSUME NEW S, NEW e \in S, NEW s \in Seq(S), NEW f \in S, NEW t \in Seq(S)
@@ -252,11 +252,18 @@ THEOREM SequenceEmptyOrAppend ==
   PROVE \E s \in Seq(S), elt \in S : seq = Append(s, elt)
 <1>. DEFINE front == [i \in 1 .. Len(seq)-1 |-> seq[i]]
             last == seq[Len(seq)]
-<1>. /\ front \in Seq(S)
-     /\ last \in S
-     /\ seq = Append(front, last)
+<1>1. /\ front \in Seq(S)
+      /\ Len(front) = Len(seq)-1
+      /\ last \in S
   OBVIOUS
-<1>. QED  BY Zenon
+<1>2. Len(seq) = Len(Append(front, last))
+  OBVIOUS
+<1>3. ASSUME NEW i \in 1 .. Len(seq) 
+      PROVE  seq[i] = Append(front, last)[i]
+  OBVIOUS
+<1>4. seq = Append(front, last)
+  BY <1>2, <1>3
+<1>. QED  BY <1>1, <1>4
 
 (***************************************************************************)
 (* Inductive reasoning for sequences                                       *)

--- a/library/SequenceTheorems_proofs.tla
+++ b/library/SequenceTheorems_proofs.tla
@@ -89,14 +89,6 @@ THEOREM ConcatAssociative ==
   ASSUME NEW S, NEW s \in Seq(S), NEW t \in Seq(S), NEW u \in Seq(S)
   PROVE  (s \o t) \o u = s \o (t \o u)
 OBVIOUS
-(*
-<1>. DEFINE lhs == (s \o t) \o u
-            rhs == s \o (t \o u)
-<1>. lhs \in Seq(S) /\ rhs \in Seq(S)  OBVIOUS
-<1>1. Len(lhs) = Len(rhs)  OBVIOUS
-<1>2. \A i \in 1 .. Len(lhs) : lhs[i] = rhs[i]  OBVIOUS
-<1>. QED  BY <1>1, <1>2, SeqEqual, Zenon
-*)
 
 (****************************************************************************)
 (* Intentionally not written as an ASSUME ... PROVE such that the conjuncts *)
@@ -108,14 +100,35 @@ THEOREM ConcatSimplifications ==
   /\ concIsEmpty:: \A S : \A s,t \in Seq(S) : s \o t = <<>> => s = <<>> /\ t = <<>>
   /\ cancelLeft:: \A S : \A s,t,v \in Seq(S) : s \o t = s \o v => t = v
   /\ cancelRight:: \A S : \A s,t,v \in Seq(S) : s \o v = t \o v => s = t
-OBVIOUS
+<1>1. ASSUME NEW S, NEW s \in Seq(S), NEW t \in Seq(S), NEW v \in Seq(S),
+             s \o t = s \o v
+      PROVE  t = v
+  <2>1. Len(t) = Len(v)
+    BY <1>1
+  <2>2. ASSUME NEW i \in 1 .. Len(t) PROVE t[i] = v[i]
+    <3>1. t[i] = (s \o t)[Len(s)+i]
+      OBVIOUS
+    <3>2. v[i] = (s \o v)[Len(s)+i]
+      BY <2>1
+    <3>. QED  BY <1>1, <3>1, <3>2
+  <2>. QED  BY <2>1, <2>2
+<1>2. ASSUME NEW S, NEW s \in Seq(S), NEW t \in Seq(S), NEW v \in Seq(S),
+             s \o v = t \o v
+      PROVE  s = t
+  <2>1. Len(s) = Len(t)
+    BY <1>2
+  <2>2. ASSUME NEW i \in 1 .. Len(s) PROVE s[i] = t[i]
+    BY <1>2, <2>1
+  <2>. QED  BY <2>1, <2>2
+<1>. QED  BY <1>1, <1>2, ConcatEqualIffEmpty
 
 (***************************************************************************)
 (*                     SubSeq, Head and Tail                               *)
 (***************************************************************************)
 
 THEOREM SubSeqProperties ==
-  ASSUME NEW S, NEW s, NEW m \in Int, NEW n \in Int,
+  ASSUME NEW S, NEW s \in Seq(S), NEW m \in Int, NEW n \in Int,
+         1 <= m, m <= n, n <= Len(s),
          \A i \in m .. n : s[i] \in S
    PROVE /\ SubSeq(s,m,n) \in Seq(S)
          /\ Len(SubSeq(s,m,n)) = IF m<=n THEN n-m+1 ELSE 0

--- a/library/SequencesExtTheorems_proofs.tla
+++ b/library/SequencesExtTheorems_proofs.tla
@@ -43,7 +43,12 @@ BY DEF Cons
 THEOREM ConsInjective ==
   ASSUME NEW S, NEW e \in S, NEW s \in Seq(S), NEW f \in S, NEW t \in Seq(S)
   PROVE  Cons(e,s) = Cons(f,t) <=> e = f /\ s = t
-BY DEF Cons
+<1>1. ASSUME Cons(e,s) = Cons(f,t) PROVE e = f /\ s = t
+  <2>1. /\ Head(Cons(e,s)) = e /\ Tail(Cons(e,s)) = s
+        /\ Head(Cons(f,t)) = f /\ Tail(Cons(f,t)) = t
+    BY DEF Cons
+  <2>. QED  BY <1>1, <2>1
+<1>. QED  BY <1>1
 
 THEOREM SequencesInductionCons ==
   ASSUME NEW P(_), NEW S,
@@ -85,25 +90,7 @@ THEOREM InsertAtProperties ==
                      IF j<i THEN seq[j]
                      ELSE IF j=i THEN elt
                      ELSE seq[j-1]
-<1>. DEFINE left == SubSeq(seq, 1, i-1)
-            mid  == <<elt>>
-            right == SubSeq(seq, i, Len(seq))
-<1>1. /\ left \in Seq(S) /\ Len(left) = i-1
-      /\ mid \in Seq(S)
-      /\ right \in Seq(S) /\ Len(right) = Len(seq)-i+1
-      /\ InsertAt(seq,i,elt) \in Seq(S)
-      /\ Len(InsertAt(seq,i,elt)) = Len(left) + 1 + Len(right)
-  BY DEF InsertAt
-<1>2. Len(InsertAt(seq,i,elt)) = Len(seq)+1
-  <2>. HIDE DEF left, right
-  <2>. QED  BY <1>1
-<1>3. ASSUME NEW j \in 1 .. Len(seq)+1
-      PROVE  InsertAt(seq,i,elt)[j] = IF j<i THEN seq[j]
-                                      ELSE IF j=i THEN elt
-                                      ELSE seq[j-1]
-  <2>. j \in 1 .. Len(left)+1+Len(right)  BY <1>1, <1>2, Zenon
-  <2>. QED  BY ConcatProperties, SubSeqProperties DEF InsertAt
-<1>. QED  BY <1>1, <1>2, <1>3
+BY DEF InsertAt
 
 THEOREM RemoveAtProperties ==
    ASSUME NEW S, NEW seq \in Seq(S),
@@ -111,21 +98,7 @@ THEOREM RemoveAtProperties ==
    PROVE  /\ RemoveAt(seq,i) \in Seq(S)
           /\ Len(RemoveAt(seq,i)) = Len(seq) - 1
           /\ \A j \in 1 .. Len(seq)-1 : RemoveAt(seq,i)[j] = IF j<i THEN seq[j] ELSE seq[j+1]
-<1>. DEFINE left == SubSeq(seq, 1, i-1)
-            right == SubSeq(seq, i+1, Len(seq))
-<1>1. /\ left \in Seq(S) /\ Len(left) = i-1
-      /\ right \in Seq(S) /\ Len(right) = Len(seq) - i
-      /\ RemoveAt(seq,i) \in Seq(S)
-      /\ Len(RemoveAt(seq,i)) = Len(left) + Len(right)
-  BY DEF RemoveAt
-<1>2. Len(RemoveAt(seq,i)) = Len(seq) - 1
-  <2>. HIDE DEF left, right
-  <2>. QED  BY <1>1
-<1>3. ASSUME NEW j \in 1 .. Len(seq)-1
-      PROVE  RemoveAt(seq,i)[j] = IF j<i THEN seq[j] ELSE seq[j+1]
-  <2>. j \in 1 .. Len(left) + Len(right)  BY <1>1, <1>2, Zenon
-  <2>. QED  BY ConcatProperties, SubSeqProperties DEF RemoveAt
-<1>. QED  BY <1>1, <1>2, <1>3, Zenon
+BY DEF RemoveAt
 
 (***************************************************************************)
 (* Theorems about Front and Last.                                          *)
@@ -174,11 +147,9 @@ LEMMA FrontInjectiveSeq ==
   BY DEF Range, IsInjective, Front, Last
 <1>3. ASSUME NEW e \in Range(seq) \ {Last(seq)}
       PROVE  e \in Range(ft)
-\* the following doesn't seem to work everywhere ...
-\*  BY DEF Range, Front, Last
-   <2>1. e \in {seq[x]:  x \in 1..(Len(seq) - 1)}
-    BY <1>3 DEF Range, Last
-  <2> QED  BY <2>1 DEF Range, Front
+  <2>1. PICK i \in 1 .. Len(seq)-1 : e = seq[i]
+    BY DEF Range, Last
+  <2>. QED  BY <2>1 DEF Range, Front
 <1>. QED  BY <1>1, <1>2, <1>3
 
 THEOREM SequencesInductionFront ==
@@ -217,14 +188,19 @@ BY DEF Reverse
 THEOREM ReverseEmpty == Reverse(<< >>) = << >>
 BY DEF Reverse
 
+THEOREM ReverseSingleton == \A x : Reverse(<< x >>) = << x >>
+BY DEF Reverse
+
 THEOREM ReverseEqual ==
   ASSUME NEW S, NEW s \in Seq(S), NEW t \in Seq(S), Reverse(s) = Reverse(t)
   PROVE  s = t
 <1>1. Len(s) = Len(t)  BY DEF Reverse
 <1>2. ASSUME NEW i \in 1 .. Len(s)
       PROVE  s[i] = t[i]
-  <2>1. Reverse(s)[Len(s)-i+1] = Reverse(t)[Len(s)-i+1]  OBVIOUS
-  <2>. QED  BY <2>1 DEF Reverse
+  <2>. /\ s[i] = Reverse(s)[Len(s)-i+1]
+       /\ t[i] = Reverse(t)[Len(s)-i+1]
+    BY DEF Reverse
+  <2>. QED  OBVIOUS
 <1>. QED  BY <1>1, <1>2, SeqEqual
 
 THEOREM ReverseEmptyIffEmpty ==
@@ -235,7 +211,14 @@ BY DEF Reverse
 THEOREM ReverseConcat ==
   ASSUME NEW S, NEW s1 \in Seq(S), NEW s2 \in Seq(S)
   PROVE  Reverse(s1 \o s2) = Reverse(s2) \o Reverse(s1)
-BY DEF Reverse
+<1>1. /\ Reverse(s1) \in Seq(S) /\ Reverse(s2) \in Seq(S)
+      /\ Reverse(s1 \o s2) \in Seq(S)
+      /\ Len(Reverse(s1 \o s2)) = Len(Reverse(s2) \o Reverse(s1))
+  BY ReverseProperties
+<1>2. ASSUME NEW i \in 1 .. Len(Reverse(s1 \o s2))
+      PROVE  Reverse(s1 \o s2)[i] = (Reverse(s2) \o Reverse(s1))[i]
+  BY DEF Reverse
+<1>. QED  BY <1>1, <1>2
 
 THEOREM ReverseAppend ==
   ASSUME NEW S, NEW seq \in Seq(S), NEW e \in S
@@ -245,22 +228,30 @@ BY DEF Reverse, Cons
 THEOREM ReverseCons ==
   ASSUME NEW S, NEW seq \in Seq(S), NEW e \in S
   PROVE  Reverse(Cons(e,seq)) = Append(Reverse(seq), e)
-BY DEF Reverse, Cons
+<1>1. Reverse(seq) \in Seq(S)
+  BY ReverseProperties
+<1>2. Reverse(Cons(e, seq)) = Reverse(seq) \o <<e>>
+  BY ReverseConcat, ReverseSingleton DEF Cons
+<1>3. @ = Append(Reverse(seq), e)
+  BY <1>1
+<1>. QED  BY <1>2, <1>3
 
-THEOREM ReverseSingleton == \A x : Reverse(<< x >>) = << x >>
-BY DEF Reverse
 
 THEOREM ReverseSubSeq ==
   ASSUME NEW S, NEW seq \in Seq(S),
-         NEW m \in 1..Len(seq), NEW n \in 1..Len(seq)
+         NEW m \in 1..Len(seq), NEW n \in 0..Len(seq)
   PROVE  Reverse(SubSeq(seq, m , n)) = SubSeq(Reverse(seq), Len(seq)-n+1, Len(seq)-m+1)
-BY DEF Reverse
+<1>. /\ Reverse(seq) \in Seq(S)
+     /\ Len(seq)-n+1 \in 1 .. Len(Reverse(seq))+1
+     /\ Len(seq)-m+1 \in 1 .. Len(Reverse(seq))
+  BY ReverseProperties
+<1>. QED  BY DEF Reverse
 
 THEOREM ReversePalindrome ==
   ASSUME NEW S, NEW seq \in Seq(S),
          Reverse(seq) = seq
   PROVE  Reverse(seq \o seq) = seq \o seq
-BY ReverseConcat, Zenon
+BY ReverseConcat
 
 THEOREM LastEqualsHeadReverse ==
   ASSUME NEW S, NEW seq \in Seq(S), seq # << >>
@@ -270,7 +261,11 @@ BY DEF Last, Reverse
 THEOREM ReverseFrontEqualsTailReverse ==
   ASSUME NEW S, NEW seq \in Seq(S), seq # << >>
   PROVE  Reverse(Front(seq)) = Tail(Reverse(seq))
-BY DEF Reverse, Front
+<1>1. Reverse(seq) \in Seq(S) /\ Len(Reverse(seq)) = Len(seq)
+  BY ReverseProperties
+<1>2. Reverse(Front(seq)) = SubSeq(Reverse(seq), 2, Len(seq))
+  BY ReverseSubSeq DEF Front
+<1>. QED  BY <1>1, <1>2
 
 (* The range of the reverse sequence equals that of the original one. *)
 THEOREM RangeReverse ==
@@ -369,7 +364,7 @@ BY IsPrefixProperties, IsStrictPrefixProperties
 THEOREM IsPrefixConcat ==
   ASSUME NEW S, NEW s \in Seq(S), NEW t \in Seq(S)
   PROVE  IsPrefix(s, s \o t)
-BY IsPrefixProperties, ConcatProperties, Zenon
+BY IsPrefixProperties, ConcatProperties
 
 THEOREM IsStrictPrefixAppend ==
   ASSUME NEW S, NEW s \in Seq(S), NEW e \in S
@@ -379,7 +374,7 @@ THEOREM IsStrictPrefixAppend ==
       /\ <<e>> \in Seq(S)
       /\ <<e>> # << >>
   OBVIOUS
-<1>. QED  BY <1>1, IsStrictPrefixProperties, Zenon
+<1>. QED  BY <1>1, IsStrictPrefixProperties
 
 THEOREM FrontIsPrefix ==
   ASSUME NEW S, NEW s \in Seq(S)
@@ -413,17 +408,17 @@ THEOREM ConcatIsPrefixCancel ==
   ASSUME NEW S, NEW s \in Seq(S), NEW t \in Seq(S), NEW u \in Seq(S)
   PROVE  /\ IsPrefix(s \o t, s \o u) <=> IsPrefix(t, u)
 <1>1. ASSUME IsPrefix(t,u) PROVE IsPrefix(s \o t, s \o u)
-  <2>1. PICK v \in Seq(S) : u = t \o v  BY <1>1, IsPrefixProperties, Isa
+  <2>1. PICK v \in Seq(S) : u = t \o v  BY <1>1, IsPrefixProperties
   <2>2. s \o u = (s \o t) \o v  BY <2>1
-  <2>. QED  BY <2>2, IsPrefixProperties, s \o u \in Seq(S), s \o t \in Seq(S), Zenon
+  <2>. QED  BY <2>2, IsPrefixProperties, s \o u \in Seq(S), s \o t \in Seq(S)
 <1>2. ASSUME IsPrefix(s \o t, s \o u) PROVE IsPrefix(t,u)
   <2>1. PICK v \in Seq(S) : s \o u = (s \o t) \o v
-    BY <1>2, s \o t \in Seq(S), s \o u \in Seq(S), IsPrefixProperties, Isa
+    BY <1>2, s \o t \in Seq(S), s \o u \in Seq(S), IsPrefixProperties
   <2>2. s \o u = s \o (t \o v)
-    BY <2>1, Z3
+    BY <2>1
   <2>3. u = t \o v
-    BY t \o v \in Seq(S), <2>2, ConcatSimplifications, Zenon
-  <2>. QED  BY <2>3, IsPrefixProperties, Zenon
+    BY t \o v \in Seq(S), <2>2, ConcatSimplifications
+  <2>. QED  BY <2>3, IsPrefixProperties
 <1>. QED  BY <1>1, <1>2
 
 THEOREM ConsIsPrefixCancel ==
@@ -441,21 +436,19 @@ THEOREM ConsIsPrefix ==
 <1>1. IsPrefix(<<e>>, u)
   BY ConcatIsPrefix, Zenon DEF Cons
 <1>2. PICK v \in Seq(S) : u = Cons(e, v)
-  BY <1>1, IsPrefixProperties, Isa DEF Cons
+  BY <1>1, IsPrefixProperties DEF Cons
 <1>3. /\ e = Head(u)
       /\ v = Tail(u)
       /\ IsPrefix(Cons(e,s), Cons(e, Tail(u)))
-  BY <1>2, ConsProperties, Zenon
+  BY <1>2, ConsProperties
 <1>. QED
-  BY <1>3, ConsIsPrefixCancel, Zenon
+  BY <1>3, ConsIsPrefixCancel
 
 THEOREM IsStrictPrefixStrictPartialOrder ==
   ASSUME NEW S
   PROVE  /\ \A s \in Seq(S) : ~ IsStrictPrefix(s,s)
          /\ \A s,t \in Seq(S) : IsStrictPrefix(s,t) => ~ IsStrictPrefix(t,s)
          /\ \A s,t,u \in Seq(S) : IsStrictPrefix(s,t) /\ IsStrictPrefix(t,u) => IsStrictPrefix(s,u)
-\* the following doesn't seem to work everywhere
-\* BY IsStrictPrefixProperties
 <1>1. ASSUME NEW s \in Seq(S)
       PROVE  ~ IsStrictPrefix(s,s)
   BY <1>1, IsStrictPrefixProperties
@@ -465,7 +458,13 @@ THEOREM IsStrictPrefixStrictPartialOrder ==
 <1>3. ASSUME NEW s \in Seq(S), NEW t \in Seq(S), NEW u \in Seq(S),
              IsStrictPrefix(s,t), IsStrictPrefix(t,u)
       PROVE  IsStrictPrefix(s,u)
-  BY <1>3, IsStrictPrefixProperties
+  <2>1. PICK st \in Seq(S) \ {<<>>} : t = s \o st
+    BY <1>3, IsStrictPrefixProperties
+  <2>2. PICK tu \in Seq(S) \ {<<>>} : u = t \o tu
+    BY <1>3, IsStrictPrefixProperties
+  <2>3. u = s \o (st \o tu)
+    BY <2>1, <2>2
+  <2>. QED  BY <2>3, IsStrictPrefixProperties
 <1> QED  BY <1>1, <1>2, <1>3
 
 
@@ -607,7 +606,7 @@ THEOREM IsSuffixPartialOrder ==
          /\ \A s,t \in Seq(S) : IsSuffix(s,t) /\ IsSuffix(t,s) => s = t
          /\ \A s,t,u \in Seq(S) : IsSuffix(s,t) /\ IsSuffix(t,u) => IsSuffix(s,u)
 <1>1. ASSUME NEW s \in Seq(S) PROVE IsSuffix(s,s)
-  BY IsSuffixProperties
+  BY s = s \o <<>>, IsSuffixProperties
 <1>2. ASSUME NEW s \in Seq(S), NEW t \in Seq(S), IsSuffix(s,t), IsSuffix(t,s)
       PROVE  s = t
   BY <1>2, IsPrefixPartialOrder, ReverseProperties, ReverseEqual DEF IsSuffix
@@ -624,29 +623,33 @@ THEOREM ConcatIsSuffix ==
 <1>1. /\ s \o t \in Seq(S)
       /\ IsSuffix(t, s \o t)
   BY IsSuffixConcat
-<1>. QED  BY <1>1, IsSuffixPartialOrder, Zenon
+<1>. QED  BY <1>1, IsSuffixPartialOrder
 
 THEOREM ConcatIsSuffixCancel ==
   ASSUME NEW S, NEW s \in Seq(S), NEW t \in Seq(S), NEW u \in Seq(S)
   PROVE  IsSuffix(s \o t, u \o t) <=> IsSuffix(s, u)
 <1>1. ASSUME IsSuffix(s, u) PROVE IsSuffix(s \o t, u \o t)
-  <2>1. PICK v \in Seq(S) : u = v \o s  BY <1>1, IsSuffixProperties, Zenon
+  <2>1. PICK v \in Seq(S) : u = v \o s  BY <1>1, IsSuffixProperties
   <2>2. u \o t = v \o (s \o t)  BY <2>1
-  <2>. QED  BY s \o t \in Seq(S), u \o t \in Seq(S), <2>2, IsSuffixProperties, Zenon
+  <2>. QED  BY s \o t \in Seq(S), u \o t \in Seq(S), <2>2, IsSuffixProperties
 <1>2. ASSUME IsSuffix(s \o t, u \o t) PROVE IsSuffix(s, u)
   <2>1. PICK v \in Seq(S) : u \o t = v \o (s \o t)
-    BY <1>2, s \o t \in Seq(S), u \o t \in Seq(S), IsSuffixProperties, Zenon
+    BY <1>2, s \o t \in Seq(S), u \o t \in Seq(S), IsSuffixProperties
   <2>2. u \o t = (v \o s) \o t
     BY <2>1
   <2>3. u = v \o s
-    BY <2>2, ConcatSimplifications(*!cancelRight*), v \o s \in Seq(S), Zenon
-  <2>. QED  BY <2>3, IsSuffixProperties, Zenon
+    BY <2>2, ConcatSimplifications(*!cancelRight*), v \o s \in Seq(S)
+  <2>. QED  BY <2>3, IsSuffixProperties
 <1>. QED  BY <1>1, <1>2
 
 THEOREM AppendIsSuffixCancel ==
   ASSUME NEW S, NEW e \in S, NEW s \in Seq(S), NEW t \in Seq(S)
   PROVE  IsSuffix(Append(s,e), Append(t,e)) <=> IsSuffix(s,t)
-BY <<e>> \in Seq(S), ConcatIsSuffixCancel, AppendIsConcat, Isa
+<1>1. IsSuffix(Append(s,e), Append(t,e)) <=> IsSuffix(s \o <<e>>, t \o <<e>>)
+  BY AppendIsConcat
+<1>2. @ <=> IsSuffix(s,t)
+  BY <<e>> \in Seq(S), ConcatIsSuffixCancel, Zenon
+<1>. QED  BY <1>1, <1>2
 
 THEOREM AppendIsSuffix ==
   ASSUME NEW S, NEW e \in S, NEW s \in Seq(S), NEW u \in Seq(S),
@@ -658,7 +661,7 @@ THEOREM AppendIsSuffix ==
 <1>1. IsSuffix(<<e>>, u)
   BY ConcatIsSuffix, AppendIsConcat, Zenon
 <1>2. PICK v \in Seq(S) : u = Append(v,e)
-  BY <1>1, IsSuffixProperties, AppendIsConcat, Isa
+  BY <1>1, IsSuffixProperties, AppendIsConcat
 <1>3. /\ e = Last(u)
       /\ v = Front(u)
       /\ IsSuffix(Append(s,e), Append(Front(u),e))
@@ -671,7 +674,23 @@ THEOREM IsStrictSuffixStrictPartialOrder ==
   PROVE  /\ \A s \in Seq(S) : ~ IsStrictSuffix(s,s)
          /\ \A s,t \in Seq(S) : IsStrictSuffix(s,t) => ~ IsStrictSuffix(t,s)
          /\ \A s,t,u \in Seq(S) : IsStrictSuffix(s,t) /\ IsStrictSuffix(t,u) => IsStrictSuffix(s,u)
-BY IsStrictSuffixProperties, IsSuffixPartialOrder
+<1>1. ASSUME NEW s \in Seq(S)
+      PROVE  ~ IsStrictSuffix(s,s)
+  BY <1>1, IsStrictSuffixProperties
+<1>2. ASSUME NEW s \in Seq(S), NEW t \in Seq(S), IsStrictSuffix(s,t), IsStrictSuffix(t,s)
+      PROVE  FALSE
+  BY <1>2, IsStrictSuffixProperties
+<1>3. ASSUME NEW s \in Seq(S), NEW t \in Seq(S), NEW u \in Seq(S),
+             IsStrictSuffix(s,t), IsStrictSuffix(t,u)
+      PROVE  IsStrictSuffix(s,u)
+  <2>1. PICK st \in Seq(S) \ {<<>>} : t = st \o s
+    BY <1>3, IsStrictSuffixProperties
+  <2>2. PICK tu \in Seq(S) \ {<<>>} : u = tu \o t
+    BY <1>3, IsStrictSuffixProperties
+  <2>3. u = (tu \o st) \o s
+    BY <2>1, <2>2
+  <2>. QED  BY <2>3, tu \o st # <<>>, IsStrictSuffixProperties
+<1> QED  BY <1>1, <1>2, <1>3
 
 THEOREM IsStrictSuffixWellFounded ==
   ASSUME NEW S
@@ -749,14 +768,14 @@ BY Isa DEF StrictSuffixesDetermineDef, WFDefOn, OpToRel, SetLessThan
 THEOREM SuffixRecursiveSequenceFunctionUnique ==
   ASSUME NEW S, NEW Def(_,_), StrictSuffixesDetermineDef(S, Def)
   PROVE  WFInductiveUnique(Seq(S), Def)
-BY StrictSuffixesDetermineDef_WFDefOn, IsStrictSuffixWellFounded, WFDefOnUnique
+BY StrictSuffixesDetermineDef_WFDefOn, IsStrictSuffixWellFounded, WFDefOnUnique, Zenon
 
 THEOREM SuffixRecursiveSequenceFunctionDef ==
   ASSUME NEW S, NEW Def(_,_), NEW f,
          StrictSuffixesDetermineDef(S, Def),
          OpDefinesFcn(f, Seq(S), Def)
   PROVE  WFInductiveDefines(f, Seq(S), Def)
-BY StrictSuffixesDetermineDef_WFDefOn, IsStrictSuffixWellFounded, WFInductiveDef
+BY StrictSuffixesDetermineDef_WFDefOn, IsStrictSuffixWellFounded, WFInductiveDef, Zenon
 
 THEOREM SuffixRecursiveSequenceFunctionType ==
   ASSUME NEW S, NEW T, NEW Def(_,_), NEW f,
@@ -800,7 +819,7 @@ THEOREM TailInductiveDef ==
     BY <2>2, TailIsSuffix, Tail(seq) \in Seq(S), Zenon
   <2>. QED  BY <2>1, <2>2, Zenon
 <1>2. OpDefinesFcn(f, Seq(S), Op)
-  BY DEF OpDefinesFcn, TailInductiveDefHypothesis
+  BY DEF OpDefinesFcn, TailInductiveDefHypothesis, Zenon
 <1>3. WFInductiveDefines(f, Seq(S), Op)
   BY <1>1, <1>2, SuffixRecursiveSequenceFunctionDef, Zenon
 <1>. QED  BY <1>3, Zenon DEF WFInductiveDefines, TailInductiveDefConclusion
@@ -848,7 +867,7 @@ THEOREM FrontInductiveDef ==
     BY <2>2, FrontIsPrefix, FrontProperties
   <2>. QED  BY <2>1, <2>2, Zenon
 <1>2. OpDefinesFcn(f, Seq(S), Op)
-  BY DEF OpDefinesFcn, FrontInductiveDefHypothesis
+  BY DEF OpDefinesFcn, FrontInductiveDefHypothesis, Zenon
 <1>3. WFInductiveDefines(f, Seq(S), Op)
   BY <1>1, <1>2, PrefixRecursiveSequenceFunctionDef, Zenon
 <1>. QED  BY <1>3, Zenon DEF WFInductiveDefines, FrontInductiveDefConclusion

--- a/library/WellFoundedInduction_proofs.tla
+++ b/library/WellFoundedInduction_proofs.tla
@@ -51,7 +51,7 @@ LEMMA IsWellFoundedOnSubset ==
         ASSUME NEW R, NEW S, NEW T \in SUBSET S,
                IsWellFoundedOn(R,S)
         PROVE  IsWellFoundedOn(R,T)
-BY DEF IsWellFoundedOn
+BY Zenon DEF IsWellFoundedOn
 
 
 LEMMA IsWellFoundedOnSubrelation ==
@@ -90,9 +90,9 @@ THEOREM WFMin ==
            f[n \in Nat] == IF n = 0 THEN f0 ELSE Def(f[n-1], n)
 <1>1. NatInductiveDefConclusion(f, f0, Def)
   <2>1. NatInductiveDefHypothesis(f, f0, Def)
-    BY DEF NatInductiveDefHypothesis
+    BY Zenon DEF NatInductiveDefHypothesis
   <2>. QED
-    BY <2>1, NatInductiveDef
+    BY <2>1, NatInductiveDef, Zenon
 <1>2. f \in [Nat -> T]
   <2>1. f0 \in T
     OBVIOUS
@@ -102,15 +102,7 @@ THEOREM WFMin ==
     BY <1>1, <2>1, <2>2, NatInductiveDefType, Isa
 <1>3. ASSUME NEW n \in Nat
       PROVE  <<f[n+1], f[n]>> \in R
-  (* FIXME: SMT backend raises exception "Index past end of list"
-  BY <1>1, <1>2 DEF NatInductiveDefConclusion
-  *)
-  <2>. /\ n+1 \in Nat
-       /\ n+1 # 0
-       /\ (n+1)-1 = n
-    OBVIOUS
-  <2>. QED
-    BY <1>1, <1>2, Zenon DEF NatInductiveDefConclusion
+  BY <1>1, <1>2, n+1 \in Nat \ {0}, (n+1)-1 = n, Zenon DEF NatInductiveDefConclusion
 <1>. QED
   BY <1>2, <1>3, Zenon DEF IsWellFoundedOn
 
@@ -250,7 +242,6 @@ LEMMA WFInductiveDefLemma ==
              /\ \A y \in LT(x) : SetLessThan(y, R, S) \subseteq LT(x)
              /\ \A y \in LT(x) : LT(y) \subseteq LT(x)
              /\ LT(x) \subseteq S
-  \* FIXME: SMT backend fails with exception
   BY Isa DEF SetLessThan, IsTransitivelyClosedOn
 <1> HIDE DEF LT  \** from now on, (mostly) use properties in step <1>1 rather than the definition
 
@@ -271,9 +262,9 @@ LEMMA WFInductiveDefLemma ==
     <3>3. \A z \in LT(x) : SetLessThan(z, R, LT(x)) = SetLessThan(z, R, S)
       BY DEF LT, SetLessThan, IsTransitivelyClosedOn
     <3>4. WFDefOn(R, LT(x), Def)
-      BY <3>1, <3>3, IsaM("blast") DEF WFDefOn
+      BY <3>1, <3>3 DEF WFDefOn
     <3>. QED
-      BY <3>2, <3>4, WFDefOnUnique
+      BY <3>2, <3>4, WFDefOnUnique, Zenon
   <2> DEFINE g == [y \in LT(x) |-> Def(ff, y)]
   <2>3. Def(ff,x) = Def(g,x)
     BY <1>1 (* x \in LT(x) *), <2>1, Zenon DEF WFDefOn
@@ -350,13 +341,13 @@ LEMMA TCRTC ==
        ASSUME NEW R, NEW S, NEW i \in S, NEW j \in S, NEW k \in S,
               <<i,j>> \in TransitiveClosureOn(R,S), <<j,k>> \in R
        PROVE  <<i,k>> \in TransitiveClosureOn(R,S)
-BY TransitiveClosureThm, TCTCTC
+BY TransitiveClosureThm, TCTCTC, Zenon
 
 LEMMA RTCTC ==
        ASSUME NEW R, NEW S, NEW i \in S, NEW j \in S, NEW k \in S,
               <<i,j>> \in R, <<j,k>> \in TransitiveClosureOn(R,S)
        PROVE  <<i,k>> \in TransitiveClosureOn(R,S)
-BY TransitiveClosureThm, TCTCTC
+BY TransitiveClosureThm, TCTCTC, Zenon
 
 LEMMA TransitiveClosureChopLast ==
         ASSUME NEW R, NEW S, NEW i \in S, NEW k \in S, <<i,k>> \in TransitiveClosureOn(R,S)
@@ -392,7 +383,7 @@ LEMMA TransitiveClosureChopLast ==
     BY <2>3, <2>4
 <1>4. QED
   <2>1. TransitiveClosureOn(R,S) \subseteq U
-    BY <1>1, <1>3, TransitiveClosureMinimal
+    BY <1>1, <1>3, TransitiveClosureMinimal, Zenon
   <2>2. QED
     BY <2>1, Zenon
 
@@ -542,17 +533,12 @@ THEOREM NatLessThanWellFounded == IsWellFoundedOn(OpToRel(<,Nat), Nat)
     OBVIOUS
   <2> DEFINE g[i \in Nat] == f[i+1]
   <2>1. g \in [Nat -> Nat]
-    BY ONLY f \in [Nat -> Nat], Isa
+    OBVIOUS
   <2>2. \A i \in Nat : <<g[i+1], g[i]>> \in R
     BY Isa
   <2>3. g[0] \in 0..(n-1)
-    <3>1. f[1] < f[0]  BY Isa DEF OpToRel
-    <3>2. /\ f[1] \in Nat
-          /\ f[1] < n
-      BY <3>1
-    <3>3. f[1] \in 0 .. (n-1)
-      BY ONLY <3>2
-    <3>. QED  BY <3>3, Isa
+    <3>. f[1] < f[0]  BY Isa DEF OpToRel
+    <3>. QED  BY Isa
   <2>4 QED
     BY <2>1, <2>2, <2>3, <1>3
 <1>4. ~ P(ff[0])
@@ -690,7 +676,7 @@ THEOREM WFLexProductOrdering ==
         <5>2. CASE j = m+1
           <6>1. /\ g(x)[1] = g(y)[1]
                 /\ << g(x)[2], g(y)[2] >> \in R
-            BY <3>0, <5>2, IsaM("force")
+            BY <3>0, <5>2
           <6>2. QED
             BY <6>1 DEF LexPairOrdering
         <5>3. QED
@@ -737,6 +723,6 @@ THEOREM WFLexProductOrdering ==
 
 =============================================================================
 \* Modification History
-\* Last modified Sat Jan 04 12:13:45 CET 2020 by merz
+\* Last modified Fri Jun 13 15:08:07 CEST 2025 by merz
 \* Last modified Sun Jan 01 18:39:23 CET 2012 by merz
 \* Last modified Wed Nov 23 10:13:18 PST 2011 by lamport

--- a/src/backend/isabelle.ml
+++ b/src/backend/isabelle.ml
@@ -180,7 +180,7 @@ let rec pp_apply sd cx ff op args = match op.core with
         | B.Lt, [e ; f] -> nonfix "less" [e ; f]
         | B.Gteq, [e ; f] -> nonfix "geq" [e ; f]
         | B.Gt, [e ; f] -> nonfix "greater" [e ; f]
-        | B.Range, [e ; f] -> nonfix (cook "..") [e ; f]
+        | B.Range, [e ; f] -> nonfix "intvl" [e ; f]   (* nonfix (cook "..") [e ; f] *)
         (* Sequence operators *)
         | B.Seq, [e] -> nonfix "Seq" [e]
         | B.Len, [e] -> nonfix "Len" [e]
@@ -451,7 +451,7 @@ and fmt_expr sd cx e = match e.core with
   | Num (m, "") ->
       let rec uloop = function
         | 0 -> "0"
-        | n -> "Succ[" ^ uloop (n - 1) ^ "]"
+        | n -> "succ[" ^ uloop (n - 1) ^ "]"
       in
       Fu.Atm (fun ff -> fprintf ff "(%s)" (uloop (int_of_string m)))
   | Num (m, n) -> raise (Unsupported "real constants")
@@ -593,7 +593,7 @@ let thy_header ?(verbose=true) modname oc =
   Printf.fprintf oc "theory %s imports Constant Zenon begin\n" modname;
   if verbose then
     Printf.fprintf oc
-                   "ML_command {* writeln (\"*** TLAPS PARSED\\n\"); *}\n";
+                   "ML_command \\<open> writeln (\"*** TLAPS PARSED\\n\"); \\<close>\n";
   let tdoms_table = [
     cook "Real"     , 0, None;
     cook "/"        , 2, None;
@@ -648,12 +648,12 @@ let thy_write thyout ob proof =
     Printf.fprintf thyout "%s" statement;
     Printf.fprintf thyout "(is \"PROP ?ob'%d\")\n" obid;
     Printf.fprintf thyout "proof -\n";
-    Printf.fprintf thyout "ML_command {* writeln \"*** TLAPS ENTER %d\"; *}\n"
+    Printf.fprintf thyout "ML_command \\<open> writeln \"*** TLAPS ENTER %d\"; \\<close>\n"
                    obid;
     Printf.fprintf thyout "show \"PROP ?ob'%d\"\n" obid;
     Printf.fprintf thyout "%s" proof;
     Printf.fprintf thyout
-                   "ML_command {* writeln \"*** TLAPS EXIT %d\"; *} qed\n"
+                   "ML_command \\<open> writeln \"*** TLAPS EXIT %d\"; \\<close> qed\n"
                    obid;
   with Failure msg ->
     Errors.warn "Proof of obligation %d cannot be checked:\n%s\n" obid msg

--- a/src/encode/n_axioms.ml
+++ b/src/encode/n_axioms.ml
@@ -4295,15 +4295,9 @@ let seqsubseq_typing ~disable_arithmetic =
     ] %% []
   ] ]
   ( appb B.Implies
-    [ List (And,
-      [ apps T.Mem
-        [ Ix 3 %% []
-        ; apps T.SeqSeq
-          [ Ix 4 %% []
-          ] %% []
-        ] %% []
-      ] @
-      (if disable_arithmetic then
+    [ List (Or,
+      [ if disable_arithmetic then
+        List (And,
         [ apps T.Mem
           [ Ix 2 %% []
           ; apps T.IntSet [] %% []
@@ -4312,34 +4306,66 @@ let seqsubseq_typing ~disable_arithmetic =
           [ Ix 1 %% []
           ; apps T.IntSet [] %% []
           ] %% []
-        ]
-      else []) @
-      [ if disable_arithmetic then
-        apps T.IntLteq
-        [ apps (T.IntLit 1) [] %% []
-        ; Ix 2 %% []
-        ] %% []
-      else
-        apps T.TIntLteq
-        [ apps (T.TIntLit 1) [] %% []
-        ; Ix 2 %% []
-        ] %% []
-      ; if disable_arithmetic then
-        apps T.IntLteq
-        [ Ix 1 %% []
-        ; apps T.SeqLen
-          [ Ix 3 %% []
+        ; apps T.IntLteq
+          [ Ix 1 %% []
+          ; Ix 2 %% []
           ] %% []
-        ] %% []
+        ; appb ~tys:[ t_idv ] B.Neq
+          [ Ix 1 %% []
+          ; Ix 2 %% []
+          ] %% []
+        ]) %% []
       else
-        apps T.TIntLteq
+        apps T.TIntLt
         [ Ix 1 %% []
-        ; apps (T.Proj t_int)
-          [ apps T.SeqLen
+        ; Ix 2 %% []
+        ] %% []
+      ; List (And,
+        [ apps T.Mem
+          [ Ix 3 %% []
+          ; apps T.SeqSeq
+            [ Ix 4 %% []
+            ] %% []
+          ] %% []
+        ] @
+        (if disable_arithmetic then
+          [ apps T.Mem
+            [ Ix 2 %% []
+            ; apps T.IntSet [] %% []
+            ] %% []
+          ; apps T.Mem
+            [ Ix 1 %% []
+            ; apps T.IntSet [] %% []
+            ] %% []
+          ]
+        else []) @
+        [ if disable_arithmetic then
+          apps T.IntLteq
+          [ apps (T.IntLit 1) [] %% []
+          ; Ix 2 %% []
+          ] %% []
+        else
+          apps T.TIntLteq
+          [ apps (T.TIntLit 1) [] %% []
+          ; Ix 2 %% []
+          ] %% []
+        ; if disable_arithmetic then
+          apps T.IntLteq
+          [ Ix 1 %% []
+          ; apps T.SeqLen
             [ Ix 3 %% []
             ] %% []
           ] %% []
-        ] %% []
+        else
+          apps T.TIntLteq
+          [ Ix 1 %% []
+          ; apps (T.Proj t_int)
+            [ apps T.SeqLen
+              [ Ix 3 %% []
+              ] %% []
+            ] %% []
+          ] %% []
+        ]) %% []
       ]) %% []
     ; apps T.Mem
       [ apps T.SeqSubSeq


### PR DESCRIPTION
This PR upgrades the Isabelle backend to Isabelle2025 and also fixes all proofs in the standard library of theorems. This also required a subtle change to the SMT backend contributed by @rozlynd.
