### PR TITLE
Make LSP independent of level calculations (2nd attempt).

### DIFF
--- a/lsp/lib/docs/proof_step.ml
+++ b/lsp/lib/docs/proof_step.ml
@@ -392,7 +392,12 @@ let of_module (mule : Tlapm_lib.Module.T.mule) prev : t option =
            proof status between the modifications. *)
         let o =
           match o.fingerprint with
-          | None -> Tlapm_lib.Backend.Prep.prepare_obligation o
+          | None ->
+              (* `Tlapm_lib.Backend.Prep.prepare_obligation o` works too slow here. *)
+              let fingerprint =
+                Tlapm_lib.Backend.Fingerprints.fingerprint ~ignore_levels:true o
+              in
+              { o with fingerprint = Some fingerprint }
           | Some _ -> o
         in
         let o = Obl.of_parsed_obligation o in

--- a/src/backend.mli
+++ b/src/backend.mli
@@ -27,8 +27,8 @@ module Prep: sig
 end
 
 module Fingerprints: sig
-    val write_fingerprint:
-        Proof.T.obligation -> Proof.T.obligation
+    val fingerprint:
+        ?ignore_levels:bool -> Proof.T.obligation -> string
 end
 
 module Fpfile: sig

--- a/src/backend/fingerprints.mli
+++ b/src/backend/fingerprints.mli
@@ -6,3 +6,13 @@ Copyright (C) 2011  INRIA and Microsoft Corporation
 (* tlapm.ml *)
 val write_fingerprint:
     Proof.T.obligation -> Proof.T.obligation
+
+val fingerprint:
+    ?ignore_levels:bool -> Proof.T.obligation -> string
+(** Returns a fingerprint for an obligation. By default the levels
+    are expected to be assigned to the expressions in the obligation
+    and are used when calculating the fingerprint. If [~ignore_levels]
+    is set to [true], level information will be ignored. This is
+    only added for calculating a hash of an obligation fast enough
+    to use it in the LSP server. It must not be used to lookup the
+    proof state in the actual proof-checking. *)


### PR DESCRIPTION
Added an option to ignore the level information while calculating a fingerprint.
By default, it is false; thus, the existing behaviour is retained.
The fingerprints with levels ignored are only used as hash functions to transfer proof state between the document versions in the LSP.

This time, the tests are passing.