### PR TITLE
Add --strict to fail on incomplete proofs and empty targets

### DIFF
--- a/doc/web/content/Documentation/Tutorial/Advanced_options.html
+++ b/doc/web/content/Documentation/Tutorial/Advanced_options.html
@@ -134,8 +134,24 @@
   <li><code>--stretch</code> <em>f</em> : multiply all timeouts by a
   factor of <em>f</em>. This is particularly useful when using a
   slower machine to re-check proofs made on a faster machine.</li>
+  <li><code>--strict</code> : treat conditions that otherwise look like a
+  successful run as errors and exit with a non-zero status. Useful for CI,
+  where these cases would otherwise be reported as "All 0 obligations proved".</li>
   </ul>
   </p>
+
+  <h3>Exit codes</h3>
+  <p>By default <code>tlapm</code> exits 0 on a completed run. Under
+  <code>--strict</code> it exits with the most severe condition encountered:</p>
+  <table frame="box" rules="all">
+    <tr><th>code</th><th>meaning</th></tr>
+    <tr><td>0</td><td>clean, complete verification</td></tr>
+    <tr><td>3</td><td>internal error (reported regardless of <code>--strict</code>)</td></tr>
+    <tr><td>10</td><td>a proof obligation failed</td></tr>
+    <tr><td>11</td><td>incomplete proof (missing or omitted steps)</td></tr>
+    <tr><td>12</td><td>explicit target selected no obligation</td></tr>
+  </table>
+  <p>Code 3 takes precedence over the <code>--strict</code> codes above.</p>
 
 <!--
   Document at least these command-line options:

--- a/src/params.ml
+++ b/src/params.ml
@@ -448,6 +448,44 @@ let check        = ref false
 let summary      = ref false
 let stats        = ref false
 
+(* `--strict`: treat conditions that otherwise look like a successful run as
+   errors (incomplete proofs, an explicit target that selects no obligation,
+   failed obligations) and exit with a non-zero, condition-specific code. *)
+let strict       = ref false
+
+(* Accumulated process exit status used under `--strict`. 0 means a clean,
+   complete verification. Several conditions may co-occur in a single run; the
+   exit code reflects the most severe one. Severity ordering (most severe
+   first):
+     3   internal error           (emitted by the top-level exception handler)
+     10  proof obligation failed  (proof-wrong)
+     11  incomplete proof         (missing/omitted steps; proof-gappy)
+     12  empty proof target       (explicit target selected no obligation)
+   The numeric values are stable identifiers; severity is defined by
+   [strict_severity], not by numeric magnitude (3 is the most severe but the
+   smallest non-zero code, kept for backwards compatibility). *)
+let exit_status  = ref 0
+
+let strict_severity = function
+  | 0  -> 0
+  | 12 -> 1
+  | 11 -> 2
+  | 10 -> 3
+  | 3  -> 4
+  | _  -> 5
+
+(* Raise [exit_status] to [code] if [code] is more severe than what was already
+   recorded. *)
+let note_strict_failure code =
+  if strict_severity code > strict_severity !exit_status then
+    exit_status := code
+
+(* True when the user restricted the run to an explicit proof target, e.g. via
+   `--line` or a `--toolbox` range. A whole-module run keeps the defaults
+   [tb_sl = 0] and [tb_el = max_int]. *)
+let has_explicit_target () =
+  !tb_sl > 0 || !tb_el < max_int
+
 let solve_cmd cmd file =
   if Sys.os_type = "Cygwin" then
     sprintf "file=%s; winfile=\"`cygpath -a -w \"%s\"`\"; %s" file file (get_exec Format.err_formatter cmd)

--- a/src/params.mli
+++ b/src/params.mli
@@ -89,6 +89,10 @@ val stdlib_path: string option
 val cleanfp: bool ref
 val fpf_in: string option ref
 val summary: bool ref
+val strict: bool ref
+val exit_status: int ref
+val note_strict_failure: int -> unit
+val has_explicit_target: unit -> bool
 val stats: bool ref
 val add_search_dir: string -> unit
 val set_search_path: string list -> unit

--- a/src/tlapm_args.ml
+++ b/src/tlapm_args.ml
@@ -154,6 +154,9 @@ let init ?(out=Format.std_formatter) ?(err=Format.err_formatter) ?(terminate=exi
     "--config", Arg.Set show_config, " show configuration and exit" ;
     "--summary", Arg.Set summary,
                  " show summary of theorems (implies -N and not -C)" ;
+    "--strict", Arg.Set strict,
+                " report incomplete proofs, empty proof targets and failed \
+                  obligations as errors and exit with a non-zero status" ;
     "--timing", Arg.Set stats, " show runtime statistics" ;
     blank;
     "-I", Arg.String add_search_dir, "<dir> add <dir> to search path" ;

--- a/src/tlapm_lib.ml
+++ b/src/tlapm_lib.ml
@@ -147,7 +147,11 @@ let print_unproved_obligations
         Util.eprintf
             "There were backend errors processing module `%S`."
             tla_module.core.name.core;
-        if not !Params.toolbox then
+        if !Params.strict then
+            (* Record the most severe condition and keep processing so that all
+               modules are reported before exiting (see [Params.exit_status]). *)
+            Params.note_strict_failure 10
+        else if not !Params.toolbox then
             failwith "backend errors: there are unproved obligations"
     end else begin
         Util.eprintf
@@ -443,6 +447,46 @@ let process_module
             | _ -> []
         in
 
+        (* `--strict` checks that are independent of the backends. *)
+        if !Params.strict then begin
+            (* #271: missing or omitted proof steps leave the proof incomplete,
+               even though such steps generate no obligation and would otherwise
+               be reported as a successful run. *)
+            let (_, summ) = fin.final_status in
+            let (n_absent, absent) = summ.sum_absent in
+            let (n_omitted, omitted) = summ.sum_omitted in
+            (* `--summary` already lists each missing/omitted proof location, so
+               skip the per-locus lines to avoid duplicate output. *)
+            if not !Params.summary then begin
+                List.iter
+                    (fun loc -> Util.eprintf ~prefix:"[ERROR]: "
+                        "Missing proof at %s" (Loc.string_of_locus loc))
+                    absent;
+                List.iter
+                    (fun loc -> Util.eprintf ~prefix:"[ERROR]: "
+                        "Omitted proof at %s" (Loc.string_of_locus loc))
+                    omitted
+            end;
+            (* Emit one module-level summary line and raise the exit status to
+               11 (incomplete proof) whenever any step is missing or omitted. *)
+            if n_absent + n_omitted > 0 then begin
+                Util.eprintf ~at:t ~prefix:"[ERROR]: "
+                    "Proof incomplete in module %S: %d missing, %d omitted \
+                     proof step(s)."
+                    t.core.name.core n_absent n_omitted;
+                Params.note_strict_failure 11
+            end;
+            (* #276: an explicit target (e.g. `--line`) that selects no
+               obligation usually means an off-by-one line number rather than a
+               genuine proof. A whole-module run with zero obligations is fine. *)
+            if Params.has_explicit_target ()
+               && Array.length fin.final_obs = 0 then begin
+                Util.eprintf ~at:t ~prefix:"[ERROR]: "
+                    "No proof obligation found for the selected target.";
+                Params.note_strict_failure 12
+            end
+        end;
+
         begin
         if not !Params.suppress_all then
             process_obs t fin.final_obs
@@ -579,7 +623,12 @@ let main fs =
       in
       ignore (List.fold_left f mcx mods)
   end ;
-  if !Params.stats then Clocks.report ()
+  if !Params.stats then Clocks.report () ;
+  (* Under `--strict`, exit with the most severe condition encountered. A clean
+     run leaves [exit_status] at 0 and falls through to the normal exit. The
+     `--strict` guard keeps non-strict runs unaffected even if [exit_status] is
+     ever set elsewhere or retained across in-process invocations. *)
+  if !Params.strict && !Params.exit_status <> 0 then exit !Params.exit_status
 
 
 let init () =

--- a/test/bugs/strict_clean_test.tla
+++ b/test/bugs/strict_clean_test.tla
@@ -1,0 +1,14 @@
+---- MODULE strict_clean_test ----
+
+(* Regression test for the `--strict` option (issues 271 and 276): a complete
+   proof with all obligations discharged must still exit 0 under `--strict`,
+   i.e. the strict checks must not introduce false positives.
+*)
+
+THEOREM TRUE OBVIOUS
+
+====
+command: ${TLAPM} --strict --nofp ${FILE}
+result: 0
+nostderr: Proof incomplete
+nostderr: No proof obligation found

--- a/test/bugs/strict_empty_target_test.tla
+++ b/test/bugs/strict_empty_target_test.tla
@@ -1,0 +1,17 @@
+---- MODULE strict_empty_target_test ----
+
+(* Regression test for https://github.com/tlaplus/tlapm/issues/276
+
+   An explicit target (`--line`) that selects no proof obligation otherwise
+   reports "All 0 obligation proved" and exits 0, making an off-by-one line
+   number look like a successful proof. Line 1 is the module header and selects
+   no obligation. With `--strict` this is reported and tlapm exits with code 12
+   (empty proof target).
+*)
+
+THEOREM TRUE OBVIOUS
+
+====
+command: ${TLAPM} --strict --nofp --line 1 ${FILE}
+result: 12
+stderr: No proof obligation found for the selected target

--- a/test/bugs/strict_missing_proof_test.tla
+++ b/test/bugs/strict_missing_proof_test.tla
@@ -1,0 +1,18 @@
+---- MODULE strict_missing_proof_test ----
+
+(* Regression test for https://github.com/tlaplus/tlapm/issues/271
+
+   A step whose proof is absent (here the bare QED step) generates no
+   obligation, so without `--strict` the run reports "All 0 obligation proved"
+   and exits 0, hiding the incomplete proof. With `--strict` the missing proof
+   is reported as an error and tlapm exits with code 11 (incomplete proof).
+*)
+
+THEOREM TRUE
+<1> QED
+
+====
+command: ${TLAPM} --strict --nofp ${FILE}
+result: 11
+stderr: Missing proof at
+stderr: Proof incomplete in module

--- a/test/bugs/strict_omitted_proof_test.tla
+++ b/test/bugs/strict_omitted_proof_test.tla
@@ -1,0 +1,17 @@
+---- MODULE strict_omitted_proof_test ----
+
+(* Regression test for https://github.com/tlaplus/tlapm/issues/271
+
+   An explicit OMITTED proof also generates no obligation. With `--strict` the
+   omission is reported as an error and tlapm exits with code 11 (incomplete
+   proof).
+*)
+
+THEOREM TRUE
+OMITTED
+
+====
+command: ${TLAPM} --strict --nofp ${FILE}
+result: 11
+stderr: Omitted proof at
+stderr: Proof incomplete in module

--- a/test/cli/cli_tests.ml
+++ b/test/cli/cli_tests.ml
@@ -128,6 +128,7 @@ let setting_values () : setting_value list = [
   `SO ("fpf_out", fpf_out, !fpf_out);
   `B ("fp_loaded", fp_loaded, !fp_loaded);
   `B ("summary", summary, !summary);
+  `B ("strict", strict, !strict);
   `B ("stats", stats, !stats);
   `B ("keep_going", keep_going, !keep_going);
   `B ("suppress_all", suppress_all, !suppress_all);
@@ -254,6 +255,16 @@ let test_summary _test_ctxt =
   assert_equal None exit_code;
   assert_equal [`B ("summary", summary, true); `B ("suppress_all", suppress_all, true)] (changed_setting_values ()) ~pp_diff:print_setting_list_diff;
   assert_equal false !check;
+  reset_setting_values ();;
+
+let test_strict _test_ctxt =
+  reset_setting_values ();
+  let (mods, out, err, exit_code) = parse_args ["--strict"; "Test.tla"] in
+  assert_equal ["Test.tla"] mods ~pp_diff:print_mod_diff;
+  assert_equal "" out ~pp_diff:print_string_diff;
+  assert_equal "" err ~pp_diff:print_string_diff;
+  assert_equal None exit_code;
+  assert_equal [`B ("strict", strict, true)] (changed_setting_values ()) ~pp_diff:print_setting_list_diff;
   reset_setting_values ();;
 
 let test_timing _test_ctxt =
@@ -568,6 +579,7 @@ let cli_test_suite = "Test CLI Parsing" >::: [
   "Print Stlib Location Test" >:: test_where;
   "Print Config Test" >:: test_config;
   "Print Summary Test" >:: test_summary;
+  "Strict Test" >:: test_strict;
   "Print Stats Test" >:: test_timing;
   "Search Paths Test" >:: test_search_paths;
   "Keep Going Test" >:: test_keep_going;


### PR DESCRIPTION
tlapm exits 0 and prints "All N obligations proved" even when steps have no proof (missing/omitted generate no obligation, #271) or when an explicit --line selects nothing (#276). This silently hides mistakes in CI and scripts, where there is no IDE to surface them.

--strict makes these conditions exit non-zero with distinct, severity-ordered codes: 10 failed obligation, 11 incomplete proof, 12 empty target (most severe wins). Default behavior is unchanged.

Addresses Github issues #271 and #276
https://github.com/tlaplus/tlapm/issues/271
https://github.com/tlaplus/tlapm/issues/276