### PR TITLE
Fix crash when a `DEF` clause cites a non-definition

### DIFF
--- a/src/proof/p_anon.ml
+++ b/src/proof/p_anon.ml
@@ -221,7 +221,21 @@ class anon = object (self : 'self)
                 let opaque = Opaque v @@ dw in
                 let opaque = self#expr scx opaque in
                 match opaque.core with
-                | Ix n -> [Dx n @@ dw]
+                | Ix n ->
+                    (* The name is in scope, but a DEF clause may only cite a
+                     * definition. If it resolves to a declaration
+                     * (CONSTANT/VARIABLE/NEW), reject it here with a located
+                     * error instead of crashing later in `Proof.Gen.set_defn`
+                     * (see issue #280). *)
+                    begin match Deque.nth ~backwards:true (snd scx) (n - 1) with
+                    | Some {core = Defn _} -> [Dx n @@ dw]
+                    | _ ->
+                        Errors.err ~at:dw
+                            "%S is not a definition and cannot be used in a \
+                            DEF clause."
+                            v;
+                        []
+                    end
                 | _ ->
                     Errors.warn ~at:dw
                         "Ignored unexpandable \

--- a/test/bugs/def_nondef_test.tla
+++ b/test/bugs/def_nondef_test.tla
@@ -1,0 +1,33 @@
+---- MODULE def_nondef_test ----
+
+(* Regression test for https://github.com/tlaplus/tlapm/issues/280
+
+   A DEF clause (`BY ... DEF X`, `USE DEF X`, or `HIDE DEF X`) that cites a
+   name which is in scope but is not a definition -- a CONSTANT, a VARIABLE, or
+   a NEW-declared constant/operator -- used to crash the whole run with
+   `Failure("Proof.Gen.set_defn/doit")` ("Oops, this seems to be a bug in
+   TLAPM"). It must instead be reported as a normal located error and the run
+   must not abort abnormally.
+*)
+
+CONSTANT C
+VARIABLE v
+
+THEOREM TRUE BY DEF C
+
+THEOREM TRUE
+  <1>1. USE DEF v
+  <1>2. QED OBVIOUS
+
+THEOREM ASSUME NEW xx PROVE TRUE
+  BY DEF xx
+
+====
+command: ${TLAPM} --nofp ${FILE}
+result: 0
+stderr: "C" is not a definition and cannot be used in a DEF clause
+stderr: "v" is not a definition and cannot be used in a DEF clause
+stderr: "xx" is not a definition and cannot be used in a DEF clause
+nostderr: set_defn
+nostderr: bug in TLAPM
+nostderr: ending abnormally


### PR DESCRIPTION
## Description

Fixes #280.

### Root cause

During anonymization (`src/proof/p_anon.ml`) a `DEF`-cited name that is in scope resolves to an `Ix` and was passed on unchecked as a `Dx`. When it names a declaration rather than a definition, `Proof.Gen.set_defn` later walked to a `Fresh`/`Fact` context slot expecting a `Defn` and aborted with `failwith`.

### Fix

Reject the reference already in `P_anon`, where the resolved index is available: if it does not point at a `Defn`, emit a normal located error (`"C" is not a definition and cannot be used in a DEF clause.`) and drop the reference, mirroring the existing handling of unexpandable identifiers. The run now reports the mistake and continues cleanly instead of crashing.

### Tests

Adds `test/bugs/def_nondef_test.tla` covering all three `DEF`-clause forms (`BY DEF`, `USE DEF`, `HIDE DEF`); it fails on the previous `set_defn` crash and passes with the fix.
