### PR TITLE
fix issue 212

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,6 @@ jobs:
             - name: Check library proofs
               run: |
                 find ./library -type f -iname "*_proofs.tla"  \
-                -not -name "SequenceTheorems_proofs.tla"      \
                 -print0 | xargs --null --max-args=1           \
                 ./_build/tlapm/bin/tlapm --cleanfp --stretch 5
             - name: Clone tlaplus/examples

--- a/library/SequenceTheorems_proofs.tla
+++ b/library/SequenceTheorems_proofs.tla
@@ -262,7 +262,7 @@ THEOREM SequenceEmptyOrAppend ==
       PROVE  seq[i] = Append(front, last)[i]
   OBVIOUS
 <1>4. seq = Append(front, last)
-  BY <1>2, <1>3, SeqEqual
+  BY <1>1, <1>2, <1>3, SeqEqual
 <1>. QED  BY <1>1, <1>4
 
 (***************************************************************************)


### PR DESCRIPTION
Explicitly adding a step proved by OBVIOUS to a later proof appears to be necessary for Z3 on Linux. Sigh.