### PR TITLE
doc: align Download/Binaries pages with README

### DIFF
--- a/doc/web/content/Download/Binaries.html
+++ b/doc/web/content/Download/Binaries.html
@@ -19,8 +19,8 @@ are missing the navigation menus.</b></p><hr/></noscript>
 <!-- DO NOT EDIT ABOVE THIS LINE, DO NOT REMOVE THIS LINE -->
 
 <div class="section">
-  <h2>Download the TLAPS installer</h2>
-  <p class="first">The TLAPS binary installer is available for the
+  <h2>Download TLAPS</h2>
+  <p class="first">Binary builds are available for the
   following systems:
     <ul style="list-style-type:none;list-style:none">
       <li>

--- a/doc/web/content/Download/Binaries/Linux.html
+++ b/doc/web/content/Download/Binaries/Linux.html
@@ -19,10 +19,46 @@
 <div class="section">
   <h2><img class="blogo" src="images/logo_linux35.png"
            alt="[Tux]"/>Linux</h2>
-  <p class="first"> The package:
+
+  <p class="first">Builds of the latest development version are attached to
+    the <a href="https://github.com/tlaplus/tlapm/releases/tag/1.6.0-pre">1.6.0
+    rolling pre-release</a>:
+    <code><a type="application/gzip"
+             href="https://github.com/tlaplus/tlapm/releases/download/1.6.0-pre/tlapm-1.6.0-pre-x86_64-linux-gnu.tar.gz">tlapm-1.6.0-pre-x86_64-linux-gnu.tar.gz</a></code>
+  </p>
+
+  <p>This archive is relocatable and needs no installer: unpack it wherever
+  you like, then put its <code>bin</code> directory on your
+  <code>PATH</code>.</p>
+
+  <div class="terminal">$ tar -xzf tlapm-1.6.0-pre-x86_64-linux-gnu.tar.gz</div>
+  <div class="terminal">$ export PATH="$PWD/tlapm/bin:$PATH"</div>
+
+  <p>Verify with <code>tlapm --version</code>; <code>tlapm --config</code>
+  lists the bundled backend provers. If you use the Toolbox or the
+  VS&nbsp;Code extension, the <code>TLAPS.tla</code> standard module is
+  under <code>tlapm/lib/tlapm/stdlib</code> &mdash; add that directory to the
+  TLA<sup>+</sup> library path.</p>
+
+  <p>Alternatively, follow
+  <a href="https://github.com/tlaplus/tlapm/blob/main/DEVELOPING.md">DEVELOPING.md</a>
+  to build TLAPS from source.</p>
+</div>
+
+
+<div class="section" style="position:relative; top:40px">
+  <h2>Release 1.5.0 (October 2022)</h2>
+
+  <p class="first">Past versioned releases are listed on the
+  <a href="https://github.com/tlaplus/tlapm/releases">GitHub releases
+  page</a>. The most recent of those, 1.5.0, ships as an installer:
     <code><a type="application/x-executable"
              href="https://github.com/tlaplus/tlapm/releases/download/202210041448/tlaps-1.5.0-x86_64-linux-gnu-inst.bin">tlaps-1.5.0-x86_64-linux-gnu-inst.bin</a></code>
   </p>
+
+  <p>It predates several years of development, so prefer the build above
+  unless you specifically need this version. The remaining instructions on
+  this page apply to it.</p>
 
   <h3>1. Install the Proof System </h3>
   <p>You may have to change the installer's permissions with the

--- a/doc/web/content/Download/Binaries/MacOS.html
+++ b/doc/web/content/Download/Binaries/MacOS.html
@@ -18,11 +18,48 @@
 
 <div class="section">
   <h2><img class="blogo" src="images/logo_macosx30s.png"
-           alt="[Apple logo]"/>Mac OS X (10.13 and later)</h2>
-  <p class="first"> The package:
+           alt="[Apple logo]"/>macOS</h2>
+
+  <p class="first">Builds of the latest development version are attached to
+    the <a href="https://github.com/tlaplus/tlapm/releases/tag/1.6.0-pre">1.6.0
+    rolling pre-release</a>. For Apple silicon:
+    <code><a type="application/gzip"
+             href="https://github.com/tlaplus/tlapm/releases/download/1.6.0-pre/tlapm-1.6.0-pre-arm64-darwin.tar.gz">tlapm-1.6.0-pre-arm64-darwin.tar.gz</a></code>
+  </p>
+
+  <p>This archive is relocatable and needs no installer: unpack it wherever
+  you like, then put its <code>bin</code> directory on your
+  <code>PATH</code>.</p>
+
+  <div class="terminal">$ tar -xzf tlapm-1.6.0-pre-arm64-darwin.tar.gz</div>
+  <div class="terminal">$ export PATH="$PWD/tlapm/bin:$PATH"</div>
+
+  <p>Verify with <code>tlapm --version</code>; <code>tlapm --config</code>
+  lists the bundled backend provers. If you use the Toolbox or the
+  VS&nbsp;Code extension, the <code>TLAPS.tla</code> standard module is
+  under <code>tlapm/lib/tlapm/stdlib</code> &mdash; add that directory to the
+  TLA<sup>+</sup> library path.</p>
+
+  <p>The rolling pre-release currently carries an Apple-silicon build only.
+  On an Intel Mac, follow
+  <a href="https://github.com/tlaplus/tlapm/blob/main/DEVELOPING.md">DEVELOPING.md</a>
+  to build TLAPS from source, or use the 1.5.0 installer below.</p>
+</div>
+
+
+<div class="section" style="position:relative; top:40px">
+  <h2>Release 1.5.0 (October 2022, macOS 10.13 and later)</h2>
+
+  <p class="first">Past versioned releases are listed on the
+  <a href="https://github.com/tlaplus/tlapm/releases">GitHub releases
+  page</a>. The most recent of those, 1.5.0, ships as an Intel installer:
     <code><a type="application/octet-stream"
              href="https://github.com/tlaplus/tlapm/releases/download/202210041448/tlaps-1.5.0-i386-darwin-inst.bin">tlaps-1.5.0-i386-darwin-inst.bin</a></code>
   </p>
+
+  <p>It predates several years of development, so prefer the build above
+  unless you specifically need this version. The remaining instructions on
+  this page apply to it.</p>
 
   <h3>1. Install &nbsp; <code>make</code> </h3>
   <p><code>make</code> is required. You can install either Apple's


### PR DESCRIPTION
Follows up on #287, where you asked for a PR aligning `Download/Binaries/*` with `README.md`.

`README.md` directs readers to the 1.6.0 rolling pre-release for the current version, and to the releases page for past versioned releases. The Binaries pages still presented the 1.5.0 installer (release `202210041448`, October 2022) as "The package", with no indication that anything newer exists.

**Changes**

- `Binaries/Linux.html` and `Binaries/MacOS.html` now lead with the rolling pre-release tarball: download link, unpack, `PATH`, and the location of `TLAPS.tla` for the Toolbox / VS Code library path. The existing 1.5.0 installer instructions are kept unchanged, under a dated heading.
- `Binaries/MacOS.html` additionally notes that the pre-release currently carries an Apple-silicon build only, so Intel users should build from source or use 1.5.0. The page previously offered only `tlaps-1.5.0-i386-darwin-inst.bin`.
- `Binaries.html`: "Download the TLAPS installer" → "Download TLAPS", since the current distribution is a tarball rather than an installer.
- `Binaries/Windows.html` is unchanged: it defers to the Linux page, so it picks this up automatically.

**Verified against the published artifact** rather than assumed — extracting `tlapm-1.6.0-pre-x86_64-linux-gnu.tar.gz` gives a relocatable tree with `tlapm/bin/tlapm` and `tlapm/lib/tlapm/stdlib/TLAPS.tla`, and `tlapm --config` resolves its paths relative to wherever it was unpacked. The tarball contains no `examples/` directory, so the old "copy the example files" step was not carried over to the new section.

Happy to adjust the wording, or to split this differently if you would rather the pages point at the releases page generically instead of naming `1.6.0-pre`.
