### PR TITLE
Examples: fix identifier reuse parse failures

### DIFF
--- a/examples/ByzPaxos/BPConProof.tla
+++ b/examples/ByzPaxos/BPConProof.tla
@@ -1478,7 +1478,7 @@ THEOREM Invariance == Spec => []Inv
           <6>1. /\ a = self
                 /\ r = [val |-> mc.val, bal |-> b]
             BY <4>1, <5>1, <5>3 DEF Inv, TypeOK 
-          <6>2. /\ \A r \in 2avSent[self] : r.bal < b 
+          <6>2. /\ \A other \in 2avSent[self] : other.bal < b 
                 /\ maxBal' = [maxBal EXCEPT ![self] = b]
             BY <3>2 DEF Phase2av
           <6>3. r.bal =< maxBal'[a]

--- a/examples/GraphTheorem.tla
+++ b/examples/GraphTheorem.tla
@@ -137,7 +137,7 @@ THEOREM
     <3>2. ASSUME NEW e \in G,
                  NEW n \in e
           PROVE  \E m \in Connected : n # m /\ e = {m, n}
-      <4>. PICK m, n \in Nodes : m # n /\ e = {m,n}
+      <4>. PICK m, other \in Nodes : m # other /\ e = {m,other}
         BY NLEdgeElements DEF SimpleGraphs
       <4>. QED  BY <2>5
     <3>3. SUFFICES ASSUME NEW n \in Connected

--- a/examples/paxos/Paxos.tla
+++ b/examples/paxos/Paxos.tla
@@ -403,10 +403,10 @@ THEOREM Invariant == Spec => []Inv
           <6>1. \A m \in S : 
                    /\ m.bal =< maxBal[m.acc]
                    /\ \A c \in (m.maxVBal+1) .. (m.bal-1) :
-                         ~ \E v \in Values : VotedForIn(m.acc, v, c)
+                         ~ \E other \in Values : VotedForIn(m.acc, other, c)
             BY DEF MsgInv
-          <6>2. \A c \in 0..(b-1) : \A a \in Q : \A v \in Values : 
-                    ~ VotedForIn(a, v, c)
+          <6>2. \A c \in 0..(b-1) : \A a \in Q : \A other \in Values : 
+                    ~ VotedForIn(a, other, c)
             BY <5>0, <5>1, <6>1
           <6>3. \A c \in 0..(b-1) : \A a \in Q : maxBal[a] > c
             BY <5>0, <6>1, QuorumAssumption DEF TypeOK


### PR DESCRIPTION
Several specs in the examples subdirectory fail to parse when checked with SANY, due to reusing identifier names already defined in an enclosing scope. TLAPM accepted these specs but SANY does not, as TLA+ does not allow definition shadowing.

Ref #136