### PR TITLE
Compare TLAPM AST with expected AST in syntax tests

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -43,6 +43,7 @@
   ocaml
   dune-site
   dune-build-info
+  sexp_diff
   sexplib
   cmdliner
   camlzip

--- a/src/pars.mli
+++ b/src/pars.mli
@@ -11,7 +11,7 @@ module Error : sig
   val err_add_internal : string -> error -> error
   val err_add_expecting : string -> error -> error
   val err_set_unexpected : string -> error -> error
-  val print_error : ?verbose:bool -> Stdlib.out_channel -> error -> unit
+  val print_error : ?send_output:(out_channel -> string -> unit) -> ?verbose:bool -> Stdlib.out_channel -> error -> unit
 end
 
 module Intf : sig
@@ -65,6 +65,7 @@ module Pco : sig
     module Prec : Intf.Prec
     type ('s, 'a) prs
     val run :
+      ?send_output:(out_channel -> string -> unit) ->
       ('s, 'a) prs ->
       init:'s ->
       source:Tok.token LazyList.t ->

--- a/src/pars/error.ml
+++ b/src/pars/error.ml
@@ -14,7 +14,7 @@ type error = Error of error_ * Loc.locus
 type t = error
 
 (* FIXME make this return a string *)
-let print_error ?(verbose = false) ouch (Error (err, locus)) =
+let print_error ?(send_output = output_string) ?(verbose = false) ouch (Error (err, locus)) =
   let unexp =
     match err.err_unex with
       | None -> ""
@@ -39,11 +39,11 @@ let print_error ?(verbose = false) ouch (Error (err, locus)) =
                         (List.unique (err.err_msgs)))
   in
   let loc = Printf.sprintf "%s\n" (Loc.string_of_locus locus) in
-  output_string ouch loc;
-  output_string ouch unexp ;
-  output_string ouch exps ;
-  output_string ouch msgs ;
-  output_string ouch ints ;
+  send_output ouch loc;
+  send_output ouch unexp ;
+  send_output ouch exps ;
+  send_output ouch msgs ;
+  send_output ouch ints ;
   flush ouch;
 
   Errors.set

--- a/src/pars/error.mli
+++ b/src/pars/error.mli
@@ -27,4 +27,4 @@ val err_set_unexpected : string -> error -> error
   (** Set the "unexpected" message (adding one if it doesn't exist) *)
 
 (** Print the error on a given output channel. *)
-val print_error : ?verbose:bool -> Stdlib.out_channel -> error -> unit
+val print_error : ?send_output:(out_channel -> string -> unit) -> ?verbose:bool -> Stdlib.out_channel -> error -> unit

--- a/src/pars/pco.ml
+++ b/src/pars/pco.ml
@@ -26,6 +26,7 @@ module type Make_sig = sig
       possible parsed value. On success, the input contains the
       unparsed suffix. On failure, the input is left untouched. *)
   val run :
+    ?send_output:(out_channel -> string -> unit) ->
     ('s, 'a) prs ->
     init:'s ->
     source:Tok.token LazyList.t ->
@@ -242,7 +243,7 @@ module Make (Tok : Intf.Tok) (Prec : Intf.Prec) = struct
 
   let exec (Prs ap) pst = ap pst
 
-  let execute ap pst =
+  let execute ?(send_output = output_string) ap pst =
     let rep = exec ap pst in
       match rep.res with
         | Parsed a -> Some a
@@ -253,10 +254,10 @@ module Make (Tok : Intf.Tok) (Prec : Intf.Prec) = struct
               | Message msg -> Error.err_add_message msg err
               | Internal msg -> Error.err_add_internal msg err
             in
-              Error.print_error ~verbose:true stderr err ;
+              Error.print_error ~send_output ~verbose:true stderr err ;
               None
 
-  let run ap ~init ~source =
+  let run ?(send_output = output_string) ap ~init ~source =
     let pst = { source = source ;
                 ustate = init ;
                 lastpos = begin
@@ -267,7 +268,7 @@ module Make (Tok : Intf.Tok) (Prec : Intf.Prec) = struct
                             { loc with Loc.start = loc.Loc.stop }
                 end ;
               }
-    in execute ap pst
+    in execute ~send_output ap pst
 
   (* primitive parsers *)
 

--- a/src/pars/pco.mli
+++ b/src/pars/pco.mli
@@ -26,6 +26,7 @@ module type Make_sig = sig
       possible parsed value. On success, the input contains the
       unparsed suffix. On failure, the input is left untouched. *)
   val run :
+    ?send_output:(out_channel -> string -> unit) ->
     ('s, 'a) prs ->
     init:'s ->
     source:Tok.token LazyList.t ->

--- a/src/tlapm_lib.ml
+++ b/src/tlapm_lib.ml
@@ -652,9 +652,9 @@ let modctx_of_string ~(content : string) ~(filename : string) ~loader_paths ~pre
          | Some l, None -> Error (Some l, Printexc.to_string e)
          | None, None -> Error (None, Printexc.to_string e))
 
-let module_of_string module_str =
+let module_of_string ?(send_output = output_string) module_str =
     let hparse = Tla_parser.P.use Module.Parser.parse in
     let (flex, _) = Alexer.lex_string module_str in
-    Tla_parser.P.run hparse ~init:Tla_parser.init ~source:flex
+    Tla_parser.P.run hparse ~send_output ~init:Tla_parser.init ~source:flex
 
 let stdlib_search_paths = Params.stdlib_search_paths

--- a/src/tlapm_lib.ml
+++ b/src/tlapm_lib.ml
@@ -653,7 +653,7 @@ let modctx_of_string ~(content : string) ~(filename : string) ~loader_paths ~pre
          | None, None -> Error (None, Printexc.to_string e))
 
 let module_of_string module_str =
-    let hparse = Tla_parser.P.use M_parser.parse in
+    let hparse = Tla_parser.P.use Module.Parser.parse in
     let (flex, _) = Alexer.lex_string module_str in
     Tla_parser.P.run hparse ~init:Tla_parser.init ~source:flex
 

--- a/src/tlapm_lib.mli
+++ b/src/tlapm_lib.mli
@@ -25,7 +25,7 @@ val modctx_of_string :
     from a specified string, assume it is located in the
     specified path. *)
 
-val module_of_string : string -> M_t.mule option
+val module_of_string : string -> Module.T.mule option
 (** Parse the specified string as a module. No dependencies
     are considered, nor proof obligations are elaborated. *)
 

--- a/src/tlapm_lib.mli
+++ b/src/tlapm_lib.mli
@@ -25,7 +25,7 @@ val modctx_of_string :
     from a specified string, assume it is located in the
     specified path. *)
 
-val module_of_string : string -> Module.T.mule option
+val module_of_string : ?send_output:(out_channel -> string -> unit) -> string -> Module.T.mule option
 (** Parse the specified string as a module. No dependencies
     are considered, nor proof obligations are elaborated. *)
 

--- a/test/parser/dune
+++ b/test/parser/dune
@@ -1,7 +1,7 @@
 (test
  (name parser_tests)
  (modes exe)
- (libraries tlapm_lib ounit2 sexplib)
+ (libraries tlapm_lib ounit2 sexplib sexp_diff)
  (deps (glob_files_rec syntax_corpus/*))
  (preprocess (pps ppx_deriving.show))
 )

--- a/test/parser/parser_tests.ml
+++ b/test/parser/parser_tests.ml
@@ -84,7 +84,6 @@ let expect_failure (test : syntax_test) : bool =
 let should_skip_tree_comparison (test : syntax_test) : bool =
   List.mem test.info.path [
     "syntax_corpus/assume-prove.txt";
-    "syntax_corpus/case.txt";
     "syntax_corpus/except.txt";
     "syntax_corpus/expressions.txt";
     "syntax_corpus/fairness.txt";

--- a/test/parser/parser_tests.ml
+++ b/test/parser/parser_tests.ml
@@ -8,9 +8,7 @@
 open Tlapm_lib;;
 
 open Syntax_corpus_file_parser;;
-open Translate_syntax_tree;;
 
-open Sexplib;;
 open OUnit2;;
 
 (** Calls TLAPM's parser with the given input. Catches all exceptions and
@@ -91,7 +89,6 @@ let should_skip_tree_comparison (test : syntax_test) : bool =
     "syntax_corpus/infix_op.txt";
     "syntax_corpus/labels.txt";
     "syntax_corpus/let_in.txt";
-    "syntax_corpus/modules.txt";
     "syntax_corpus/number.txt";
     "syntax_corpus/operators.txt";
     "syntax_corpus/postfix_op.txt";
@@ -127,7 +124,9 @@ let tests = "Standardized syntax test corpus" >::: (
           | None -> assert_bool "Expected parse success" (expect_failure test)
           | Some tlapm_output ->
             skip_if (should_skip_tree_comparison test) "Skipping parse tree comparison";
-            let actual = tlapm_output |> translate_module |> ts_node_to_sexpr in
+            let open Translate_syntax_tree in
+            let open Sexplib in
+            let actual = tlapm_output |> translate_tla_source_file |> ts_node_to_sexpr in
             if Sexp.equal expected actual
             then assert_bool "Expected parse test to fail" (not (expect_failure test))
             else

--- a/test/parser/parser_tests.ml
+++ b/test/parser/parser_tests.ml
@@ -89,7 +89,6 @@ let should_skip_tree_comparison (test : syntax_test) : bool =
     "syntax_corpus/fairness.txt";
     "syntax_corpus/functions.txt";
     "syntax_corpus/infix_op.txt";
-    "syntax_corpus/jlist.txt";
     "syntax_corpus/labels.txt";
     "syntax_corpus/let_in.txt";
     "syntax_corpus/modules.txt";

--- a/test/parser/parser_tests.ml
+++ b/test/parser/parser_tests.ml
@@ -89,7 +89,6 @@ let should_skip (test : syntax_test) : bool =
     "syntax_corpus/expressions.txt";
     "syntax_corpus/fairness.txt";
     "syntax_corpus/functions.txt";
-    "syntax_corpus/if_then_else.txt";
     "syntax_corpus/infix_op.txt";
     "syntax_corpus/jlist.txt";
     "syntax_corpus/labels.txt";

--- a/test/parser/parser_tests.ml
+++ b/test/parser/parser_tests.ml
@@ -28,36 +28,7 @@ let parse (input : string) : Module.T.mule option =
     @return Whether the test is expected to fail.
 *)
 let expect_failure (test : syntax_test) : bool =
-  List.mem test.info.path [
-    "syntax_corpus/assume-prove.txt";
-    "syntax_corpus/case.txt";
-    "syntax_corpus/conjlist.txt";
-    "syntax_corpus/disjlist.txt";
-    "syntax_corpus/except.txt";
-    "syntax_corpus/expressions.txt";
-    "syntax_corpus/fairness.txt";
-    "syntax_corpus/functions.txt";
-    "syntax_corpus/if_then_else.txt";
-    "syntax_corpus/infix_op.txt";
-    "syntax_corpus/jlist.txt";
-    "syntax_corpus/labels.txt";
-    "syntax_corpus/let_in.txt";
-    "syntax_corpus/modules.txt";
-    "syntax_corpus/number.txt";
-    "syntax_corpus/operators.txt";
-    "syntax_corpus/postfix_op.txt";
-    "syntax_corpus/prefix_op.txt";
-    "syntax_corpus/proofs.txt";
-    "syntax_corpus/quantification.txt";
-    "syntax_corpus/records.txt";
-    "syntax_corpus/recursive.txt";
-    "syntax_corpus/sets.txt";
-    "syntax_corpus/step_expressions.txt";
-    "syntax_corpus/string.txt";
-    "syntax_corpus/subexpressions.txt";
-    "syntax_corpus/tuples.txt";
-    "syntax_corpus/use_or_hide.txt";
-  ] || List.mem test.info.name [
+  List.mem test.info.name [
 
     (* https://github.com/tlaplus/tlapm/issues/54#issuecomment-2435515180 *)
     "RECURSIVE inside LET/IN";
@@ -110,6 +81,39 @@ let expect_failure (test : syntax_test) : bool =
     "Nonfix Submodule Excl (GH tlaplus/tlaplus #GH884)";
     "Nonfix Double Exclamation Operator (GH TSTLA #GH97, GH tlaplus/tlaplus #884)";
   ]
+let should_skip (test : syntax_test) : bool =
+  List.mem test.info.path [
+    "syntax_corpus/assume-prove.txt";
+    "syntax_corpus/case.txt";
+    "syntax_corpus/disjlist.txt";
+    "syntax_corpus/except.txt";
+    "syntax_corpus/expressions.txt";
+    "syntax_corpus/fairness.txt";
+    "syntax_corpus/functions.txt";
+    "syntax_corpus/if_then_else.txt";
+    "syntax_corpus/infix_op.txt";
+    "syntax_corpus/jlist.txt";
+    "syntax_corpus/labels.txt";
+    "syntax_corpus/let_in.txt";
+    "syntax_corpus/modules.txt";
+    "syntax_corpus/number.txt";
+    "syntax_corpus/operators.txt";
+    "syntax_corpus/postfix_op.txt";
+    "syntax_corpus/prefix_op.txt";
+    "syntax_corpus/proofs.txt";
+    "syntax_corpus/quantification.txt";
+    "syntax_corpus/records.txt";
+    "syntax_corpus/recursive.txt";
+    "syntax_corpus/sets.txt";
+    "syntax_corpus/step_expressions.txt";
+    "syntax_corpus/string.txt";
+    "syntax_corpus/subexpressions.txt";
+    "syntax_corpus/tuples.txt";
+    "syntax_corpus/use_or_hide.txt";
+  ] || List.mem test.info.name [
+    (* Jlist terminated by single line comment omitted in TLAPM AST *)
+    "Keyword-Unit-Terminated Conjlist";
+  ]
 
 let tests = "Standardized syntax test corpus" >::: (
   get_all_tests_under "syntax_corpus"
@@ -117,6 +121,7 @@ let tests = "Standardized syntax test corpus" >::: (
     Format.sprintf "[%s] %s" test.info.path test.info.name >::
     (fun _ ->
       skip_if test.skip "Test has skip attribute";
+      skip_if (should_skip test) "Skip file";
       match test.test with
       | Error_test input -> (
         match parse input with

--- a/test/parser/parser_tests.ml
+++ b/test/parser/parser_tests.ml
@@ -107,7 +107,6 @@ let should_skip (test : syntax_test) : bool =
     "syntax_corpus/step_expressions.txt";
     "syntax_corpus/string.txt";
     "syntax_corpus/subexpressions.txt";
-    "syntax_corpus/tuples.txt";
     "syntax_corpus/use_or_hide.txt";
   ] || List.mem test.info.name [
     (* Jlist terminated by single line comment omitted in TLAPM AST *)

--- a/test/parser/parser_tests.ml
+++ b/test/parser/parser_tests.ml
@@ -85,7 +85,6 @@ let should_skip (test : syntax_test) : bool =
   List.mem test.info.path [
     "syntax_corpus/assume-prove.txt";
     "syntax_corpus/case.txt";
-    "syntax_corpus/disjlist.txt";
     "syntax_corpus/except.txt";
     "syntax_corpus/expressions.txt";
     "syntax_corpus/fairness.txt";
@@ -113,6 +112,7 @@ let should_skip (test : syntax_test) : bool =
   ] || List.mem test.info.name [
     (* Jlist terminated by single line comment omitted in TLAPM AST *)
     "Keyword-Unit-Terminated Conjlist";
+    "Keyword-Unit-Terminated Disjlist";
   ]
 
 let tests = "Standardized syntax test corpus" >::: (

--- a/test/parser/parser_tests.ml
+++ b/test/parser/parser_tests.ml
@@ -81,7 +81,7 @@ let expect_failure (test : syntax_test) : bool =
     "Nonfix Submodule Excl (GH tlaplus/tlaplus #GH884)";
     "Nonfix Double Exclamation Operator (GH TSTLA #GH97, GH tlaplus/tlaplus #884)";
   ]
-let should_skip (test : syntax_test) : bool =
+let should_skip_tree_comparison (test : syntax_test) : bool =
   List.mem test.info.path [
     "syntax_corpus/assume-prove.txt";
     "syntax_corpus/case.txt";
@@ -104,7 +104,6 @@ let should_skip (test : syntax_test) : bool =
     "syntax_corpus/recursive.txt";
     "syntax_corpus/sets.txt";
     "syntax_corpus/step_expressions.txt";
-    "syntax_corpus/string.txt";
     "syntax_corpus/subexpressions.txt";
     "syntax_corpus/use_or_hide.txt";
   ] || List.mem test.info.name [
@@ -119,7 +118,6 @@ let tests = "Standardized syntax test corpus" >::: (
     Format.sprintf "[%s] %s" test.info.path test.info.name >::
     (fun _ ->
       skip_if test.skip "Test has skip attribute";
-      skip_if (should_skip test) "Skip file";
       match test.test with
       | Error_test input -> (
         match parse input with
@@ -130,6 +128,7 @@ let tests = "Standardized syntax test corpus" >::: (
           match parse input with
           | None -> assert_bool "Expected parse success" (expect_failure test)
           | Some tlapm_output ->
+            skip_if (should_skip_tree_comparison test) "Skipping parse tree comparison";
             let actual = tlapm_output |> translate_module |> ts_node_to_sexpr in
             if Sexp.equal expected actual
             then assert_bool "Expected parse test to fail" (not (expect_failure test))

--- a/test/parser/parser_tests.ml
+++ b/test/parser/parser_tests.ml
@@ -163,3 +163,16 @@ let () =
   in
   print_endline (show_test_run_summary test_results);
   assert_equal 0 test_results.failed;
+
+open Translate_syntax_tree;;
+open Sexplib;;
+
+let () =
+  "---- MODULE Test ----\nEXTENDS Naturals, FiniteSets\n===="
+  |> Tlapm_lib.module_of_string
+  |> Option.get
+  |> translate_module
+  |> ts_node_to_sexpr
+  |> Sexp.to_string_hum
+  |> print_endline
+

--- a/test/parser/parser_tests.ml
+++ b/test/parser/parser_tests.ml
@@ -88,7 +88,6 @@ let should_skip_tree_comparison (test : syntax_test) : bool =
     "syntax_corpus/infix_op.txt";
     "syntax_corpus/labels.txt";
     "syntax_corpus/let_in.txt";
-    "syntax_corpus/operators.txt";
     "syntax_corpus/postfix_op.txt";
     "syntax_corpus/prefix_op.txt";
     "syntax_corpus/proofs.txt";
@@ -106,6 +105,11 @@ let should_skip_tree_comparison (test : syntax_test) : bool =
     
     (* Unnecessary parentheses omitted in TLAPM AST *)
     "Nested Parentheses";
+    
+    (* TLAPM AST does not distinguish between nonfix and infix ops *)
+    "Lexically-Conflicting Nonfix Operators";
+    "Minus and Negative";
+    "Nonfix Minus (GH tlaplus/tlaplus #GH884)";
   ]
 
 let tests = "Standardized syntax test corpus" >::: (

--- a/test/parser/parser_tests.ml
+++ b/test/parser/parser_tests.ml
@@ -30,7 +30,6 @@ let parse (input : string) : Module.T.mule option =
 let expect_failure (test : syntax_test) : bool =
   List.mem test.info.path [
     "syntax_corpus/assume-prove.txt";
-    "syntax_corpus/assume.txt";
     "syntax_corpus/case.txt";
     "syntax_corpus/conjlist.txt";
     "syntax_corpus/disjlist.txt";

--- a/test/parser/parser_tests.ml
+++ b/test/parser/parser_tests.ml
@@ -83,13 +83,11 @@ let should_skip_tree_comparison (test : syntax_test) : bool =
   List.mem test.info.path [
     "syntax_corpus/assume-prove.txt";
     "syntax_corpus/except.txt";
-    "syntax_corpus/expressions.txt";
     "syntax_corpus/fairness.txt";
     "syntax_corpus/functions.txt";
     "syntax_corpus/infix_op.txt";
     "syntax_corpus/labels.txt";
     "syntax_corpus/let_in.txt";
-    "syntax_corpus/number.txt";
     "syntax_corpus/operators.txt";
     "syntax_corpus/postfix_op.txt";
     "syntax_corpus/prefix_op.txt";
@@ -105,6 +103,9 @@ let should_skip_tree_comparison (test : syntax_test) : bool =
     (* Jlist terminated by single line comment omitted in TLAPM AST *)
     "Keyword-Unit-Terminated Conjlist";
     "Keyword-Unit-Terminated Disjlist";
+    
+    (* Unnecessary parentheses omitted in TLAPM AST *)
+    "Nested Parentheses";
   ]
 
 let tests = "Standardized syntax test corpus" >::: (

--- a/test/parser/syntax_corpus/case.txt
+++ b/test/parser/syntax_corpus/case.txt
@@ -11,8 +11,8 @@ op ==
 
 --------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (case
       (case_arm (nat_number) (case_arrow) (nat_number))
       (case_box) (case_arm (nat_number) (case_arrow) (nat_number))
@@ -31,8 +31,8 @@ op == CASE 1 -> 2
 
 --------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (case (case_arm (nat_number) (case_arrow) (nat_number)))
   )
 (double_line)))
@@ -50,8 +50,8 @@ op ==
 
 --------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (case (case_arm (nat_number) (case_arrow)
       (case
         (case_arm (nat_number) (case_arrow) (nat_number))
@@ -75,8 +75,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (conj_list
       (conj_item
         (bullet_conj)
@@ -116,8 +116,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (case
       (case_arm
         (conj_list (conj_item (bullet_conj) (nat_number)) (conj_item (bullet_conj) (nat_number)))
@@ -152,8 +152,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (disj_list
       (disj_item
         (bullet_disj)
@@ -193,8 +193,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (case
       (case_arm
         (disj_list (disj_item (bullet_disj) (nat_number)) (disj_item (bullet_disj) (nat_number)))
@@ -230,8 +230,8 @@ op ==
 
 --------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (conj_list
       (conj_item
         (bullet_conj)
@@ -278,8 +278,8 @@ op3 ==
 
 -------------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (case
       (case_arm (identifier_ref) (case_arrow) (conj_list (conj_item (bullet_conj)
         (case
@@ -292,7 +292,7 @@ op3 ==
       (case_arm (identifier_ref) (case_arrow) (identifier_ref))
     )
   )
-  (operator_definition (identifier) (def_eq)
+  (operator_definition name: (identifier) (def_eq) definition:
     (case
       (case_arm (identifier_ref) (case_arrow) (conj_list (conj_item (bullet_conj)
         (case
@@ -305,7 +305,7 @@ op3 ==
       (case_arm (identifier_ref) (case_arrow) (identifier_ref))
     )
   )
-  (operator_definition (identifier) (def_eq)
+  (operator_definition name: (identifier) (def_eq) definition:
     (case
       (case_arm (identifier_ref) (case_arrow) (conj_list
         (conj_item (bullet_conj)

--- a/test/parser/syntax_corpus/conjlist.txt
+++ b/test/parser/syntax_corpus/conjlist.txt
@@ -10,8 +10,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (conj_list
       (conj_item (bullet_conj) (nat_number))
       (conj_item (bullet_conj) (nat_number))
@@ -30,8 +30,8 @@ op == /\ 1
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (conj_list
       (conj_item (bullet_conj) (nat_number))
       (conj_item (bullet_conj) (nat_number))
@@ -51,8 +51,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (conj_list
       (conj_item (bullet_conj) (nat_number))
       (conj_item (bullet_conj) (nat_number))
@@ -72,12 +72,12 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (bound_infix_op
-      (conj_list (conj_item (bullet_conj) (nat_number)))
-      (land)
-      (nat_number)
+      lhs: (conj_list (conj_item (bullet_conj) (nat_number)))
+      symbol: (land)
+      rhs: (nat_number)
     )
   )
 (double_line)))
@@ -94,15 +94,15 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (conj_list
       (conj_item
         (bullet_conj)
         (bound_infix_op
-          (nat_number)
-          (land)
-          (nat_number)
+          lhs: (nat_number)
+          symbol: (land)
+          rhs: (nat_number)
         )
       )
     )
@@ -122,8 +122,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (conj_list
       (conj_item (bullet_conj) (nat_number))
       (conj_item (bullet_conj) (nat_number))
@@ -145,8 +145,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (conj_list
       (conj_item (bullet_conj) (nat_number))
       (conj_item (bullet_conj) (nat_number))
@@ -167,8 +167,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (conj_list
       (conj_item
         (bullet_conj)
@@ -195,8 +195,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (conj_list
       (conj_item (bullet_conj)
         (conj_list
@@ -222,15 +222,15 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (conj_list
       (conj_item
         (bullet_conj)
         (bound_infix_op
-          (nat_number)
-          (plus)
-          (nat_number)
+          lhs: (nat_number)
+          symbol: (plus)
+          rhs: (nat_number)
         )
       )
       (conj_item (bullet_conj) (nat_number))
@@ -251,15 +251,15 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (conj_list
       (conj_item
         (bullet_conj)
         (bound_infix_op
-          (nat_number)
-          (slash)
-          (nat_number)
+          lhs: (nat_number)
+          symbol: (slash)
+          rhs: (nat_number)
         )
       )
       (conj_item (bullet_conj) (nat_number))
@@ -280,16 +280,16 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (bound_infix_op
-      (bound_infix_op
-        (conj_list (conj_item (bullet_conj) (nat_number)))
-        (plus)
-        (nat_number)
+      lhs: (bound_infix_op
+        lhs: (conj_list (conj_item (bullet_conj) (nat_number)))
+        symbol: (plus)
+        rhs: (nat_number)
       )
-      (land)
-      (nat_number)
+      symbol: (land)
+      rhs: (nat_number)
     )
   )
 (double_line)))
@@ -307,16 +307,16 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (bound_infix_op
-      (bound_infix_op
-        (conj_list (conj_item (bullet_conj) (nat_number)))
-        (slash)
-        (nat_number)
+      lhs: (bound_infix_op
+        lhs: (conj_list (conj_item (bullet_conj) (nat_number)))
+        symbol: (slash)
+        rhs: (nat_number)
       )
-      (land)
-      (nat_number)
+      symbol: (land)
+      rhs: (nat_number)
     )
   )
 (double_line)))
@@ -331,12 +331,12 @@ op == 1 /\ 2
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (bound_infix_op
-      (nat_number)
-      (land)
-      (nat_number)
+      lhs: (nat_number)
+      symbol: (land)
+      rhs: (nat_number)
     )
   )
 (double_line)))
@@ -353,8 +353,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (conj_list
       (conj_item (bullet_conj) (parentheses (nat_number)))
       (conj_item (bullet_conj) (parentheses (nat_number)))
@@ -375,14 +375,14 @@ op == (
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (bound_infix_op
-      (parentheses
+      lhs: (parentheses
         (conj_list (conj_item (bullet_conj) (nat_number)))
       )
-      (land)
-      (nat_number)
+      symbol: (land)
+      rhs: (nat_number)
     )
   )
 (double_line)))
@@ -402,10 +402,10 @@ op == (
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (bound_infix_op
-      (parentheses
+      lhs: (parentheses
         (conj_list
           (conj_item (bullet_conj) (nat_number))
           (conj_item
@@ -417,8 +417,8 @@ op == (
           )
         )
       )
-      (land)
-      (nat_number)
+      symbol: (land)
+      rhs: (nat_number)
     )
   )
 (double_line)))
@@ -440,8 +440,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (conj_list
       (conj_item (bullet_conj) (nat_number))
       (conj_item
@@ -450,9 +450,9 @@ op ==
           (conj_item
             (bullet_conj)
             (bound_infix_op
-              (nat_number)
-              (plus)
-              (parentheses
+              lhs: (nat_number)
+              symbol: (plus)
+              rhs: (parentheses
                 (conj_list
                   (conj_item (bullet_conj) (nat_number))
                   (conj_item (bullet_conj) (nat_number))
@@ -479,8 +479,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (conj_list
       (conj_item (bullet_conj) (nat_number))
       (conj_item (bullet_conj) (nat_number))
@@ -522,36 +522,36 @@ op5 ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (conj_list
       (conj_item (bullet_conj) (nat_number))
       (conj_item (bullet_conj) (nat_number))
     )
   )
   (assumption (identifier_ref))
-  (operator_definition (identifier) (def_eq)
+  (operator_definition name: (identifier) (def_eq) definition:
     (conj_list
       (conj_item (bullet_conj) (nat_number))
       (conj_item (bullet_conj) (nat_number))
     )
   )
   (local_definition (instance (identifier_ref)))
-  (operator_definition (identifier) (def_eq)
+  (operator_definition name: (identifier) (def_eq) definition:
     (conj_list
       (conj_item (bullet_conj) (nat_number))
       (conj_item (bullet_conj) (nat_number))
     )
   )
   (single_line)
-  (operator_definition (identifier) (def_eq)
+  (operator_definition name: (identifier) (def_eq) definition:
     (conj_list
       (conj_item (bullet_conj) (nat_number))
       (conj_item (bullet_conj) (nat_number))
     )
   )
-  (module (header_line) (identifier) (header_line) (double_line))
-  (operator_definition (identifier) (def_eq)
+  (module (header_line) name: (identifier) (header_line) (double_line))
+  (operator_definition name: (identifier) (def_eq) definition:
     (conj_list
       (conj_item (bullet_conj) (nat_number))
       (conj_item (bullet_conj) (nat_number))
@@ -572,8 +572,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (conj_list
       (conj_item (bullet_conj) (nat_number))
       (conj_item (bullet_conj) (tuple_literal (langle_bracket) (rangle_bracket)))
@@ -593,8 +593,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (conj_list
       (conj_item (bullet_conj) (nat_number))
       (conj_item (bullet_conj) (finite_set_literal))

--- a/test/parser/syntax_corpus/disjlist.txt
+++ b/test/parser/syntax_corpus/disjlist.txt
@@ -10,8 +10,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (disj_list
       (disj_item (bullet_disj) (nat_number))
       (disj_item (bullet_disj) (nat_number))
@@ -30,8 +30,8 @@ op == \/ 1
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (disj_list
       (disj_item (bullet_disj) (nat_number))
       (disj_item (bullet_disj) (nat_number))
@@ -51,8 +51,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (disj_list
       (disj_item (bullet_disj) (nat_number))
       (disj_item (bullet_disj) (nat_number))
@@ -72,12 +72,12 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (bound_infix_op
-      (disj_list (disj_item (bullet_disj) (nat_number)))
-      (lor)
-      (nat_number)
+      lhs: (disj_list (disj_item (bullet_disj) (nat_number)))
+      symbol: (lor)
+      rhs: (nat_number)
     )
   )
 (double_line)))
@@ -94,15 +94,15 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (disj_list
       (disj_item
         (bullet_disj)
         (bound_infix_op
-          (nat_number)
-          (lor)
-          (nat_number)
+          lhs: (nat_number)
+          symbol: (lor)
+          rhs: (nat_number)
         )
       )
     )
@@ -122,8 +122,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (disj_list
       (disj_item (bullet_disj) (nat_number))
       (disj_item (bullet_disj) (nat_number))
@@ -145,8 +145,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (disj_list
       (disj_item (bullet_disj) (nat_number))
       (disj_item (bullet_disj) (nat_number))
@@ -167,8 +167,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (disj_list
       (disj_item
         (bullet_disj)
@@ -195,8 +195,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (disj_list
       (disj_item (bullet_disj)
         (disj_list
@@ -222,15 +222,15 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (disj_list
       (disj_item
         (bullet_disj)
         (bound_infix_op
-          (nat_number)
-          (plus)
-          (nat_number)
+          lhs: (nat_number)
+          symbol: (plus)
+          rhs: (nat_number)
         )
       )
       (disj_item (bullet_disj) (nat_number))
@@ -251,15 +251,15 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (disj_list
       (disj_item
         (bullet_disj)
         (bound_infix_op
-          (nat_number)
-          (slash)
-          (nat_number)
+          lhs: (nat_number)
+          symbol: (slash)
+          rhs: (nat_number)
         )
       )
       (disj_item (bullet_disj) (nat_number))
@@ -280,16 +280,16 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (bound_infix_op
-      (bound_infix_op
-        (disj_list (disj_item (bullet_disj) (nat_number)))
-        (plus)
-        (nat_number)
+      lhs: (bound_infix_op
+        lhs: (disj_list (disj_item (bullet_disj) (nat_number)))
+        symbol: (plus)
+        rhs: (nat_number)
       )
-      (lor)
-      (nat_number)
+      symbol: (lor)
+      rhs: (nat_number)
     )
   )
 (double_line)))
@@ -307,16 +307,16 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (bound_infix_op
-      (bound_infix_op
-        (disj_list (disj_item (bullet_disj) (nat_number)))
-        (slash)
-        (nat_number)
+      lhs: (bound_infix_op
+        lhs: (disj_list (disj_item (bullet_disj) (nat_number)))
+        symbol: (slash)
+        rhs: (nat_number)
       )
-      (lor)
-      (nat_number)
+      symbol: (lor)
+      rhs: (nat_number)
     )
   )
 (double_line)))
@@ -331,12 +331,12 @@ op == 1 \/ 2
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (bound_infix_op
-      (nat_number)
-      (lor)
-      (nat_number)
+      lhs: (nat_number)
+      symbol: (lor)
+      rhs: (nat_number)
     )
   )
 (double_line)))
@@ -353,8 +353,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (disj_list
       (disj_item (bullet_disj) (parentheses (nat_number)))
       (disj_item (bullet_disj) (parentheses (nat_number)))
@@ -375,14 +375,14 @@ op == (
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (bound_infix_op
-      (parentheses
+      lhs: (parentheses
         (disj_list (disj_item (bullet_disj) (nat_number)))
       )
-      (lor)
-      (nat_number)
+      symbol: (lor)
+      rhs: (nat_number)
     )
   )
 (double_line)))
@@ -402,10 +402,10 @@ op == (
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (bound_infix_op
-      (parentheses
+      lhs: (parentheses
         (disj_list
           (disj_item (bullet_disj) (nat_number))
           (disj_item
@@ -417,8 +417,8 @@ op == (
           )
         )
       )
-      (lor)
-      (nat_number)
+      symbol: (lor)
+      rhs: (nat_number)
     )
   )
 (double_line)))
@@ -440,8 +440,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (disj_list
       (disj_item (bullet_disj) (nat_number))
       (disj_item
@@ -450,9 +450,9 @@ op ==
           (disj_item
             (bullet_disj)
             (bound_infix_op
-              (nat_number)
-              (plus)
-              (parentheses
+              lhs: (nat_number)
+              symbol: (plus)
+              rhs: (parentheses
                 (disj_list
                   (disj_item (bullet_disj) (nat_number))
                   (disj_item (bullet_disj) (nat_number))
@@ -479,8 +479,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (disj_list
       (disj_item (bullet_disj) (nat_number))
       (disj_item (bullet_disj) (nat_number))
@@ -522,36 +522,36 @@ op5 ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (disj_list
       (disj_item (bullet_disj) (nat_number))
       (disj_item (bullet_disj) (nat_number))
     )
   )
   (assumption (identifier_ref))
-  (operator_definition (identifier) (def_eq)
+  (operator_definition name: (identifier) (def_eq) definition:
     (disj_list
       (disj_item (bullet_disj) (nat_number))
       (disj_item (bullet_disj) (nat_number))
     )
   )
   (local_definition (instance (identifier_ref)))
-  (operator_definition (identifier) (def_eq)
+  (operator_definition name: (identifier) (def_eq) definition:
     (disj_list
       (disj_item (bullet_disj) (nat_number))
       (disj_item (bullet_disj) (nat_number))
     )
   )
   (single_line)
-  (operator_definition (identifier) (def_eq)
+  (operator_definition name: (identifier) (def_eq) definition:
     (disj_list
       (disj_item (bullet_disj) (nat_number))
       (disj_item (bullet_disj) (nat_number))
     )
   )
-  (module (header_line) (identifier) (header_line) (double_line))
-  (operator_definition (identifier) (def_eq)
+  (module (header_line) name: (identifier) (header_line) (double_line))
+  (operator_definition name: (identifier) (def_eq) definition:
     (disj_list
       (disj_item (bullet_disj) (nat_number))
       (disj_item (bullet_disj) (nat_number))
@@ -572,8 +572,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (disj_list
       (disj_item (bullet_disj) (nat_number))
       (disj_item (bullet_disj) (tuple_literal (langle_bracket) (rangle_bracket)))
@@ -593,8 +593,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (disj_list
       (disj_item (bullet_disj) (nat_number))
       (disj_item (bullet_disj) (finite_set_literal))

--- a/test/parser/syntax_corpus/if_then_else.txt
+++ b/test/parser/syntax_corpus/if_then_else.txt
@@ -8,9 +8,9 @@ op == IF "A" THEN "B" ELSE "C"
 
 ------------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
-    (if_then_else (string) (string) (string))
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
+    (if_then_else if: (string) then: (string) else: (string))
   )
 (double_line)))
 
@@ -28,15 +28,15 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (conj_list
       (conj_item
         (bullet_conj)
         (if_then_else
-          (nat_number)
-          (nat_number)
-          (nat_number)
+          if: (nat_number)
+          then: (nat_number)
+          else: (nat_number)
         )
       )
       (conj_item (bullet_conj) (nat_number))
@@ -59,15 +59,15 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (if_then_else
-      (conj_list
+      if: (conj_list
         (conj_item (bullet_conj) (nat_number))
         (conj_item (bullet_conj) (nat_number))
       )
-      (nat_number)
-      (nat_number)
+      then: (nat_number)
+      else: (nat_number)
     )
   )
 (double_line)))
@@ -86,15 +86,15 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (disj_list
       (disj_item
         (bullet_disj)
         (if_then_else
-          (nat_number)
-          (nat_number)
-          (nat_number)
+          if: (nat_number)
+          then: (nat_number)
+          else: (nat_number)
         )
       )
       (disj_item (bullet_disj) (nat_number))
@@ -117,15 +117,16 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (if_then_else
-      (disj_list
+      if: (disj_list
         (disj_item (bullet_disj) (nat_number))
         (disj_item (bullet_disj) (nat_number))
       )
-      (nat_number)
-      (nat_number)
+      then: (nat_number)
+      else: (nat_number)
     )
   )
 (double_line)))
+

--- a/test/parser/syntax_corpus/jlist.txt
+++ b/test/parser/syntax_corpus/jlist.txt
@@ -11,15 +11,15 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (bound_infix_op
-      (conj_list
+      lhs: (conj_list
         (conj_item (bullet_conj) (nat_number))
         (conj_item (bullet_conj) (nat_number))
       )
-      (lor)
-      (nat_number)
+      symbol: (lor)
+      rhs: (nat_number)
     )
   )
 (double_line)))
@@ -37,15 +37,15 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (bound_infix_op
-      (disj_list
+      lhs: (disj_list
         (disj_item (bullet_disj) (nat_number))
         (disj_item (bullet_disj) (nat_number))
       )
-      (land)
-      (nat_number)
+      symbol: (land)
+      rhs: (nat_number)
     )
   )
 (double_line)))
@@ -68,25 +68,25 @@ opB ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (bound_infix_op
-      (conj_list
+      lhs: (conj_list
         (conj_item (bullet_conj) (nat_number))
         (conj_item (bullet_conj) (nat_number))
       )
-      (lor)
-      (nat_number)
+      symbol: (lor)
+      rhs: (nat_number)
     )
   )
-  (operator_definition (identifier) (def_eq)
+  (operator_definition name: (identifier) (def_eq) definition:
     (bound_infix_op
-      (disj_list
+      lhs: (disj_list
         (disj_item (bullet_disj) (nat_number))
         (disj_item (bullet_disj) (nat_number))
       )
-      (land)
-      (nat_number)
+      symbol: (land)
+      rhs: (nat_number)
     )
   )
 (double_line)))
@@ -107,8 +107,8 @@ op ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (conj_list
       (conj_item
         (bullet_conj)
@@ -153,19 +153,31 @@ disj ==
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (conj_list
-      (conj_item (bullet_conj) (label (identifier) (label_as) (identifier_ref)))
-      (conj_item (bullet_conj) (bound_infix_op (identifier_ref) (assign) (identifier_ref)))
-      (conj_item (bullet_conj) (bound_infix_op (identifier_ref) (bnf_rule) (identifier_ref)))
+      (conj_item (bullet_conj) (label name: (identifier) (label_as) expression: (identifier_ref)))
+      (conj_item (bullet_conj) (bound_infix_op
+        lhs: (identifier_ref)
+        symbol: (assign)
+        rhs: (identifier_ref)))
+      (conj_item (bullet_conj) (bound_infix_op
+        lhs: (identifier_ref)
+        symbol: (bnf_rule)
+        rhs: (identifier_ref)))
     )
   )
-  (operator_definition (identifier) (def_eq)
+  (operator_definition name: (identifier) (def_eq) definition:
     (disj_list
-      (disj_item (bullet_disj) (label (identifier) (label_as) (identifier_ref)))
-      (disj_item (bullet_disj) (bound_infix_op (identifier_ref) (assign) (identifier_ref)))
-      (disj_item (bullet_disj) (bound_infix_op (identifier_ref) (bnf_rule) (identifier_ref)))
+      (disj_item (bullet_disj) (label name: (identifier) (label_as) expression: (identifier_ref)))
+      (disj_item (bullet_disj) (bound_infix_op
+        lhs: (identifier_ref)
+        symbol: (assign)
+        rhs: (identifier_ref)))
+      (disj_item (bullet_disj) (bound_infix_op
+        lhs: (identifier_ref)
+        symbol: (bnf_rule)
+        rhs: (identifier_ref)))
     )
   )
 (double_line)))

--- a/test/parser/syntax_corpus/modules.txt
+++ b/test/parser/syntax_corpus/modules.txt
@@ -8,7 +8,7 @@ Single module
 -------------|||
 
 (source_file
-  (module (header_line) (identifier) (header_line) (double_line))
+  (module (header_line) name: (identifier) (header_line) (double_line))
 )
 
 =============|||
@@ -21,7 +21,7 @@ EXTENDS M1, M2, M3
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
+(source_file (module (header_line) name: (identifier) (header_line)
   (extends (identifier_ref) (identifier_ref) (identifier_ref))
 (double_line)))
 
@@ -64,9 +64,9 @@ Sequential Nested modules
 -------------|||
 
 (source_file
-  (module (header_line) (identifier) (header_line)
-    (module (header_line) (identifier) (header_line) (double_line))
-    (module (header_line) (identifier) (header_line) (double_line))
+  (module (header_line) name: (identifier) (header_line)
+    (module (header_line) name: (identifier) (header_line) (double_line))
+    (module (header_line) name: (identifier) (header_line) (double_line))
   (double_line))
 )
 

--- a/test/parser/syntax_corpus/number.txt
+++ b/test/parser/syntax_corpus/number.txt
@@ -9,9 +9,9 @@ op == 12345.12345
 
 ----------------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq) (nat_number))
-  (operator_definition (identifier) (def_eq) (real_number))
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition: (nat_number))
+  (operator_definition name: (identifier) (def_eq) definition: (real_number))
 (double_line)))
 
 ======================|||
@@ -29,13 +29,13 @@ op == \H9876543210FEDCBA
 
 ----------------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq) (binary_number (format) (value)))
-  (operator_definition (identifier) (def_eq) (binary_number (format) (value)))
-  (operator_definition (identifier) (def_eq) (octal_number (format) (value)))
-  (operator_definition (identifier) (def_eq) (octal_number (format) (value)))
-  (operator_definition (identifier) (def_eq) (hex_number (format) (value)))
-  (operator_definition (identifier) (def_eq) (hex_number (format) (value)))
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition: (binary_number (format) (value)))
+  (operator_definition name: (identifier) (def_eq) definition: (binary_number (format) (value)))
+  (operator_definition name: (identifier) (def_eq) definition: (octal_number (format) (value)))
+  (operator_definition name: (identifier) (def_eq) definition: (octal_number (format) (value)))
+  (operator_definition name: (identifier) (def_eq) definition: (hex_number (format) (value)))
+  (operator_definition name: (identifier) (def_eq) definition: (hex_number (format) (value)))
 (double_line)))
 
 ======================|||
@@ -99,6 +99,6 @@ op == .5
 
 ----------------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq) (real_number))
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition: (real_number))
 (double_line)))

--- a/test/parser/syntax_corpus/operators.txt
+++ b/test/parser/syntax_corpus/operators.txt
@@ -8,9 +8,9 @@ conflicts_with_octal == \o (1,2)
 
 --------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
-    (bound_nonfix_op (infix_op_symbol (circ)) (nat_number) (nat_number))
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
+    (bound_nonfix_op symbol: (infix_op_symbol (circ)) (nat_number) (nat_number))
   )
 (double_line)))
 
@@ -26,15 +26,15 @@ op == - 1 - 2
 
 --------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (bound_nonfix_op (prefix_op_symbol (negative)) (nat_number))
   )
-  (operator_definition (identifier) (def_eq)
-    (bound_prefix_op (negative) (parentheses (nat_number)))
+  (operator_definition name: (identifier) (def_eq) definition:
+    (bound_prefix_op symbol: (negative) rhs: (parentheses (nat_number)))
   )
-  (operator_definition (identifier) (def_eq)
-    (bound_infix_op (bound_prefix_op (negative) (nat_number)) (minus) (nat_number))
+  (operator_definition name: (identifier) (def_eq) definition:
+    (bound_infix_op lhs: (bound_prefix_op symbol: (negative) rhs: (nat_number)) symbol: (minus) rhs: (nat_number))
   )
 (double_line)))
 
@@ -48,14 +48,14 @@ f(x, g(_, _), _+_, -._, _^+) == x
 
 --------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier)
-    (identifier)
-    (operator_declaration (identifier) (placeholder) (placeholder))
-    (operator_declaration (placeholder) (infix_op_symbol (plus)) (placeholder))
-    (operator_declaration (prefix_op_symbol (negative)) (placeholder))
-    (operator_declaration (placeholder) (postfix_op_symbol (sup_plus)))
-  (def_eq) (identifier_ref))
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier)
+    parameter: (identifier)
+    parameter: (operator_declaration name: (identifier) parameter: (placeholder) parameter: (placeholder))
+    parameter: (operator_declaration (placeholder) name: (infix_op_symbol (plus)) (placeholder))
+    parameter: (operator_declaration name: (prefix_op_symbol (negative)) (placeholder))
+    parameter: (operator_declaration (placeholder) name: (postfix_op_symbol (sup_plus)))
+  (def_eq) definition: (identifier_ref))
 (double_line)))
 
 =============|||
@@ -87,8 +87,8 @@ op == - (1,2)
 
 --------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (bound_nonfix_op (infix_op_symbol (minus)) (nat_number) (nat_number))
   )
 (double_line)))
@@ -201,20 +201,20 @@ op ==
 
 --------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (conj_list
       (conj_item (bullet_conj)
-        (bound_infix_op (identifier_ref) (map_to) (identifier_ref))
+        (bound_infix_op lhs: (identifier_ref) symbol: (map_to) rhs: (identifier_ref))
       )
       (conj_item (bullet_conj)
-        (bound_infix_op (identifier_ref) (assign) (identifier_ref))
+        (bound_infix_op lhs: (identifier_ref) symbol: (assign) rhs: (identifier_ref))
       )
       (conj_item (bullet_conj)
-        (bound_infix_op (identifier_ref) (bnf_rule) (identifier_ref))
+        (bound_infix_op lhs: (identifier_ref) symbol: (bnf_rule) rhs: (identifier_ref))
       )
       (conj_item (bullet_conj)
-        (label (identifier) (label_as) (identifier_ref))
+        (label name: (identifier) (label_as) expression: (identifier_ref))
       )
       (conj_item (bullet_conj) (identifier_ref))
     )

--- a/test/parser/syntax_corpus/sets.txt
+++ b/test/parser/syntax_corpus/sets.txt
@@ -8,8 +8,8 @@ op == { }
 
 ----------------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (finite_set_literal)
   )
 (double_line)))
@@ -228,6 +228,29 @@ op == {<<x, y, z>> \in Nat \X Int \X Real : P(x, y, z)}
   )
 (double_line)))
 
+======================|||
+Set Filter with Single Element Tuple
+======================|||
+
+---- MODULE Test ----
+op == {<<x>> \in Nat : P(x, y, z)}
+====
+
+----------------------|||
+
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq)
+    definition: (set_filter
+      generator: (quantifier_bound
+        intro: (tuple_of_identifiers (langle_bracket) (identifier) (rangle_bracket))
+        (set_in)
+        set: (nat_number_set)
+      )
+      filter: (bound_op name: (identifier_ref) parameter: (identifier_ref) parameter: (identifier_ref) parameter: (identifier_ref))
+    )
+  )
+(double_line)))
+
 =====================|||
 Set Filter Precedence
 =====================|||
@@ -270,18 +293,18 @@ op == {
 
 ----------------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (set_filter
-      (quantifier_bound
-        (identifier) (set_in)
-        (conj_list
+      generator: (quantifier_bound
+        intro: (identifier) (set_in)
+        set: (conj_list
           (conj_item (bullet_conj) (identifier_ref))
           (conj_item (bullet_conj) (identifier_ref))
           (conj_item (bullet_conj) (identifier_ref))
         )
       )
-      (conj_list
+      filter: (conj_list
         (conj_item (bullet_conj) (identifier_ref))
         (conj_item (bullet_conj) (identifier_ref))
         (conj_item (bullet_conj) (identifier_ref))

--- a/test/parser/syntax_corpus/string.txt
+++ b/test/parser/syntax_corpus/string.txt
@@ -8,8 +8,8 @@ op == "Hello, world!"
 
 ------------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq) (string))
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition: (string))
 (double_line)))
 
 ==================|||
@@ -22,8 +22,8 @@ op == "The cow goes \"moo\", the chicken goes \"cluck cluck\""
 
 ------------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (string
       (escape_char)
       (escape_char)
@@ -43,8 +43,8 @@ op == <<"/\\", "\\/">>
 
 ------------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (tuple_literal (langle_bracket)
       (string (escape_char))
       (string (escape_char))
@@ -62,17 +62,9 @@ op == "\*"
 
 ------------------|||
 
-(source_file
-  (module
-    (header_line)
-    (identifier)
-    (header_line)
-    (operator_definition
-      (identifier)
-      (def_eq)
-      (string
-        (escape_char)))
-    (double_line)))
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition: (string (escape_char)))
+(double_line)))
 
 ==================|||
 String with block comment start
@@ -84,16 +76,9 @@ op == "(*"
 
 ------------------|||
 
-(source_file
-  (module
-    (header_line)
-    (identifier)
-    (header_line)
-    (operator_definition
-      (identifier)
-      (def_eq)
-      (string))
-    (double_line)))
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition: (string))
+(double_line)))
 
 ==================|||
 String Set
@@ -142,7 +127,7 @@ op == "foo ` bar"
 
 ------------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq) (string))
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition: (string))
 (double_line)))
 

--- a/test/parser/syntax_corpus/tuples.txt
+++ b/test/parser/syntax_corpus/tuples.txt
@@ -8,8 +8,8 @@ op == <<>>
 
 ----------------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (tuple_literal (langle_bracket) (rangle_bracket))
   )
 (double_line)))
@@ -24,8 +24,8 @@ op == <<1, 2, 3, 4, 5>>
 
 ----------------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (tuple_literal (langle_bracket)
       (nat_number)
       (nat_number)
@@ -46,8 +46,8 @@ op == <<x, y, z>>
 
 ----------------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (tuple_literal (langle_bracket)
       (identifier_ref)
       (identifier_ref)
@@ -66,8 +66,8 @@ op == <<<<x, y>>, <<z>>>>
 
 ----------------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
-  (operator_definition (identifier) (def_eq)
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
     (tuple_literal (langle_bracket)
       (tuple_literal (langle_bracket)
         (identifier_ref)

--- a/test/parser/syntax_corpus/unit.txt
+++ b/test/parser/syntax_corpus/unit.txt
@@ -102,7 +102,7 @@ INSTANCE M WITH
 
 -------------------------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
+(source_file (module (header_line) name: (identifier) (header_line)
   (instance (identifier_ref)
     (substitution (identifier_ref) (gets) (identifier_ref))
     (substitution (prefix_op_symbol (powerset)) (gets) (identifier_ref))

--- a/test/parser/syntax_corpus/unit.txt
+++ b/test/parser/syntax_corpus/unit.txt
@@ -9,7 +9,7 @@ VARIABLES x, y, z
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
+(source_file (module (header_line) name: (identifier) (header_line)
   (variable_declaration (identifier) (identifier) (identifier))
   (variable_declaration (identifier) (identifier) (identifier))
 (double_line)))
@@ -25,13 +25,13 @@ CONSTANTS f(_, _), _+_, -._, _^+
 
 -------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
+(source_file (module (header_line) name: (identifier) (header_line)
   (constant_declaration (identifier) (identifier) (identifier))
   (constant_declaration
-    (operator_declaration (identifier) (placeholder) (placeholder))
-    (operator_declaration (placeholder) (infix_op_symbol (plus)) (placeholder))
-    (operator_declaration (prefix_op_symbol (negative)) (placeholder))
-    (operator_declaration (placeholder) (postfix_op_symbol (sup_plus)))
+    (operator_declaration name: (identifier) parameter: (placeholder) parameter: (placeholder))
+    (operator_declaration (placeholder) name: (infix_op_symbol (plus)) (placeholder))
+    (operator_declaration name: (prefix_op_symbol (negative)) (placeholder))
+    (operator_declaration (placeholder) name: (postfix_op_symbol (sup_plus)))
   )
 (double_line)))
 

--- a/test/parser/syntax_corpus/unit.txt
+++ b/test/parser/syntax_corpus/unit.txt
@@ -66,7 +66,7 @@ INSTANCE M WITH
 
 -------------------------------|||
 
-(source_file (module (header_line) (identifier) (header_line)
+(source_file (module (header_line) name: (identifier) (header_line)
   (instance (identifier_ref)
     (substitution (identifier_ref) (gets)
       (conj_list (conj_item (bullet_conj) (nat_number)))

--- a/test/parser/translate_syntax_tree.ml
+++ b/test/parser/translate_syntax_tree.ml
@@ -55,10 +55,35 @@ let as_specific_name (if_id : decl_or_ref) (id : string) : ts_node =
   | "Nat" -> {name = "nat_number_set"; children = []}
   | "FALSE" -> {name = "boolean"; children = []}
   | "TRUE" -> {name = "boolean"; children = []}
+  | "STRING" -> {name = "string_set"; children = []}
   | _ -> {
     name = (match if_id with | Declaration -> "identifier" | Reference -> "identifier_ref");
     children = []
   }
+
+(** The standardized test corpus requires counting escaped strings (for syntax
+    highlighting reasons) so we do a foldl over the characters of the string
+    determining whether each character was preceded by a backslash, counting
+    up the number of escaped characters in the string.
+*)
+let translate_string (str : string) : ts_node = {
+  name = "string";
+  children =
+    let (_, escape_count) = String.fold_left (
+      fun (is_escaped, acc) c ->
+        match is_escaped, c with
+        | (true, 't') -> (false, acc + 1)
+        | (true, 'n') -> (false, acc + 1)
+        | (true, 'r') -> (false, acc + 1)
+        | (true, 'f') -> (false, acc + 1)
+        | (true, '*') -> (false, acc + 1)
+        | (true, '"') -> (false, acc + 1)
+        | (true, '\\') -> (false, acc + 1)
+        | (_, '\\') -> (true, acc)
+        | _ -> (false, acc)
+      ) (false, 0) str in
+    repeat escape_count (leaf "escape_char")
+}
 
 let op_to_node (if_id : decl_or_ref) (op : operator) : ts_node =
   match op with
@@ -90,10 +115,11 @@ let builtin_to_op (builtin : Builtin.builtin) : operator =
   match builtin with
   | TRUE -> Named "TRUE"
   | FALSE -> Named "FALSE"
+  | STRING -> Named "STRING"
   | Plus -> Infix "plus"
   | Conj -> Infix "land"
   | Disj -> Infix "lor"
-  | _ -> Named "builtin_as_op_ph"
+  | _ -> failwith "builtin"
 
 let translate_operator_declaration (name : string) (arity : int) : field_or_node list =
   let op = str_to_op name in
@@ -228,7 +254,7 @@ and translate_bound_op (callee : Expr.T.expr) (args : Expr.T.expr list) : ts_nod
 and translate_expr (expr : Expr.T.expr) : ts_node =
   match expr.core with
   | Num (_, _) -> {name = "nat_number"; children = []}
-  | String _ -> {name = "string"; children = []}
+  | String str -> translate_string str
   | Opaque id -> as_specific_name Reference id
   | Internal internal -> internal |> builtin_to_op |> op_to_node Reference
   | List (bullet, juncts) -> translate_jlist bullet juncts

--- a/test/parser/translate_syntax_tree.ml
+++ b/test/parser/translate_syntax_tree.ml
@@ -4,6 +4,7 @@
 *)
 
 open Sexplib;;
+open Tlapm_lib;;
 
 type field_or_node =
   | Field of string * ts_node
@@ -15,13 +16,8 @@ and ts_node = {
 
 let leaf (name : string) : field_or_node = Node {name; children = []}
   
-let leaf_opt (name : string) : field_or_node option = Some (leaf name)
-
 let field_leaf (field_name : string) (name : string) : field_or_node =
   Field (field_name, {name; children = []})
-
-let field_leaf_opt (field_name : string) (name : string) : field_or_node option =
-  Some (field_leaf field_name name)
 
 let rec ts_node_to_sexpr (node : ts_node) : Sexp.t =
   let flatten_child (child : field_or_node) : Sexp.t list =
@@ -38,7 +34,44 @@ let rec ts_node_to_sexpr (node : ts_node) : Sexp.t =
     )
   )
 
-let translate_extends (tree : Tlapm_lib__Util.hints) : field_or_node list =
+let rec repeat (count : int) (elem : 't) : 't list =
+  if count = 0 then [] else elem :: (repeat (count - 1) elem)
+
+type operator =
+  | Prefix of string
+  | Infix of string
+  | Postfix of string
+  | Named
+
+let as_operator (op_str : string) (arity : int) : operator =
+  match op_str, arity with
+  | ("ENABLED", 1) -> Prefix "enabled"
+  | ("DOMAIN", 1) -> Prefix "domain"
+  | ("SUBSET", 1) -> Prefix "powerset"
+  | ("-", 1) -> Prefix "negative"
+  | ("-", 2) -> Infix "minus"
+  | ("+", 2) -> Infix "plus"
+  | ("'", 1) -> Postfix "prime"
+  | _ -> Named
+
+let translate_operator_declaration (name : string) (arity : int) : field_or_node list =
+  match as_operator name arity with
+  | Prefix symbol -> [
+    Field ("name", {name = "prefix_op_symbol"; children = [leaf symbol]});
+    leaf "placeholder"
+  ]
+  | Infix symbol -> [
+    leaf "placeholder";
+    Field ("name", {name = "infix_op_symbol"; children = [leaf symbol]});
+    leaf "placeholder"
+  ]
+  | Postfix symbol -> [
+    leaf "placeholder";
+    Field ("name", {name = "postfix_op_symbol"; children = [leaf symbol]});
+  ]
+  | Named -> (field_leaf "name" "identifier") :: (repeat arity (field_leaf "parameter" "placeholder"))
+  
+let translate_extends (tree : Util.hints) : field_or_node list =
   match tree with
   | [] -> []
   | _ -> [(Node {
@@ -46,7 +79,35 @@ let translate_extends (tree : Tlapm_lib__Util.hints) : field_or_node list =
     children = (List.map (fun _ -> leaf "identifier_ref") tree)
   })]
 
-let translate_module (tree : Tlapm_lib__M_t.mule) : ts_node =
+let translate_constant_decl ((name, shape) : (Util.hint * Expr.T.shape)) : field_or_node =
+  match shape with
+  | Shape_expr -> leaf "identifier"
+  | Shape_op arity -> Node {
+    name = "operator_declaration";
+    children = translate_operator_declaration name.core arity;
+  }
+
+(** TODO *)
+let translate_variable_decl (_decl : Util.hint) : field_or_node =
+  leaf "ph"
+
+(** TODO *)
+let translate_recursive_decl ((_hint, _shape) : (Util.hint * Expr.T.shape)) : field_or_node =
+  leaf "ph"
+
+(** TODO *)
+let translate_operator_definition (_defn : Expr.T.defn) (_wheredef : Expr.T.wheredef) (_visibility : Expr.T.visibility) (_export : Expr.T.export) : field_or_node list =
+  [leaf "ph"]
+
+(** TODO *)
+let translate_assumption (_hint : Util.hint option) (_expr : Expr.T.expr) : field_or_node list =
+  [leaf "ph"]
+
+(** TODO *)
+let translate_theorem (_hint : Util.hint option) (_sequent : Expr.T.sequent) (_level : int) (_proof1 : Proof.T.proof) (_proof2 : Proof.T.proof) (_summary : Module.T.summary) : field_or_node list =
+  [leaf "ph"]
+
+let rec translate_module (tree : Module.T.mule) : ts_node =
   {
     name = "source_file";
     children = [
@@ -57,8 +118,39 @@ let translate_module (tree : Tlapm_lib__M_t.mule) : ts_node =
           [field_leaf "name" "identifier"];
           [leaf "header_line"];
           translate_extends tree.core.extendees;
+          List.map translate_unit tree.core.body;
           [leaf "double_line"];
         ]
       }
     ]
   }
+
+and translate_unit (unit : Module.T.modunit) : field_or_node =
+  match unit.core with
+  | Constants ls -> Node {
+    name = "constant_declaration";
+    children = List.map translate_constant_decl ls
+  }
+  | Variables ls -> Node {
+    name = "variable_declaration";
+    children = List.map translate_variable_decl ls
+  }
+  | Recursives ls -> Node {
+    name = "recursive_declaration";
+    children = List.map translate_recursive_decl ls
+  }
+  | Definition (defn, wheredef, visibility, export) -> Node {
+    name = "operator_definition";
+    children = translate_operator_definition defn wheredef visibility export
+  }
+  | Axiom (hint, expr) -> Node {
+    name = "assumption";
+    children = translate_assumption hint expr
+  }
+  | Theorem (hint, sequent, level, proof1, proof2, summary) -> Node {
+    name = "theorem";
+    children = translate_theorem hint sequent level proof1 proof2 summary
+  }
+  | Submod mule -> Node (translate_module mule)
+  | Mutate _ -> leaf "ph"
+  | Anoninst _ -> leaf "ph"

--- a/test/parser/translate_syntax_tree.ml
+++ b/test/parser/translate_syntax_tree.ml
@@ -228,6 +228,7 @@ and translate_bound_op (callee : Expr.T.expr) (args : Expr.T.expr list) : ts_nod
 and translate_expr (expr : Expr.T.expr) : ts_node =
   match expr.core with
   | Num (_, _) -> {name = "nat_number"; children = []}
+  | String _ -> {name = "string"; children = []}
   | Opaque id -> as_specific_name Reference id
   | Internal internal -> internal |> builtin_to_op |> op_to_node Reference
   | List (bullet, juncts) -> translate_jlist bullet juncts
@@ -237,6 +238,14 @@ and translate_expr (expr : Expr.T.expr) : ts_node =
   | Tuple expr_ls -> {
     name = "tuple_literal";
     children = [leaf "langle_bracket"] @ (node_list_map translate_expr expr_ls) @ [leaf "rangle_bracket"]
+  }
+  | If (i, t, e) -> {
+    name = "if_then_else";
+    children = [
+      Field ("if", translate_expr i);
+      Field ("then", translate_expr t);
+      Field ("else", translate_expr e);
+    ]
   }
   | _ -> {name = "expr_ph"; children = []}
 

--- a/test/parser/translate_syntax_tree.ml
+++ b/test/parser/translate_syntax_tree.ml
@@ -1,0 +1,64 @@
+(** This file contains functionality for translating TLAPM's syntax tree
+    format into the common TLA+ syntax corpus format, for comparison of
+    expected with actual parse trees for a given parse input.
+*)
+
+open Sexplib;;
+
+type field_or_node =
+  | Field of string * ts_node
+  | Node of ts_node
+and ts_node = {
+  name : string;
+  children : field_or_node list;
+}
+
+let leaf (name : string) : field_or_node = Node {name; children = []}
+  
+let leaf_opt (name : string) : field_or_node option = Some (leaf name)
+
+let field_leaf (field_name : string) (name : string) : field_or_node =
+  Field (field_name, {name; children = []})
+
+let field_leaf_opt (field_name : string) (name : string) : field_or_node option =
+  Some (field_leaf field_name name)
+
+let rec ts_node_to_sexpr (node : ts_node) : Sexp.t =
+  let flatten_child (child : field_or_node) : Sexp.t list =
+    match child with
+    | Field (name, node) -> [
+        Atom (name ^ ":");
+        ts_node_to_sexpr node
+      ]
+    | Node (node) -> [ts_node_to_sexpr node]
+  in
+  Sexp.(List
+    (Atom node.name ::
+      List.flatten (List.map flatten_child node.children)
+    )
+  )
+
+let translate_extends (tree : Tlapm_lib__Util.hints) : field_or_node list =
+  match tree with
+  | [] -> []
+  | _ -> [(Node {
+    name = "extends";
+    children = (List.map (fun _ -> leaf "identifier_ref") tree)
+  })]
+
+let translate_module (tree : Tlapm_lib__M_t.mule) : ts_node =
+  {
+    name = "source_file";
+    children = [
+      Node {
+        name = "module";
+        children = List.flatten [
+          [leaf "header_line"];
+          [field_leaf "name" "identifier"];
+          [leaf "header_line"];
+          translate_extends tree.core.extendees;
+          [leaf "double_line"];
+        ]
+      }
+    ]
+  }

--- a/tlapm.opam
+++ b/tlapm.opam
@@ -30,6 +30,7 @@ depends: [
   "ocaml"
   "dune-site"
   "dune-build-info"
+  "sexp_diff"
   "sexplib"
   "cmdliner"
   "camlzip"


### PR DESCRIPTION
These changes extend the work in #159 - which only ran the tests in a simple pass/fail manner - to also compare TLAPM's AST to the expected AST encoded as an S-expression. This entails a bunch of code to translate TLAPM's AST to the expected S-expression format for comparison.